### PR TITLE
Shape and type deduction

### DIFF
--- a/include/tvm/relax/ir_builder.h
+++ b/include/tvm/relax/ir_builder.h
@@ -82,7 +82,7 @@ class IRBuilderNode : public Object {
   /*!
    * \brief Generate an output for the current dataflow block or function.
    * \param output The output variable of the block/function.
-   * \return The variable being binded to \p ouput.
+   * \return The variable being binded to \p output.
    */
   Var EmitOutput(const Expr& output);
   /*!

--- a/include/tvm/relax/ir_builder.h
+++ b/include/tvm/relax/ir_builder.h
@@ -107,13 +107,15 @@ class IRBuilderNode : public Object {
 
  private:
   /*! \brief The state of the function currently being built. */
-  RelaxFunction func;
+  RelaxFunction func_;
   /*! \brief A flag tracking if currently inside a dataflow block or not. */
-  bool is_dataflow = false;
+  bool is_dataflow_ = false;
   /*! \brief A global variable counter for naming global variables. */
-  int global_var_counter = 0;
+  int global_var_counter_ = 0;
   /*! \brief A dataflow variable counter for naming dataflow variables. */
-  int dataflow_var_counter = 0;
+  int dataflow_var_counter_ = 0;
+  /*! \brief A diagnostic context for reporting errors. */
+  DiagnosticContext diag_ctx_ = DiagnosticContext::Default(IRModule({}, {}));
 };
 
 class IRBuilder : public ObjectRef {

--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -40,6 +40,7 @@ using relay::Call;
  * \brief Infer the output shape for operators. This function will
  * be invoked to fill the \p shape_ field of expressions.
  * \param call The call node.
+ * \param diag_ctx The diagnostic context for reporting errors.
  * \return The inferred output shape expression.
  */
 using FInferShape = runtime::TypedPackedFunc<Optional<RelayExpr>(const Call& call, DiagnosticContext diag_ctx)>;
@@ -48,6 +49,7 @@ using FInferShape = runtime::TypedPackedFunc<Optional<RelayExpr>(const Call& cal
  * \brief Infer the output type for operators. This function will
  * be invoked to fill the \p checked_type_ field of expressions.
  * \param call The call node.
+ * \param diag_ctx The diagnostic context for reporting errors.
  * \return The inferred output type.
  */
 using FInferType = runtime::TypedPackedFunc<Type(const Call& call, DiagnosticContext diag_ctx)>;

--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -39,21 +39,18 @@ using relay::Call;
 /*!
  * \brief Infer the output shape for operators. This function will
  * be invoked to fill the \p shape_ field of expressions.
- * \param attrs The attribute of the call node.
  * \param call The call node.
  * \return The inferred output shape expression.
  */
-using FInferShape =
-    runtime::TypedPackedFunc<Optional<RelayExpr>(const Attrs& attrs, const Call& call)>;
+using FInferShape = runtime::TypedPackedFunc<Optional<RelayExpr>(const Call& call)>;
 
 /*!
  * \brief Infer the output type for operators. This function will
  * be invoked to fill the \p checked_type_ field of expressions.
- * \param attrs The attribute of the call node.
  * \param call The call node.
  * \return The inferred output type.
  */
-using FInferType = runtime::TypedPackedFunc<Type(const Attrs& attrs, const Call& call)>;
+using FInferType = runtime::TypedPackedFunc<Type(const Call& call)>;
 
 }  // namespace relax
 }  // namespace tvm

--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -39,18 +39,21 @@ using relay::Call;
 /*!
  * \brief Infer the output shape for operators. This function will
  * be invoked to fill the \p shape_ field of expressions.
+ * \param attrs The attribute of the call node.
  * \param call The call node.
  * \return The inferred output shape expression.
  */
