### PR TITLE
Update MatchShape AST Node

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -198,7 +198,7 @@ class MatchShapeNode : public BindingNode {
  public:
   Expr value;
   Array<PrimExpr> pattern;
-  Optional<Var> var;
+  Var var;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("value", &value);
@@ -227,7 +227,7 @@ class MatchShapeNode : public BindingNode {
 class MatchShape : public Binding {
  public:
   TVM_DLL explicit MatchShape(Expr value, Array<PrimExpr> pattern,
-                              Optional<Var> var = NullOpt, Span span = Span());
+                              Var var, Span span = Span());
   TVM_DEFINE_OBJECT_REF_METHODS(MatchShape, Binding, MatchShapeNode);
 };
 

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -196,22 +196,26 @@ class Binding : public ObjectRef {
 class MatchShape;
 class MatchShapeNode : public BindingNode {
  public:
-  Array<PrimExpr> pattern;
   Expr value;
+  Array<PrimExpr> pattern;
+  Optional<Var> var;
 
   void VisitAttrs(AttrVisitor* v) {
-    v->Visit("pattern", &pattern);
     v->Visit("value", &value);
+    v->Visit("pattern", &pattern);
+    v->Visit("var", &var);
     v->Visit("span", &span);
   }
 
   bool SEqualReduce(const MatchShapeNode* other, SEqualReducer equal) const {
-    return equal(pattern, other->pattern) && equal(value, other->value);
+    return equal(value, other->value) && equal(pattern, other->pattern)
+      && equal(var, other->var);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
-    hash_reduce(pattern);
     hash_reduce(value);
+    hash_reduce(pattern);
+    hash_reduce(var);
   }
 
   static constexpr const char* _type_key = "relax.expr.MatchShape";
@@ -222,7 +226,8 @@ class MatchShapeNode : public BindingNode {
 
 class MatchShape : public Binding {
  public:
-  TVM_DLL explicit MatchShape(Array<PrimExpr> pattern, Expr value, Span span = Span());
+  TVM_DLL explicit MatchShape(Expr value, Array<PrimExpr> pattern,
+                              Optional<Var> var = NullOpt, Span span = Span());
   TVM_DEFINE_OBJECT_REF_METHODS(MatchShape, Binding, MatchShapeNode);
 };
 

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -105,10 +105,9 @@ class Binding(Node):
 class MatchShape(Binding):
     value: Expr
     pattern: List[PrimExpr]
-    var: Optional[Var]
+    var: Var
 
-    def __init__(self, value: Expr, pattern: List[PrimExpr],
-                 var: Optional[Var] = None, span: Span = None) -> None:
+    def __init__(self, value: Expr, pattern: List[PrimExpr], var: Var, span: Span = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.MatchShape, value, pattern, var, span)
 
 

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -103,11 +103,13 @@ class Binding(Node):
 
 @tvm._ffi.register_object("relax.expr.MatchShape")
 class MatchShape(Binding):
-    pattern: List[PrimExpr]
     value: Expr
+    pattern: List[PrimExpr]
+    var: Optional[Var]
 
-    def __init__(self, pattern: List[PrimExpr], value: Expr, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.MatchShape, pattern, value, span)
+    def __init__(self, value: Expr, pattern: List[PrimExpr],
+                 var: Optional[Var] = None, span: Span = None) -> None:
+        self.__init_handle_by_constructor__(_ffi_api.MatchShape, value, pattern, var, span)
 
 
 @tvm._ffi.register_object("relax.expr.VarBinding")

--- a/src/relax/expr.cc
+++ b/src/relax/expr.cc
@@ -65,10 +65,10 @@ Var::Var(Id vid, Optional<Expr> shape_annotation, Optional<Type> type_annotation
 }
 
 TVM_REGISTER_GLOBAL("relax.Var")
-    .set_body_typed([](String name_hint, Optional<Expr> shape_annotation,
-                       Optional<Type> type_annotation, Span span) {
-      return Var(name_hint, shape_annotation, type_annotation, span);
-    });
+.set_body_typed([](String name_hint, Optional<Expr> shape_annotation,
+                   Optional<Type> type_annotation, Span span) {
+  return Var(name_hint, shape_annotation, type_annotation, span);
+});
 
 TVM_REGISTER_NODE_TYPE(DataflowVarNode);
 
@@ -83,10 +83,10 @@ DataflowVar::DataflowVar(Id vid, Optional<Expr> shape_annotation, Optional<Type>
 }
 
 TVM_REGISTER_GLOBAL("relax.DataflowVar")
-    .set_body_typed([](String name_hint, Optional<Expr> shape_annotation,
-                       Optional<Type> type_annotation, Span span) {
-      return DataflowVar(name_hint, shape_annotation, type_annotation, span);
-    });
+.set_body_typed([](String name_hint, Optional<Expr> shape_annotation,
+                   Optional<Type> type_annotation, Span span) {
+  return DataflowVar(name_hint, shape_annotation, type_annotation, span);
+});
 
 Binding::Binding(Span span) {
   ObjectPtr<BindingNode> n = make_object<BindingNode>();
@@ -96,22 +96,25 @@ Binding::Binding(Span span) {
 
 TVM_REGISTER_NODE_TYPE(BindingNode);
 
-TVM_REGISTER_GLOBAL("relax.Binding").set_body_typed([](Span span) { return Binding(span); });
+TVM_REGISTER_GLOBAL("relax.Binding").set_body_typed([](Span span) {
+  return Binding(span);
+});
 
 TVM_REGISTER_NODE_TYPE(MatchShapeNode);
 
-MatchShape::MatchShape(Array<PrimExpr> pattern, Expr value, Span span) {
+MatchShape::MatchShape(Expr value, Array<PrimExpr> pattern, Optional<Var> var, Span span) {
   ObjectPtr<MatchShapeNode> n = make_object<MatchShapeNode>();
-  n->pattern = std::move(pattern);
   n->value = std::move(value);
+  n->pattern = std::move(pattern);
+  n->var = std::move(var);
   n->span = span;
   data_ = std::move(n);
 }
 
 TVM_REGISTER_GLOBAL("relax.MatchShape")
-    .set_body_typed([](Array<PrimExpr> pattern, Expr value, Span span) {
-      return MatchShape(pattern, value, span);
-    });
+.set_body_typed([](Expr value, Array<PrimExpr> pattern, Optional<Var> var, Span span) {
+  return MatchShape(value, pattern, var, span);
+});
 
 TVM_REGISTER_NODE_TYPE(VarBindingNode);
 
@@ -182,9 +185,10 @@ Function::Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr bo
 }
 
 TVM_REGISTER_GLOBAL("relax.Function")
-    .set_body_typed([](runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
-                       Type ret_type,
-                       Span span) { return Function(name, params, body, ret_type, span); });
+.set_body_typed([](runtime::Optional<GlobalVar> name, Array<Var> params,
+                   Expr body, Type ret_type, Span span) {
+  return Function(name, params, body, ret_type, span);
+});
 
 TVM_REGISTER_NODE_TYPE(ExternFuncNode);
 

--- a/src/relax/expr.cc
+++ b/src/relax/expr.cc
@@ -102,7 +102,7 @@ TVM_REGISTER_GLOBAL("relax.Binding").set_body_typed([](Span span) {
 
 TVM_REGISTER_NODE_TYPE(MatchShapeNode);
 
-MatchShape::MatchShape(Expr value, Array<PrimExpr> pattern, Optional<Var> var, Span span) {
+MatchShape::MatchShape(Expr value, Array<PrimExpr> pattern, Var var, Span span) {
   ObjectPtr<MatchShapeNode> n = make_object<MatchShapeNode>();
   n->value = std::move(value);
   n->pattern = std::move(pattern);
@@ -112,7 +112,7 @@ MatchShape::MatchShape(Expr value, Array<PrimExpr> pattern, Optional<Var> var, S
 }
 
 TVM_REGISTER_GLOBAL("relax.MatchShape")
-.set_body_typed([](Expr value, Array<PrimExpr> pattern, Optional<Var> var, Span span) {
+.set_body_typed([](Expr value, Array<PrimExpr> pattern, Var var, Span span) {
   return MatchShape(value, pattern, var, span);
 });
 

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -39,31 +39,28 @@ def test_match_shape() -> None:
     m = tir.Var("m", dtype="int32")
     n = tir.Var("n", dtype="int32")
     shape = rx.const([16, 8], "int32") 
-    b0 = rx.MatchShape(shape, [m, n])
+    var = rx.Var("v0", type_annotation=rx.ShapeType())
+    b0 = rx.MatchShape(shape, [m, n], var)
     assert b0.value == shape
     assert b0.pattern[0] == m
     assert b0.pattern[1] == n
-    assert b0.var is None
-
-    # var: Shape = match_shape([16, 8], [m, n])
-    shape_var = rx.Var("v0")
-    b1 = rx.MatchShape(shape, [m, n], shape_var)
-    assert b1.value == shape
-    assert b1.pattern[0] == m
-    assert b1.pattern[1] == n
-    assert b1.var == shape_var
+    assert b0.var is not None
+    assert b0.var.checked_type_ == rx.ShapeType()
 
     # var1: Tensor[(m, n), "float32"] =
     #   match_shape(var0: Tensor[_, "float32"], [m, n])
     type_anno0 = rx.DynTensorType(-1, "float32")
-    var0 = rx.Var("var0", type_annotation=type_anno0)
-    type_anno1 = rx.DynTensorType(2, "float32")
-    var1 = rx.Var("var1", [m, n], type_anno1) 
-    b2 = rx.MatchShape(var0, [m, n], var1)
-    assert b2.value == var0
-    assert b2.pattern[0] == m
-    assert b2.pattern[1] == n
-    assert b2.var == var1
+    value = rx.Var("value", type_annotation=type_anno0)
+
+    shape_anno = [m, n]
+    type_anno = TensorType(shape_anno, "float32")
+    var = rx.Var("v1", shape_anno, type_anno)
+    b1 = rx.MatchShape(value, [m, n], var)
+    assert b1.value == value
+    assert b1.pattern[0] == m
+    assert b1.pattern[1] == n
+    assert b1.var is not None
+    assert b1.var.checked_type_ == TensorType([m, n], "float32")
 
 
 def test_var_binding() -> None:
@@ -78,7 +75,7 @@ def test_binding_block() -> None:
     m = tir.Var("m", dtype="int32")
     n = tir.Var("n", dtype="int32")
     shape = rx.const([16, 8], "int32") 
-    b0 = rx.MatchShape(shape, [m, n])
+    b0 = rx.MatchShape(shape, [m, n], rx.Var("v0"))
 
     v0 = rx.Var("v0")
     val = rx.const(np.random.rand(24, 56))
@@ -93,7 +90,7 @@ def test_dataflow_block() -> None:
     m = tir.Var("m", dtype="int32")
     n = tir.Var("n", dtype="int32")
     shape = rx.const([16, 8], "int32") 
-    b0 = rx.MatchShape(shape, [m, n])
+    b0 = rx.MatchShape(shape, [m, n], rx.Var("v0"))
 
     v0 = rx.Var("v0")
     val = rx.const(np.random.rand(24, 56))

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -1,7 +1,6 @@
 import tvm
 from tvm import tir
 from tvm import relax as rx
-from tvm.ir import TensorType
 import numpy as np
 
 
@@ -11,7 +10,7 @@ def test_var() -> None:
     assert v0.shape_ is None
     assert v0.type_annotation is None
     shape_anno = [54, 96]
-    type_anno = TensorType(shape_anno, "float32")
+    type_anno = rx.DynTensorType(2, "float32")
     v1 = rx.Var("v1", shape_anno, type_anno)
     assert v1.name_hint == "v1"
     for s0, s1 in zip(v1.shape_, shape_anno):
@@ -25,7 +24,7 @@ def test_dataflow_var() -> None:
     assert v0.shape_ is None
     assert v0.type_annotation is None
     shape_anno = [54, 96]
-    type_anno = TensorType(shape_anno, "float16")
+    type_anno = rx.DynTensorType(2, "float16")
     v1 = rx.DataflowVar("v1", shape_anno, type_anno)
     assert v1.name_hint == "v1"
     for s0, s1 in zip(v1.shape_, shape_anno):
@@ -53,14 +52,16 @@ def test_match_shape() -> None:
     value = rx.Var("value", type_annotation=type_anno0)
 
     shape_anno = [m, n]
-    type_anno = TensorType(shape_anno, "float32")
+    type_anno = rx.DynTensorType(2, "float32")
     var = rx.Var("v1", shape_anno, type_anno)
     b1 = rx.MatchShape(value, [m, n], var)
     assert b1.value == value
     assert b1.pattern[0] == m
     assert b1.pattern[1] == n
     assert b1.var is not None
-    assert b1.var.checked_type_ == TensorType([m, n], "float32")
+    for s0, s1 in zip(b1.var.shape, [m, n]):
+        assert s0 == s1
+    assert b1.var.checked_type_ == rx.DynTensorType(2, "float32")
 
 
 def test_var_binding() -> None:
@@ -124,7 +125,7 @@ def test_func():
     bindings = [rx.VarBinding(x, rx.const(1))]
     blocks = [rx.BindingBlock(bindings)]
     seqe = rx.SeqExpr(blocks, x)
-    ret_type = TensorType(None, "float32")
+    ret_type = rx.DynTensorType(-1, "float32")
     func = rx.Function([x], seqe, ret_type, rx.GlobalVar("func"))
     assert func.params[0] == x
     assert func.body == seqe


### PR DESCRIPTION
The PR brings AST changes for new `match_shape` usage.

- The order of value and pattern is changed in order to align with `match_buffer` in TIR script;
- Add an optional `Var` node so that we can specify a return variable (can be Shape or Tensor) during binding construction;

**Demo Usage**
- `match_shape(x.shape, [m, n])`
- `s: Shape = match_shape(x.shape, [m, n])`
- `x1: Tensor[(m, n), "float32] = match_shape(x0: Tensor[_, "float32"], [m, n])`

