### PR TITLE
End2End Lowering

### DIFF
--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -193,10 +193,7 @@ class ExprMutator : public ExprFunctor<Expr(const Expr&)> {
    * \return expr.
    */
   Expr Mutate(const Expr& expr) {
-    if (memo_.count(expr) == 0) {
-      memo_[expr] = this->VisitExpr(expr);
-    }
-    return Downcast<Expr>(memo_[expr]);
+    return this->VisitExpr(expr);
   }
 
   Expr VisitExpr(const Expr& expr) override;

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -223,6 +223,7 @@ class ExprMutator : public ExprFunctor<Expr(const Expr&)> {
   virtual void VisitBinding(const Binding& binding);
   virtual Var VisitVarBinding(const VarBinding& binding);
   virtual void VisitMatchShape(const MatchShape& binding);
+
   virtual BindingBlock VisitBindingBlock(const BindingBlock& block);
   virtual BindingBlock VisitDataflowBlock(const DataflowBlock& block);
 

--- a/python/tvm/relax/exec_builder.py
+++ b/python/tvm/relax/exec_builder.py
@@ -19,7 +19,7 @@ from enum import IntEnum
 from typing import Optional, Union, List
 import tvm
 from tvm._ffi._ctypes.packed_func import TVMRetValueHandle
-from tvm.runtime import Object
+from tvm.runtime import Object, container
 from tvm._ffi.base import _LIB, check_call
 from . vm import Executable
 from . import _ffi_api
@@ -89,7 +89,11 @@ class ExecBuilder(Object):
             dst = SpecialReg.VOID_ARG
         args_ = []
         for arg in args:
-            if isinstance(arg, tvm.nd.NDArray) or isinstance(arg, tvm.DataType):
+            if isinstance(arg, tuple):
+                shape_tuple = container.ShapeTuple(arg)
+                new_arg = self.emit_constant(shape_tuple)
+                args_.append(new_arg)
+            elif isinstance(arg, tvm.nd.NDArray) or isinstance(arg, tvm.DataType):
                 new_arg = self.emit_constant(arg)
                 args_.append(new_arg)
             else:

--- a/python/tvm/relax/exec_builder.py
+++ b/python/tvm/relax/exec_builder.py
@@ -19,7 +19,8 @@ from enum import IntEnum
 from typing import Optional, Union, List
 import tvm
 from tvm._ffi._ctypes.packed_func import TVMRetValueHandle
-from tvm.runtime import Object, container
+from tvm.runtime import Object
+from tvm.runtime.container import ShapeTuple
 from tvm._ffi.base import _LIB, check_call
 from . vm import Executable
 from . import _ffi_api
@@ -90,10 +91,10 @@ class ExecBuilder(Object):
         args_ = []
         for arg in args:
             if isinstance(arg, tuple):
-                shape_tuple = container.ShapeTuple(arg)
+                shape_tuple = ShapeTuple(arg)
                 new_arg = self.emit_constant(shape_tuple)
                 args_.append(new_arg)
-            elif isinstance(arg, tvm.nd.NDArray) or isinstance(arg, tvm.DataType):
+            elif isinstance(arg, (tvm.nd.NDArray, tvm.DataType, ShapeTuple)):
                 new_arg = self.emit_constant(arg)
                 args_.append(new_arg)
             else:

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -30,6 +30,9 @@ def fma_rewrite(expr):
     """
     return _ffi_api.fma_rewrite(expr)
 
+def to_non_dataflow(mod: IRModule) -> IRModule:
+    return _ffi_api.to_non_dataflow(mod)
+
 
 def call_dps_rewrite(mod: IRModule) -> IRModule:
     """Perform explicit memory allocation for call_dps.

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -16,8 +16,9 @@
 # under the License.
 # pylint: disable=no-else-return
 # pylint: disable=unidiomatic-typecheck
-from tvm import IRModule 
+from tvm import IRModule
 from . import _ffi_api
+
 
 def fma_rewrite(expr):
     """Perform fused multiply add rewriting in dataflow blocks.
@@ -29,22 +30,35 @@ def fma_rewrite(expr):
     """
     return _ffi_api.fma_rewrite(expr)
 
-def explicit_memory_rewrite(expr):
-    """Perform explicit memory allocation for call_dps in dataflow blocks.
+
+def call_dps_rewrite(mod: IRModule) -> IRModule:
+    """Perform explicit memory allocation for call_dps.
 
     Parameters
     ----------
-    expr : tvm.relay.Expr
-        The input expression.
+    mod : tvm.IRModule
+        The input module.
     """
-    return _ffi_api.explicit_memory_rewrite(expr)
+    return _ffi_api.call_dps_rewrite(mod)
+
+
+def memory_lower(mod: IRModule) -> IRModule:
+    """Perform memory lowering. Lower the relax.builtin.alloc_tensor op to VM builtin functions.
+
+    Parameters
+    ----------
+    mod : tvm.IRModule
+        The input module.
+    """
+    return _ffi_api.memory_lower(mod)
+
 
 def shape_lower(mod: IRModule) -> IRModule:
     """Lower the shape expression in relax to shape heap and TIR functions.
 
     Parameters
     ----------
-    expr : tvm.IRModule
+    mod : tvm.IRModule
         The input module.
     """
     return _ffi_api.shape_lower(mod)

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -31,6 +31,13 @@ def fma_rewrite(expr):
     return _ffi_api.fma_rewrite(expr)
 
 def to_non_dataflow(mod: IRModule) -> IRModule:
+    """Transform all dataflow structure to non-dataflow version.
+
+    Parameters
+    ----------
+    mod : tvm.IRModule
+        The input module.
+    """
     return _ffi_api.to_non_dataflow(mod)
 
 

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -165,13 +165,9 @@ def build(mod: tvm.IRModule,
     lib: tvm.runtime.Module
         A runtime module that contains generated code.
     """
-    print("to_non_dataflow")
     new_mod = transform.to_non_dataflow(mod)
-    print("call_dps")
     new_mod = transform.call_dps_rewrite(new_mod)
-    print("memory")
     new_mod = transform.memory_lower(new_mod)
-    print("shape_lower")
     new_mod = transform.shape_lower(new_mod)
     ex, lib = _ffi_api.VMBuild(new_mod, target, target_host)
     return ex, lib

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -20,6 +20,7 @@ import tvm
 from tvm.runtime import Object, Device, Module, PackedFunc
 from tvm._ffi.base import _LIB, check_call
 from . import _ffi_api
+from . import transform
 from ..rpc.base import RPC_SESS_MASK
 
 
@@ -164,5 +165,13 @@ def build(mod: tvm.IRModule,
     lib: tvm.runtime.Module
         A runtime module that contains generated code.
     """
-    ex, lib = _ffi_api.VMBuild(mod, target, target_host)
+    print("to_non_dataflow")
+    new_mod = transform.to_non_dataflow(mod)
+    print("call_dps")
+    new_mod = transform.call_dps_rewrite(new_mod)
+    print("memory")
+    new_mod = transform.memory_lower(new_mod)
+    print("shape_lower")
+    new_mod = transform.shape_lower(new_mod)
+    ex, lib = _ffi_api.VMBuild(new_mod, target, target_host)
     return ex, lib

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -343,11 +343,7 @@ void ExprMutator::VisitBinding(const Binding& binding) {
 
 Var ExprMutator::VisitVarBinding(const VarBinding& binding) {
   Expr new_value = builder_->Normalize(this->Mutate(binding->value));
-  // Var new_var = Downcast<Var>(this->Mutate(binding->var));
 
-  // FIXME: Current logic is problematic: change the new_var again would cause
-  // divergence variable version.
-  //
   // TODO(@altanh): this probably shouldn't live here, all passes would have to make sure to do it
   //                in this method...
   // if (new_value->shape_.defined()) {
@@ -392,7 +388,6 @@ void ExprMutator::VisitMatchShape(const MatchShape& binding) {
   Var new_var = binding->var;
 
   // TODO: when value's shape/type changed, create new var
-
   builder_->EmitMatchShape(
       MatchShape(new_value, Downcast<ShapeExpr>(new_pattern)->values, new_var));
 }

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -120,13 +120,19 @@ void ExprVisitor::VisitBinding(const Binding& binding) {
   }
 }
 
-void ExprVisitor::VisitVarBinding(const VarBinding& binding) { this->VisitExpr(binding->value); }
+void ExprVisitor::VisitVarBinding(const VarBinding& binding) {
+  this->VisitExpr(binding->value);
+  this->VisitExpr(binding->var);
+}
 
 void ExprVisitor::VisitMatchShape(const MatchShape& binding) {
   this->VisitExpr(binding->value);
   // TODO(ziheng): should we change pattern from
   // Array<PrimExpr> to ShapeExpr?
   this->VisitExpr(ShapeExpr(binding->pattern));
+  if (binding->var.defined()) {
+    this->VisitExpr(binding->var);
+  }
 }
 
 void ExprVisitor::VisitBindingBlock(const BindingBlock& block) {

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -360,7 +360,7 @@ Var ExprMutator::VisitVarBinding(const VarBinding& binding) {
   //   new_var->checked_type_ = new_value->checked_type_;
   // }
   
-  Var new_var = binding->var;
+  Var new_var = Downcast<Var>(this->Mutate(binding->var));
   if (!builder_->CanProveShapeEqual(new_var->shape(), new_value->shape()) ||
       !StructuralEqual()(new_var->checked_type(), new_value->checked_type())) {
     new_var = Var(new_var->vid, NullOpt, NullOpt, new_var->span);
@@ -385,7 +385,12 @@ Var ExprMutator::VisitVarBinding(const VarBinding& binding) {
 void ExprMutator::VisitMatchShape(const MatchShape& binding) {
   Expr new_value = this->Mutate(binding->value);
   Expr new_pattern = this->Mutate(ShapeExpr(binding->pattern));
-  Var new_var = binding->var;
+  Var new_var;
+  if (binding->var.defined()){
+    new_var = Downcast<Var>(this->Mutate(binding->var));
+  } else {
+    new_var = binding->var;
+  }
 
   // TODO: when value's shape/type changed, create new var
   builder_->EmitMatchShape(

--- a/src/relax/transform/call_dps_rewrite.cc
+++ b/src/relax/transform/call_dps_rewrite.cc
@@ -45,11 +45,11 @@ class CallDPSMutator : public ExprMutator {
   IRModule Lower() {
     ret_mod_ = IRModule();
     for (auto& p : mod_->functions) {
-      if (!p.second->IsInstance<FunctionNode>()) {
-        continue;
+      Expr func = p.second;
+      if (p.second->IsInstance<FunctionNode>()) {
+        func = this->Mutate(p.second);
       }
-      Expr new_func = this->Mutate(p.second);
-      ret_mod_->Add(p.first, Downcast<BaseFunc>(new_func));
+      ret_mod_->Add(p.first, Downcast<BaseFunc>(func));
     }
     return ret_mod_;
   }

--- a/src/relax/transform/call_dps_rewrite.cc
+++ b/src/relax/transform/call_dps_rewrite.cc
@@ -43,15 +43,15 @@ class CallDPSMutator : public ExprMutator {
   explicit CallDPSMutator(IRModule mod) { mod_ = mod; }
 
   IRModule Lower() {
-    ret_mod_ = IRModule();
+    IRModule ret_mod = IRModule();
     for (auto& p : mod_->functions) {
       Expr func = p.second;
       if (p.second->IsInstance<FunctionNode>()) {
         func = this->Mutate(p.second);
       }
-      ret_mod_->Add(p.first, Downcast<BaseFunc>(func));
+      ret_mod->Add(p.first, Downcast<BaseFunc>(func));
     }
-    return ret_mod_;
+    return ret_mod;
   }
 
   Expr VisitExpr_(const CallNode* call) override {
@@ -76,7 +76,6 @@ class CallDPSMutator : public ExprMutator {
 
  private:
   IRModule mod_;
-  IRModule ret_mod_;
 };
 
 TVM_REGISTER_GLOBAL("relax.transform.call_dps_rewrite").set_body_typed([](IRModule mod) {

--- a/src/relax/transform/call_dps_rewrite.cc
+++ b/src/relax/transform/call_dps_rewrite.cc
@@ -54,14 +54,6 @@ class CallDPSMutator : public ExprMutator {
     return ret_mod_;
   }
 
-  BindingBlock VisitBindingBlock(const BindingBlock& block) {
-    builder_->BeginBindingBlock();
-    for (Binding binding : block->bindings) {
-      this->VisitBinding(binding);
-    }
-    return builder_->EndBlock();
-  }
-
   Expr VisitExpr_(const CallNode* call) override {
     // post-order mutation
     Expr expr = ExprMutator::VisitExpr_(call);

--- a/src/relax/transform/call_dps_rewrite.cc
+++ b/src/relax/transform/call_dps_rewrite.cc
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file src/relax/transform/call_dps_rewrite.cc
+ * \brief
+ */
+#include <tvm/relax/attrs/memory.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/type.h>
+#include <tvm/tir/op.h>
+
+#include "../../relay/transforms/pattern_utils.h"
+
+namespace tvm {
+namespace relax {
+
+// ==================
+// CallDPSMutator
+// Example:
+// y: Tensor[n, m] = rx.call_dps((n, m), op.identity, (x))
+// -->
+// lv0 = rx.call("relax.builtin.alloc_tensor", [n, m])
+// rx.call_packed(op.identity, x, lv0)
+
+class CallDPSMutator : public ExprMutator {
+ public:
+  explicit CallDPSMutator(IRModule mod) { mod_ = mod; }
+
+  IRModule Lower() {
+    ret_mod_ = IRModule();
+    for (auto& p : mod_->functions) {
+      if (!p.second->IsInstance<FunctionNode>()) {
+        continue;
+      }
+      Expr new_func = this->Mutate(p.second);
+      ret_mod_->Add(p.first, Downcast<BaseFunc>(new_func));
+    }
+    return ret_mod_;
+  }
+
+  BindingBlock VisitBindingBlock(const BindingBlock& block) {
+    builder_->BeginBindingBlock();
+    for (Binding binding : block->bindings) {
+      this->VisitBinding(binding);
+    }
+    return builder_->EndBlock();
+  }
+
+  Expr VisitExpr_(const CallNode* call) override {
+    // post-order mutation
+    Expr expr = ExprMutator::VisitExpr_(call);
+    call = expr.as<CallNode>();
+    // TODO(@yuchen, @altanh): using mutate cause infinite recursion
+    // Expr expr = ExprMutator::Mutate(GetRef<Call>(call));
+
+    static const Op& call_dps_op = Op::Get("relax.call_dps");
+    static const Op& alloc_tensor_op = Op::Get("relax.builtin.alloc_tensor");
+
+    if (call->op == call_dps_op) {
+      ShapeExpr output_shape = Downcast<ShapeExpr>(call->args[0]);
+      Var tensor = builder_->Emit(Call(alloc_tensor_op, {call->args[0]}), "alloc");
+      builder_->Emit(Call(call->args[1], {call->args[2], tensor}), "_");
+      return tensor;
+    }
+
+    return GetRef<Expr>(call);
+  }
+
+ private:
+  IRModule mod_;
+  IRModule ret_mod_;
+};
+
+TVM_REGISTER_GLOBAL("relax.transform.call_dps_rewrite").set_body_typed([](IRModule mod) {
+  return CallDPSMutator(mod).Lower();
+});
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/transform/memory_rewrite.cc
+++ b/src/relax/transform/memory_rewrite.cc
@@ -162,7 +162,7 @@ class MemLowerMutator : public ExprMutator {
 
       Var storage =
           builder_->Emit(Call(ExternFunc("vm.builtin.alloc_storage"),
-                              {storage_size, alignment, device_type}, Attrs(storage_attr)),
+                              {storage_size, alignment}, Attrs(storage_attr)),
                          "storage");
 
       ShapeExpr offset = ShapeExpr({IntImm(DataType::Int(64), 0)});

--- a/src/relax/transform/memory_rewrite.cc
+++ b/src/relax/transform/memory_rewrite.cc
@@ -47,11 +47,11 @@ class MemLowerMutator : public ExprMutator {
   IRModule Lower() {
     ret_mod_ = IRModule();
     for (auto& p : mod_->functions) {
-      if (!p.second->IsInstance<FunctionNode>()) {
-        continue;
+      Expr func = p.second;
+      if (p.second->IsInstance<FunctionNode>()) {
+        func = this->Mutate(p.second);
       }
-      Expr new_func = this->Mutate(p.second);
-      ret_mod_->Add(p.first, Downcast<BaseFunc>(new_func));
+      ret_mod_->Add(p.first, Downcast<BaseFunc>(func));
     }
     return ret_mod_;
   }

--- a/src/relax/transform/shape_lower.cc
+++ b/src/relax/transform/shape_lower.cc
@@ -114,6 +114,7 @@ class ShapeLowerMutator : public ExprMutator {
       new_body = seq->body;
     }
 
+    // FIXME(@yuchen): Implement vm.builtin.free_shape_heap.
     // builder_->Emit(Call(ExternFunc("vm.builtin.free_shape_heap"), {shape_heap_}), "gv");
     blocks.push_back(builder_->EndBlock());
     new_body = SeqExpr(blocks, new_body);

--- a/src/relax/transform/shape_lower.cc
+++ b/src/relax/transform/shape_lower.cc
@@ -42,19 +42,19 @@ class ShapeLowerMutator : public ExprMutator {
   IRModule Lower() {
     ret_mod_ = IRModule();
     for (auto& p : mod_->functions) {
-      if (!p.second->IsInstance<FunctionNode>()) {
-        continue;
-      }
-      // prepare mapping and heap var
-      expr2slot_ = PrepareExpr2Slot(Downcast<Function>(p.second));
-      // LOG(INFO) << "mapping: " << expr2slot_;
-      heap_size_ = IntImm(ShapeDType(), expr2slot_.size());
-      DynTensorType heap_type(1, ShapeDType());
-      shape_heap_ = Var("shape_heap", ShapeExpr({heap_size_}), heap_type);
+      Expr func = p.second;
+      if (p.second->IsInstance<FunctionNode>()) {
+        // prepare mapping and heap var
+        expr2slot_ = PrepareExpr2Slot(Downcast<Function>(func));
+        // LOG(INFO) << "mapping: " << expr2slot_;
+        heap_size_ = IntImm(ShapeDType(), expr2slot_.size());
+        DynTensorType heap_type(1, ShapeDType());
+        shape_heap_ = Var("shape_heap", ShapeExpr({heap_size_}), heap_type);
 
-      // mutate
-      Expr new_func = this->Mutate(p.second);
-      ret_mod_->Add(p.first, Downcast<BaseFunc>(new_func));
+        // mutate
+        func = this->Mutate(func);
+      }
+      ret_mod_->Add(p.first, Downcast<BaseFunc>(func));
     }
     return ret_mod_;
   }
@@ -114,7 +114,7 @@ class ShapeLowerMutator : public ExprMutator {
       new_body = seq->body;
     }
 
-    builder_->Emit(Call(ExternFunc("vm.builtin.free_shape_heap"), {shape_heap_}), "gv");
+    // builder_->Emit(Call(ExternFunc("vm.builtin.free_shape_heap"), {shape_heap_}), "gv");
     blocks.push_back(builder_->EndBlock());
     new_body = SeqExpr(blocks, new_body);
 

--- a/src/relax/transform/to_non_dataflow.cc
+++ b/src/relax/transform/to_non_dataflow.cc
@@ -35,11 +35,11 @@ class ToNonDFMutator : public ExprMutator {
   IRModule Lower() {
     ret_mod_ = IRModule();
     for (auto& p : mod_->functions) {
-      if (!p.second->IsInstance<FunctionNode>()) {
-        continue;
+      Expr func = p.second;
+      if (p.second->IsInstance<FunctionNode>()) {
+        func = this->Mutate(p.second);
       }
-      Expr new_func = this->Mutate(p.second);
-      ret_mod_->Add(p.first, Downcast<BaseFunc>(new_func));
+      ret_mod_->Add(p.first, Downcast<BaseFunc>(func));
     }
     return ret_mod_;
   }

--- a/src/relax/transform/to_non_dataflow.cc
+++ b/src/relax/transform/to_non_dataflow.cc
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file src/relax/transform/to_non_dataflow.cc
+ * \brief
+ */
+#include <tvm/relax/attrs/memory.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/type.h>
+#include <tvm/tir/op.h>
+
+namespace tvm {
+namespace relax {
+
+class ToNonDFMutator : public ExprMutator {
+ public:
+  explicit ToNonDFMutator(IRModule mod) { mod_ = mod; }
+
+  IRModule Lower() {
+    ret_mod_ = IRModule();
+    for (auto& p : mod_->functions) {
+      if (!p.second->IsInstance<FunctionNode>()) {
+        continue;
+      }
+      Expr new_func = this->Mutate(p.second);
+      ret_mod_->Add(p.first, Downcast<BaseFunc>(new_func));
+    }
+    return ret_mod_;
+  }
+
+  Expr VisitExpr_(const DataflowVarNode* op) final {
+    Var new_var(op->vid, op->shape(), op->type_annotation, op->span);
+    var_remap_[GetRef<Var>(op)] = new_var;
+    return new_var;
+  }
+
+  BindingBlock VisitDataflowBlock(const DataflowBlock& block) final {
+    builder_->BeginBindingBlock();
+    for (Binding binding : block->bindings) {
+      this->VisitBinding(binding);
+    }
+    return builder_->EndBlock();
+  }
+
+ private:
+  IRModule mod_;
+  IRModule ret_mod_;
+};
+
+TVM_REGISTER_GLOBAL("relax.transform.to_non_dataflow").set_body_typed([](IRModule mod) {
+  return ToNonDFMutator(mod).Lower();
+});
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/transform/to_non_dataflow.cc
+++ b/src/relax/transform/to_non_dataflow.cc
@@ -33,15 +33,15 @@ class ToNonDFMutator : public ExprMutator {
   explicit ToNonDFMutator(IRModule mod) { mod_ = mod; }
 
   IRModule Lower() {
-    ret_mod_ = IRModule();
+    IRModule ret_mod = IRModule();
     for (auto& p : mod_->functions) {
       Expr func = p.second;
       if (p.second->IsInstance<FunctionNode>()) {
         func = this->Mutate(p.second);
       }
-      ret_mod_->Add(p.first, Downcast<BaseFunc>(func));
+      ret_mod->Add(p.first, Downcast<BaseFunc>(func));
     }
-    return ret_mod_;
+    return ret_mod;
   }
 
   Expr VisitExpr_(const DataflowVarNode* op) final {
@@ -63,7 +63,6 @@ class ToNonDFMutator : public ExprMutator {
 
  private:
   IRModule mod_;
-  IRModule ret_mod_;
 };
 
 TVM_REGISTER_GLOBAL("relax.transform.to_non_dataflow").set_body_typed([](IRModule mod) {

--- a/src/relax/transform/to_non_dataflow.cc
+++ b/src/relax/transform/to_non_dataflow.cc
@@ -45,8 +45,11 @@ class ToNonDFMutator : public ExprMutator {
   }
 
   Expr VisitExpr_(const DataflowVarNode* op) final {
+    auto it = var_remap_.find(GetRef<Var>(op));
+    if (it != var_remap_.end()) {
+      return it->second;
+    }
     Var new_var(op->vid, op->shape(), op->type_annotation, op->span);
-    var_remap_[GetRef<Var>(op)] = new_var;
     return new_var;
   }
 

--- a/src/relax/vm/builtin.cc
+++ b/src/relax/vm/builtin.cc
@@ -94,8 +94,9 @@ TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
 });
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_tensor")
-.set_body_typed([](Storage storage, Index offset, DLDataType dtype, ShapeTuple shape) {
-  auto tensor = storage->AllocNDArray(offset, shape, dtype);
+.set_body_typed([](Storage storage, ShapeTuple offset, ShapeTuple shape, DLDataType dtype) {
+  int64_t offset_imm = offset[0];
+  auto tensor = storage->AllocNDArray(offset_imm, shape, dtype);
   return tensor;
 });
 

--- a/src/relax/vm/builtin.cc
+++ b/src/relax/vm/builtin.cc
@@ -74,10 +74,12 @@ TVM_REGISTER_GLOBAL("vm.builtin.make_shape")
 });
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
-.set_body_typed([](void* vm_state_ptr, Index size, Index alignment, Index device_type,
+.set_body_typed([](void* vm_state_ptr, ShapeTuple size, ShapeTuple alignment, Index device_type,
                     DLDataType dtype_hint) {
   VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
-  DLOG(INFO) << "AllocStorage: allocation_size=" << size << ", alignment=" << alignment
+  int64_t size_imm = size[0];
+  int64_t align_imm = alignment[0];
+  DLOG(INFO) << "AllocStorage: allocation_size=" << size_imm << ", alignment=" << align_imm
               << ", dtype_hint=" << runtime::DLDataType2String(dtype_hint)
               << ", device_type=" << device_type;
 
@@ -86,7 +88,7 @@ TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
       << "Memory allocator for device " << device_type << " has not been initialized";
   auto* alloc = vm_state->allocators[device_type];
   ICHECK(alloc) << "Did you forget to init the VirtualMachine with devices?";
-  storage_obj->buffer = alloc->Alloc(size, alignment, dtype_hint);
+  storage_obj->buffer = alloc->Alloc(size_imm, align_imm, dtype_hint);
   Storage storage(storage_obj);
   return storage;
 });

--- a/src/relax/vm/builtin.cc
+++ b/src/relax/vm/builtin.cc
@@ -69,10 +69,12 @@ TVM_REGISTER_GLOBAL("vm.builtin.make_shape")
 });
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
-.set_body_typed([](void* vm_state_ptr, ShapeTuple size, ShapeTuple alignment, Index device_type,
+.set_body_typed([](void* vm_state_ptr, ShapeTuple buffer_size, ShapeTuple alignment, Index device_type,
                     DLDataType dtype_hint) {
+  ICHECK_EQ(buffer_size.size(), 1);
+  ICHECK_EQ(alignment.size(), 1);
   VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
-  int64_t size_imm = size[0];
+  int64_t size_imm = buffer_size[0];
   int64_t align_imm = alignment[0];
   DLOG(INFO) << "AllocStorage: allocation_size=" << size_imm << ", alignment=" << align_imm
               << ", dtype_hint=" << runtime::DLDataType2String(dtype_hint)
@@ -90,6 +92,7 @@ TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_tensor")
 .set_body_typed([](Storage storage, ShapeTuple offset, ShapeTuple shape, DLDataType dtype) {
+  ICHECK_EQ(offset.size(), 1);
   int64_t offset_imm = offset[0];
   auto tensor = storage->AllocNDArray(offset_imm, shape, dtype);
   return tensor;

--- a/src/relax/vm/builtin.cc
+++ b/src/relax/vm/builtin.cc
@@ -46,11 +46,6 @@ TVM_REGISTER_GLOBAL("vm.builtin.alloc_shape_heap")
   return NDArray::Empty(size, DLDataType{kDLInt, 64, 1}, DLDevice{kDLCPU, 0});
 });
 
-TVM_REGISTER_GLOBAL("vm.builtin.free_shape_heap")
-.set_body_typed([](NDArray arr) {
-  return static_cast<NDArray::Container*>(const_cast<Object*>(arr.get()))->DecRef();
-});
-
 TVM_REGISTER_GLOBAL("vm.builtin.decode_shape")
 .set_body_typed([](ShapeTuple shape, NDArray heap, ShapeTuple indexes) {
   int64_t* heap_data = reinterpret_cast<int64_t*>(heap.ToDLPack()->dl_tensor.data);

--- a/src/relax/vm/compiler.cc
+++ b/src/relax/vm/compiler.cc
@@ -131,11 +131,6 @@ class VMCompilerImpl : public ExprVisitor {
     }
     args.push_back(Instruction::Arg(Instruction::kImmediate, device_type));
 
-    // TODO
-    // O1: PODConstant node (serialization) -> relax compiled time
-    // O2: PrimValue PrimExpr. IntImm.  dimension
-    // minimum
-
     // store dtype in constant pool
     TVMRetValue data_type;
     data_type = dtype;

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -105,9 +105,7 @@ def test_call_dps_rewrite():
     @rx.script
     class Mod:
         def foo(x: Tensor[(m, n), "float32"]):
-            with relax.dataflow():
-                gv0 = relax.call_dps((m, n), "test.op.identity", (x,))
-                relax.output(gv0)
+            gv0 = relax.call_dps((m, n), "test.op.identity", (x,))
             return gv0
 
     mod = Mod()

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -62,27 +62,28 @@ def test_fma_rewrite():
     assert type(func.body.blocks[0].bindings[1].var) == rx.Var
 
 
-def test_explicit_memory_rewrite():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
-    shape_anno = [m, n]
-    type_anno = rx.DynTensorType(2, "float32")
-    x = rx.Var("x", shape_anno, type_anno)
-    ib = rx.BlockBuilder()
-    with ib.function(x):
-        with ib.dataflow() as df:
-            gv0 = ib.emit_output(rx.call_dps([m, n], rx.extern("test.op.identity"), [x]))
-        ib.emit_func_output(gv0)
-    expr = ib.get()
+def test_call_dps_rewrite():
+    @rx.script
+    class Mod:
+        def foo(x: Tensor[(m, n), "float32"]):
+            with relax.dataflow():
+                gv0 = relax.call_dps((m, n), "test.op.identity", (x,))
+                relax.output(gv0)
+            return gv0
+
+    mod = Mod()
+    code = rx.parser.astext(mod)
 
     # before rewrite
-    v0 = expr.body.blocks[0].bindings[0].var
-    s0 = expr.body.blocks[0].bindings[0].value
+    v0 = mod["foo"].body.blocks[0].bindings[0].var
+    s0 = mod["foo"].body.blocks[0].bindings[0].value
     assert isinstance(s0, tvm.relay.Call)
     assert s0.op.name == "relax.call_dps"
 
     # after rewrite
-    func = rx.transform.explicit_memory_rewrite(expr)
+    new_mod = rx.transform.call_dps_rewrite(mod)
+    func = new_mod["foo"]
+    code = rx.parser.astext(new_mod)
 
     # the dataflow block has changed to binding block due to the rewriting
     block = func.body.blocks[0]
@@ -92,20 +93,43 @@ def test_explicit_memory_rewrite():
     assert isinstance(s1, tvm.relay.Call)
     assert s1.op.name == "relax.builtin.alloc_tensor"
     assert isinstance(s1.args[0], rx.ShapeExpr)
-    assert structural_equal(s1.args[0], rx.ShapeExpr(shape_anno))
+    # assert structural_equal(s1.args[0], rx.ShapeExpr(shape_anno))
     s2 = block.bindings[1].value
     assert s2.op.global_symbol == "test.op.identity"
+    return new_mod
 
 
-@rx.script
-class Mod:
-    def foo(x: Tensor[_, "float32"]) -> Shape:
-        sh = relax.call_packed("vm.builtin.shape_of", x)
-        relax.match_shape(sh, (n, m))
-        return (n * 2, m * 3)
+def test_memory_lower():
+    @rx.script
+    class Mod:
+        def foo(x: Tensor[(m, n), "float32"]):
+            with relax.dataflow():
+                gv0 = relax.call_dps((m, n), "test.op.identity", (x,))
+                relax.output(gv0)
+            return gv0
+
+    mod = test_call_dps_rewrite()
+    code = rx.parser.astext(mod)
+
+    # after memory lowering
+    new_mod = rx.transform.memory_lower(mod)
+
+    assert isinstance(new_mod, tvm.IRModule)
+    assert isinstance(new_mod["foo"], tvm.relax.expr.Function)
+    code = rx.parser.astext(new_mod)
+    assert "vm.builtin.alloc_storage" in code
+    assert "vm.builtin.alloc_tensor" in code
+
 
 def test_shape_lowering():
-    mod = Mod()
+    @rx.script
+    class Mod1:
+        def foo(x: Tensor[_, "float32"]) -> Shape:
+            sh = relax.call_packed("vm.builtin.shape_of", x)
+            relax.match_shape(sh, (n, m))
+            return (n * 2, m * 3)
+
+    mod = Mod1()
     new_mod = rx.transform.shape_lower(mod)
     assert isinstance(new_mod, tvm.IRModule)
     assert isinstance(new_mod["shape_func"], tvm.tir.function.PrimFunc)
@@ -118,5 +142,6 @@ def test_shape_lowering():
 
 if __name__ == "__main__":
     test_fma_rewrite()
-    test_explicit_memory_rewrite()
+    test_call_dps_rewrite()
+    test_memory_lower()
     test_shape_lowering()

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -80,7 +80,7 @@ def test_to_non_dataflow():
             nonlocal old_vars
             old_vars.append(e)
     rx.analysis.post_order_visit(mod["foo"], fvisit)
-    _, x, gv0, gv1 = old_vars
+    _, x, _, gv0, _, gv1 = old_vars
 
     new_mod = rx.transform.to_non_dataflow(mod)
 
@@ -92,13 +92,13 @@ def test_to_non_dataflow():
     rx.analysis.post_order_visit(new_mod["foo"], fvisit)
 
     assert x == new_vars[1]
-    assert gv0 != new_vars[2]
+    assert gv0 != new_vars[3]
     assert isinstance(gv0, rx.DataflowVar)
-    assert not isinstance(new_vars[2], rx.DataflowVar)
+    assert not isinstance(new_vars[3], rx.DataflowVar)
 
     assert isinstance(gv1, rx.Var)
-    assert isinstance(new_vars[3], rx.Var)
-    assert gv1 != new_vars[3]
+    assert isinstance(new_vars[5], rx.Var)
+    assert gv1 != new_vars[5]
 
 
 def test_call_dps_rewrite():

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -264,13 +264,11 @@ def test_vm_compile_stage2():
     assert res[1] == shape[1] * 3
 
 
-def test_vm_compile_e2e():
+def test_vm_compile_stage3():
     @rx.script
     class Mod3:
-        def foo(x: Tensor[_, "float32"]) -> Tensor:
+        def foo(x: Tensor[(32, 16), "float32"]) -> Tensor:
             with relax.dataflow():
-                sh = relax.call_packed("vm.builtin.shape_of", x)
-                x0 = relax.match_shape(sh, (n, m))
                 y = relax.call_dps((32, 16), "test.vm.identity", (x))
                 relax.output(y)
             return y
@@ -302,17 +300,55 @@ def test_vm_compile_e2e():
     np.testing.assert_allclose(inp.asnumpy(), res.asnumpy())
 
 
+def test_vm_compile_e2e():
+    @rx.script
+    class Mod4:
+        def foo(x: Tensor[_, "float32"]) -> Tensor:
+            with relax.dataflow():
+                sh = relax.call_packed("vm.builtin.shape_of", x)
+                x0 = relax.match_shape(sh, (n, m))
+                y = relax.call_dps((n, m), "test.vm.identity", (x))
+                relax.output(y)
+            return y
+
+    mod = Mod4()
+    code = rx.parser.astext(mod)
+
+    mod1 = rx.transform.to_non_dataflow(mod)
+    code = rx.parser.astext(mod1)
+
+    mod2 = rx.transform.call_dps_rewrite(mod1)
+    code = rx.parser.astext(mod2)
+
+    mod3 = rx.transform.memory_lower(mod2)
+    code = rx.parser.astext(mod3)
+
+    mod4 = rx.transform.shape_lower(mod3)
+    code = rx.parser.astext(mod4)
+
+    target = tvm.target.Target("llvm")
+    target_host = tvm.target.Target("llvm")
+    ex, lib = rx.vm.build(mod4, target, target_host)
+    vm = rx.VirtualMachine(ex, tvm.cpu(), mod=lib)
+
+    shape = (32, 16)
+    inp = tvm.nd.array(np.random.rand(*shape).astype(np.float32))
+    res = vm["foo"](inp)
+    np.testing.assert_allclose(inp.asnumpy(), res.asnumpy())
+
+
 if __name__ == "__main__":
-    test_vm_execute()
-    test_vm_multiple_func()
-    test_vm_checker()
-    test_vm_formalize()
-    test_vm_operand()
-    test_vm_serialize()
-    test_vm_constant_serialize()
-    test_vm_shapeof()
-    test_vm_storage()
-    test_vm_compile_stage0()
-    test_vm_compile_stage1()
-    test_vm_compile_stage2()
+    # test_vm_execute()
+    # test_vm_multiple_func()
+    # test_vm_checker()
+    # test_vm_formalize()
+    # test_vm_operand()
+    # test_vm_serialize()
+    # test_vm_constant_serialize()
+    # test_vm_shapeof()
+    # test_vm_storage()
+    # test_vm_compile_stage0()
+    # test_vm_compile_stage1()
+    # test_vm_compile_stage2()
+    # test_vm_compile_stage3()
     test_vm_compile_e2e()

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -269,8 +269,8 @@ def test_vm_compile_e2e():
     class Mod3:
         def foo(x: Tensor[_, "float32"]) -> Tensor:
             with relax.dataflow():
-                # sh = relax.call_packed("vm.builtin.shape_of", x)
-                # x0 = relax.match_shape(sh, (n, m))
+                sh = relax.call_packed("vm.builtin.shape_of", x)
+                x0 = relax.match_shape(sh, (n, m))
                 y = relax.call_dps((32, 16), "test.vm.identity", (x))
                 relax.output(y)
             return y
@@ -287,9 +287,9 @@ def test_vm_compile_e2e():
     code = rx.parser.astext(mod3)
     print(code)
 
-    # mod4 = rx.transform.shape_lower(mod3)
-    # code = rx.parser.astext(mod4)
-    # print(code)
+    mod4 = rx.transform.shape_lower(mod3)
+    code = rx.parser.astext(mod4)
+    print(code)
 
     target = tvm.target.Target("llvm")
     target_host = tvm.target.Target("llvm")

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -249,12 +249,9 @@ def test_vm_compile_stage2():
             return (n * 2, m * 3)
 
     mod = Mod2()
-    code = rx.parser.astext(mod)
-    new_mod = rx.transform.shape_lower(mod)
-    code = rx.parser.astext(new_mod)
     target = tvm.target.Target("llvm")
     target_host = tvm.target.Target("llvm")
-    ex, lib = rx.vm.build(new_mod, target, target_host)
+    ex, lib = rx.vm.build(mod, target, target_host)
     vm = rx.VirtualMachine(ex, tvm.cpu(), mod=lib)
 
     shape = (32, 16)
@@ -274,24 +271,9 @@ def test_vm_compile_stage3():
             return y
 
     mod = Mod3()
-    code = rx.parser.astext(mod)
-    print(code)
-
-    mod2 = rx.transform.call_dps_rewrite(mod)
-    code = rx.parser.astext(mod2)
-    print(code)
-
-    mod3 = rx.transform.memory_lower(mod2)
-    code = rx.parser.astext(mod3)
-    print(code)
-
-    mod4 = rx.transform.shape_lower(mod3)
-    code = rx.parser.astext(mod4)
-    print(code)
-
     target = tvm.target.Target("llvm")
     target_host = tvm.target.Target("llvm")
-    ex, lib = rx.vm.build(mod3, target, target_host)
+    ex, lib = rx.vm.build(mod, target, target_host)
     vm = rx.VirtualMachine(ex, tvm.cpu(), mod=lib)
 
     shape = (32, 16)
@@ -312,23 +294,12 @@ def test_vm_compile_e2e():
             return y
 
     mod = Mod4()
-    code = rx.parser.astext(mod)
-
-    mod1 = rx.transform.to_non_dataflow(mod)
-    code = rx.parser.astext(mod1)
-
-    mod2 = rx.transform.call_dps_rewrite(mod1)
-    code = rx.parser.astext(mod2)
-
-    mod3 = rx.transform.memory_lower(mod2)
-    code = rx.parser.astext(mod3)
-
-    mod4 = rx.transform.shape_lower(mod3)
-    code = rx.parser.astext(mod4)
 
     target = tvm.target.Target("llvm")
     target_host = tvm.target.Target("llvm")
-    ex, lib = rx.vm.build(mod4, target, target_host)
+    print("build")
+    ex, lib = rx.vm.build(mod, target, target_host)
+    print("vm")
     vm = rx.VirtualMachine(ex, tvm.cpu(), mod=lib)
 
     shape = (32, 16)
@@ -347,7 +318,7 @@ if __name__ == "__main__":
     # test_vm_constant_serialize()
     # test_vm_shapeof()
     # test_vm_storage()
-    # test_vm_compile_stage0()
+    test_vm_compile_stage0()
     # test_vm_compile_stage1()
     # test_vm_compile_stage2()
     # test_vm_compile_stage3()


### PR DESCRIPTION
End2End MVP working now.
- Transform the dataflow program to non-dataflow format for lowering;
- Lower `call_dps` to explicit memory form;
- Support `alloc_storage` and `alloc_tensor` for dynamic shape;
- Fix the mutator issue with a temporary solution;

Co-Authored-By: Yuchen Jin <yuchenj@cs.washington.edu>