-using FInferShape = runtime::TypedPackedFunc<Optional<RelayExpr>(const Call& call)>;
+using FInferShape =
+    runtime::TypedPackedFunc<Optional<RelayExpr>(const Attrs& attrs, const Call& call)>;
 
 /*!
  * \brief Infer the output type for operators. This function will
  * be invoked to fill the \p checked_type_ field of expressions.
+ * \param attrs The attribute of the call node.
  * \param call The call node.
  * \return The inferred output type.
  */
-using FInferType = runtime::TypedPackedFunc<Type(const Call& call)>;
+using FInferType = runtime::TypedPackedFunc<Type(const Attrs& attrs, const Call& call)>;
 
 }  // namespace relax
 }  // namespace tvm

--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -42,7 +42,7 @@ using relay::Call;
  * \param call The call node.
  * \return The inferred output shape expression.
  */
-using FInferShape = runtime::TypedPackedFunc<Optional<RelayExpr>(const Call& call)>;
+using FInferShape = runtime::TypedPackedFunc<Optional<RelayExpr>(const Call& call, DiagnosticContext diag_ctx)>;
 
 /*!
  * \brief Infer the output type for operators. This function will
@@ -50,7 +50,7 @@ using FInferShape = runtime::TypedPackedFunc<Optional<RelayExpr>(const Call& cal
  * \param call The call node.
  * \return The inferred output type.
  */
-using FInferType = runtime::TypedPackedFunc<Type(const Call& call)>;
+using FInferType = runtime::TypedPackedFunc<Type(const Call& call, DiagnosticContext diag_ctx)>;
 
 }  // namespace relax
 }  // namespace tvm

--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/relax/op_attr_types.h
+ * \brief Data structures that can appear in operator attributes.
+ */
+#ifndef TVM_RELAX_OP_ATTR_TYPES_H_
+#define TVM_RELAX_OP_ATTR_TYPES_H_
+
+#include <tvm/relay/expr.h>
+#include <tvm/relay/type.h>
+#include <tvm/te/schedule.h>
+#include <tvm/te/tensor.h>
+
+#include <string>
+
+namespace tvm {
+namespace relax {
+
+using relay::Call;
+
+/*!
+ * \brief Infer the output shape for operators. This function will
+ * be invoked to fill the \p shape_ field of expressions.
+ * \param call The call node.
+ * \return The inferred output shape expression.
+ */
+using FInferShape = runtime::TypedPackedFunc<Optional<RelayExpr>(const Call& call)>;
+
+/*!
+ * \brief Infer the output type for operators. This function will
+ * be invoked to fill the \p checked_type_ field of expressions.
+ * \param call The call node.
+ * \return The inferred output type.
+ */
+using FInferType = runtime::TypedPackedFunc<Type(const Call& call)>;
+
+}  // namespace relax
+}  // namespace tvm
+#endif  // TVM_RELAX_OP_ATTR_TYPES_H_

--- a/python/tvm/ir/expr.py
+++ b/python/tvm/ir/expr.py
@@ -45,7 +45,7 @@ class RelayExpr(BaseExpr):
         checked_type : tvm.relay.Type
             The checked type.
         """
-        ret = self._checked_type_
+        ret = self.checked_type_
         if ret is None:
             raise ValueError("The type checker has not populated" " the checked_type for this node")
         return ret

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -66,6 +66,8 @@ class Var(Expr):
         type_annotation: Optional[Type] = None,
         span: Span = None,
     ) -> None:
+        if shape_annotation is not None:
+            shape_annotation = make_shape(shape_annotation)
         self.__init_handle_by_constructor__(
             _ffi_api.Var, name_hint, shape_annotation, type_annotation, span
         )
@@ -86,6 +88,8 @@ class DataflowVar(Var):
         type_annotation: Optional[Type] = None,
         span: Span = None,
     ) -> None:
+        if shape_annotation is not None:
+            shape_annotation = make_shape(shape_annotation)
         self.__init_handle_by_constructor__(
             _ffi_api.DataflowVar, name_hint, shape_annotation, type_annotation, span
         )

--- a/python/tvm/relax/op/tensor.py
+++ b/python/tvm/relax/op/tensor.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+"""Basic tensor operations."""
 from . import _ffi_api
 from ..expr import Expr
 

--- a/src/relax/ir_builder.cc
+++ b/src/relax/ir_builder.cc
@@ -67,13 +67,13 @@ void IRBuilderNode::BuildBlock() {
 Optional<RelayExpr> InferShape(const Call& call) {
   auto op_map = Op::GetAttrMap<FInferShape>("FInferShape");
   Op op = Downcast<Op>(call->op);
-  return op_map[op](call->attrs, call);
+  return op_map[op](call);
 }
 
 Type InferType(const Call& call) {
   auto op_map = Op::GetAttrMap<FInferType>("FInferType");
   Op op = Downcast<Op>(call->op);
-  return op_map[op](call->attrs, call);
+  return op_map[op](call);
 }
 
 Var IRBuilderNode::Emit(const Call& call) {

--- a/src/relax/ir_builder.cc
+++ b/src/relax/ir_builder.cc
@@ -41,7 +41,7 @@ void IRBuilderNode::FillFuncNameParam(const Array<Var>& params, const std::strin
   if (!func_name.empty()) {
     this->func.func_name = GlobalVar(func_name);
   }
-  
+
   this->func.params = params;
 }
 
@@ -67,13 +67,13 @@ void IRBuilderNode::BuildBlock() {
 Optional<RelayExpr> InferShape(const Call& call) {
   auto op_map = Op::GetAttrMap<FInferShape>("FInferShape");
   Op op = Downcast<Op>(call->op);
-  return op_map[op](call);
+  return op_map[op](call->attrs, call);
 }
 
 Type InferType(const Call& call) {
   auto op_map = Op::GetAttrMap<FInferType>("FInferType");
   Op op = Downcast<Op>(call->op);
-  return op_map[op](call);
+  return op_map[op](call->attrs, call);
 }
 
 Var IRBuilderNode::Emit(const Call& call) {
@@ -147,20 +147,16 @@ DataflowScope::DataflowScope(IRBuilder ib) {
   data_ = std::move(n);
 }
 
-void DataflowScope::EnterWithScope() {
-  this->get()->ir_builder->BuildBlock();
-}
+void DataflowScope::EnterWithScope() { this->get()->ir_builder->BuildBlock(); }
 
-void DataflowScope::ExitWithScope() {
-  this->get()->ir_builder->BuildBlock();
-}
+void DataflowScope::ExitWithScope() { this->get()->ir_builder->BuildBlock(); }
 
 TVM_REGISTER_GLOBAL("relax.IRBuilderCreate").set_body_typed(IRBuilderNode::Create);
 
 TVM_REGISTER_GLOBAL("relax.IRBuilderFillFuncNameParam")
-.set_body_typed([](IRBuilder builder, const Array<Var>& params, const std::string& func_name) {
-  return builder->FillFuncNameParam(params, func_name);
-});
+    .set_body_typed([](IRBuilder builder, const Array<Var>& params, const std::string& func_name) {
+      return builder->FillFuncNameParam(params, func_name);
+    });
 
 TVM_REGISTER_GLOBAL("relax.IRBuilderBuildFunction").set_body_typed([](IRBuilder builder) {
   return builder->BuildFunction();
@@ -171,9 +167,9 @@ TVM_REGISTER_GLOBAL("relax.IRBuilderEmit").set_body_typed([](IRBuilder builder, 
 });
 
 TVM_REGISTER_GLOBAL("relax.IRBuilderEmitOutput")
-.set_body_typed([](IRBuilder builder, const Expr& output) {
-  return builder->EmitOutput(output);
-});
+    .set_body_typed([](IRBuilder builder, const Expr& output) {
+      return builder->EmitOutput(output);
+    });
 
 TVM_REGISTER_GLOBAL("relax.IRBuilderGet").set_body_typed([](IRBuilder builder) {
   return builder->Get();

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -42,7 +42,7 @@ namespace relax {
  *
  * \param OpName the name of registry.
  */
-#define RELAX_REGISTER_BINARY_OP(OpName)                                          \
+#define RELAX_REGISTER_BINARY_BROADCAST_OP(OpName)                                          \
   TVM_REGISTER_GLOBAL("relax.op." OpName).set_body_typed([](Expr lhs, Expr rhs) { \
     static const Op& op = Op::Get("relax." OpName);                               \
     return Call(op, {lhs, rhs}, Attrs(), {});                                     \

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -25,9 +25,9 @@
 #ifndef TVM_RELAX_OP_OP_COMMON_H_
 #define TVM_RELAX_OP_OP_COMMON_H_
 
+#include <tvm/relax/op_attr_types.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/op.h>
-#include <tvm/relay/op_attr_types.h>
 
 namespace tvm {
 namespace relax {
@@ -44,7 +44,7 @@ namespace relax {
  */
 #define RELAX_REGISTER_BINARY_OP(OpName)                                          \
   TVM_REGISTER_GLOBAL("relax.op." OpName).set_body_typed([](Expr lhs, Expr rhs) { \
-    static const Op& op = Op::Get("relax." OpName);                                        \
+    static const Op& op = Op::Get("relax." OpName);                               \
     return Call(op, {lhs, rhs}, Attrs(), {});                                     \
   });                                                                             \
   RELAY_REGISTER_OP("relax." OpName)                                              \

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -44,13 +44,15 @@ namespace relax {
  */
 #define RELAX_REGISTER_BINARY_OP(OpName)                                          \
   TVM_REGISTER_GLOBAL("relax.op." OpName).set_body_typed([](Expr lhs, Expr rhs) { \
-    static const Op& op = Op::Get(OpName);                                        \
+    static const Op& op = Op::Get("relax." OpName);                                        \
     return Call(op, {lhs, rhs}, Attrs(), {});                                     \
   });                                                                             \
   RELAY_REGISTER_OP("relax." OpName)                                              \
       .set_num_inputs(2)                                                          \
       .add_argument("lhs", "Tensor", "The left hand side tensor.")                \
-      .add_argument("rhs", "Tensor", "The right hand side tensor.")
+      .add_argument("rhs", "Tensor", "The right hand side tensor.")               \
+      .set_attr<FInferShape>("FInferShape", InferShapeBinaryBroadcast)            \
+      .set_attr<FInferType>("FInferType", InferTypeBinaryBroadcast)
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -30,11 +30,12 @@ namespace tvm {
 namespace relax {
 
 RELAX_REGISTER_BINARY_OP("add")
-    .describe("Elementwise add with broadcasting");
+    .describe("Elementwise add with broadcasting")
+    .set_support_level(1);
 
 RELAX_REGISTER_BINARY_OP("multiply")
-    .describe("Elementwise multiply with broadcasting");
-
+    .describe("Elementwise multiply with broadcasting")
+    .set_support_level(1);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -29,11 +29,11 @@
 namespace tvm {
 namespace relax {
 
-RELAX_REGISTER_BINARY_OP("add")
+RELAX_REGISTER_BINARY_BROADCAST_OP("add")
     .describe("Elementwise add with broadcasting")
     .set_support_level(1);
 
-RELAX_REGISTER_BINARY_OP("multiply")
+RELAX_REGISTER_BINARY_BROADCAST_OP("multiply")
     .describe("Elementwise multiply with broadcasting")
     .set_support_level(1);
 

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -22,34 +22,19 @@
  * \brief binary broadcast operators.
  */
 
-#include <tvm/arith/analyzer.h>
-#include <tvm/relax/expr.h>
-#include <tvm/relax/type.h>
-#include <tvm/tir/op.h>
-#include <tvm/topi/broadcast.h>
+#include "binary.h"
 
 #include "../op_common.h"
 
 namespace tvm {
 namespace relax {
 
-using Expr = tvm::RelayExpr;
-using relay::Call;
-
-#define RELAX_BINARY_COMPUTE(FTOPI)                       \
-  [](const Attrs& attrs, const Array<te::Tensor>& inputs, \
-     const Type& out_type) -> Array<te::Tensor> {         \
-    ICHECK_EQ(inputs.size(), 2U);                         \
-    return {FTOPI(inputs[0], inputs[1])};                 \
-  }
-
 RELAX_REGISTER_BINARY_OP("add")
-    .describe("Elementwise add with broadcasting")
-    .set_support_level(1);
+    .describe("Elementwise add with broadcasting");
 
 RELAX_REGISTER_BINARY_OP("multiply")
-    .describe("Elementwise multiply with broadcasting")
-    .set_support_level(1);
+    .describe("Elementwise multiply with broadcasting");
+
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -54,7 +54,7 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs) {
   return false;
 }
 
-Optional<Expr> InferShapeBinaryBroadcast(const Call& call) {
+Optional<Expr> InferShapeBinaryBroadcast(const Attrs& attrs, const Call& call) {
   ICHECK_EQ(call->args.size(), 2);
   Expr lhs_shape = call->args[0]->shape();
   Expr rhs_shape = call->args[1]->shape();
@@ -92,7 +92,7 @@ Optional<Expr> InferShapeBinaryBroadcast(const Call& call) {
   }
 }
 
-Type InferTypeBinaryBroadcast(const Call& call) {
+Type InferTypeBinaryBroadcast(const Attrs& attrs, const Call& call) {
   ICHECK_EQ(call->args.size(), 2);
   Type lhs_type = call->args[0]->checked_type();
   Type rhs_type = call->args[1]->checked_type();

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -115,7 +115,7 @@ Type InferTypeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx) {
   } else if (t0->dtype != t1->dtype) {
     diag_ctx.EmitFatal(Diagnostic::Error(call->span)
                        << "Data types " << t0->dtype << " and " << t1->dtype
-                       << " do not match broadcasting rule");
+                       << " must be equal for broadcasting operators");
   } else {
     output_dtype = t0->dtype;
   }

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -54,9 +54,7 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs) {
   return false;
 }
 
-Optional<Expr> InferShapeBinaryBroadcast(const Call& call) {
-  IRModule module = IRModule({}, {});
-  DiagnosticContext diag_ctx = DiagnosticContext::Default(module);
+Optional<Expr> InferShapeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx) {
   if (call->args.size() != 2) {
     diag_ctx.EmitFatal(Diagnostic::Error(call->span)
                        << "Binary broadcast op should have 2 arguments");
@@ -97,9 +95,7 @@ Optional<Expr> InferShapeBinaryBroadcast(const Call& call) {
   }
 }
 
-Type InferTypeBinaryBroadcast(const Call& call) {
-  IRModule module = IRModule({}, {});
-  DiagnosticContext diag_ctx = DiagnosticContext::Default(module);
+Type InferTypeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx) {
   if (call->args.size() != 2) {
     diag_ctx.EmitFatal(Diagnostic::Error(call->span)
                        << "Binary broadcast op should have 2 arguments");

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file binary.h
+ * \brief shape and type deduction for binary broadcast operators.
+ */
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/relax/expr.h>
+#include <tvm/relax/op_attr_types.h>
+#include <tvm/relax/type.h>
+#include <tvm/tir/op.h>
+#include <tvm/topi/broadcast.h>
+
+#include "../op_common.h"
+
+namespace tvm {
+namespace relax {
+
+bool EqualConstInt(const PrimExpr& lhs, int64_t value) {
+  if (const int64_t* pvalue = tir::as_const_int(lhs)) {
+    return pvalue[0] == value;
+  }
+  return false;
+}
+
+bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs) {
+  PrimExpr diff = lhs - rhs;
+  if (const int64_t* pdiff = tir::as_const_int(diff)) {
+    return pdiff[0] == 0;
+  }
+  tvm::arith::Analyzer ana;
+  diff = ana.Simplify(diff);
+  if (const int64_t* pdiff = tir::as_const_int(diff)) {
+    return pdiff[0] == 0;
+  }
+  return false;
+}
+
+Optional<Expr> InferShapeBinaryBroadcast(const Call& call) {
+  ICHECK_EQ(call->args.size(), 2);
+  Expr lhs_shape = call->args[0]->shape();
+  Expr rhs_shape = call->args[1]->shape();
+  auto* s0 = lhs_shape.as<ShapeExprNode>();
+  auto* s1 = rhs_shape.as<ShapeExprNode>();
+  if (s0 && s1) {
+    std::vector<PrimExpr> output_shape;
+    size_t ndim0 = s0->values.size();
+    size_t ndim1 = s1->values.size();
+    size_t i = 1;
+    for (; i <= std::min(ndim0, ndim1); ++i) {
+      PrimExpr dim0 = s0->values[ndim0 - i];
+      PrimExpr dim1 = s1->values[ndim1 - i];
+      if (EqualConstInt(dim0, 1)) {
+        output_shape.push_back(dim0);
+      } else if (EqualConstInt(dim1, 1)) {
+        output_shape.push_back(dim1);
+      } else if (EqualCheck(dim0, dim1)) {
+        output_shape.push_back(dim0);
+      } else {
+        // defer the computation of output shapes to runtime
+        // e.g., broadcast Tensor([m, n]), Tensor([k]) -> defer to runtime
+        return Call(ExternFunc(String("vm.binary_broadcast_shape_infer")),
+                    {call->args[0], call->args[1]}, {}, {});
+      }
+    }
+    size_t max_ndim = std::max(ndim0, ndim1);
+    auto& longer_shape = (ndim0 > ndim1) ? s0 : s1;
+    for (; i <= max_ndim; ++i) {
+      output_shape.push_back(longer_shape->values[max_ndim - i]);
+    }
+    return ShapeExpr(Array<PrimExpr>(output_shape.rbegin(), output_shape.rend()));
+  } else {
+    return NullOpt;
+  }
+}
+
+Type InferTypeBinaryBroadcast(const Call& call) {
+  ICHECK_EQ(call->args.size(), 2);
+  Type lhs_type = call->args[0]->checked_type();
+  Type rhs_type = call->args[1]->checked_type();
+  auto* t0 = lhs_type.as<DynTensorTypeNode>();
+  auto* t1 = rhs_type.as<DynTensorTypeNode>();
+  if (!t0 || !t1) {
+    LOG(FATAL) << "Both lhs and rhs should be DynTensor for broadcasting";
+  }
+
+  DataType output_dtype;
+  if (t0->IsUnknownDtype() || t1->IsUnknownDtype()) {
+    output_dtype = DataType::Void();
+  } else if (t0->dtype != t1->dtype) {
+    LOG(FATAL) << "Data types " << t0->dtype << " and " << t1->dtype
+               << " do not match broadcasting rule";
+  } else {
+    output_dtype = t0->dtype;
+  }
+
+  int output_rank;
+  if (t0->IsUnknownRank() || t1->IsUnknownRank()) {
+    output_rank = -1;
+  } else {
+    output_rank = std::max(t0->rank, t1->rank);
+  }
+  return DynTensorType(output_rank, output_dtype);
+}
+
+}  // namespace relax
+}  // namespace tvm


### PR DESCRIPTION
Implementation of the "simple" mode of shape and type deduction. 
The key signatures are:
`FInferShape`: `TypedPackedFunc<Optional<RelayExpr>(const Call& call, DiagnosticContext diag_ctx)>`
`FInferType`: `TypedPackedFunc<Type(const Call& call, DiagnosticContext diag_ctx)>`.

As a POC, shape and type deduction for binary broadcast operators are implemented with these two signatures. 
IRBuilder eagerly does shape and type inference using the attributes(FInferShape and FInferType) registered to the op, and fills the `shape_` and `checked_type_` fields for each expression.