### PR TITLE
fix IRModule parsing by resolving GlobalVars later

### DIFF
--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -25,7 +25,7 @@ class FunctionPass(tvm.ir.transform.Pass):
     pass class should be created through `function_pass`.
     """
 
-def FMARewrite() -> tvm.transform.Pass:
+def FMARewrite() -> tvm.ir.transform.Pass:
     """Perform fused multiply add rewriting in dataflow blocks.
 
     Returns
@@ -35,7 +35,7 @@ def FMARewrite() -> tvm.transform.Pass:
     return _ffi_api.FMARewrite()
 
 
-def ToNonDataflow() -> tvm.transform.Pass:
+def ToNonDataflow() -> tvm.ir.transform.Pass:
     """Transform all dataflow structure to non-dataflow version.
 
     Returns
@@ -45,7 +45,7 @@ def ToNonDataflow() -> tvm.transform.Pass:
     return _ffi_api.ToNonDataflow()
 
 
-def CallDPSRewrite() -> tvm.transform.Pass:
+def CallDPSRewrite() -> tvm.ir.transform.Pass:
     """Perform explicit tensor allocation for call_dps.
 
     Returns
@@ -55,7 +55,7 @@ def CallDPSRewrite() -> tvm.transform.Pass:
     return _ffi_api.CallDPSRewrite()
 
 
-def VMMemoryLower() -> tvm.transform.Pass:
+def VMMemoryLower() -> tvm.ir.transform.Pass:
     """Perform memory lowering. Lowers the relax.builtin.alloc_tensor intrinsic to VM intrinsics.
 
     Returns
@@ -65,7 +65,7 @@ def VMMemoryLower() -> tvm.transform.Pass:
     return _ffi_api.VMMemoryLower()
 
 
-def VMShapeLower() -> tvm.transform.Pass:
+def VMShapeLower() -> tvm.ir.transform.Pass:
     """Lower the shape expressions in relax to VM shape heap manipulations and generate related 
     TIR functions to do shape calculations.
 
@@ -76,7 +76,7 @@ def VMShapeLower() -> tvm.transform.Pass:
     return _ffi_api.VMShapeLower()
 
 
-def ToANF() -> tvm.transform.Pass:
+def ToANF() -> tvm.ir.transform.Pass:
     """Transforming Relax IR to A-normal form.
 
     Returns
@@ -84,3 +84,7 @@ def ToANF() -> tvm.transform.Pass:
     ret: tvm.transform.Pass
     """
     return _ffi_api.ToANF()
+
+
+def ResolveGlobals() -> tvm.ir.transform.Pass:
+    return _ffi_api.ResolveGlobals()

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -19,18 +19,20 @@
 import tvm.ir
 from . import _ffi_api
 
+
 @tvm._ffi.register_object("relax.FunctionPass")
 class FunctionPass(tvm.ir.transform.Pass):
     """A pass that works on each tvm.relax.Function in a module. A function
     pass class should be created through `function_pass`.
     """
 
+
 def FMARewrite() -> tvm.ir.transform.Pass:
     """Perform fused multiply add rewriting in dataflow blocks.
 
     Returns
     -------
-    ret: tvm.transform.Pass
+    ret: tvm.ir.transform.Pass
     """
     return _ffi_api.FMARewrite()
 
@@ -40,7 +42,7 @@ def ToNonDataflow() -> tvm.ir.transform.Pass:
 
     Returns
     -------
-    ret: tvm.transform.Pass
+    ret: tvm.ir.transform.Pass
     """
     return _ffi_api.ToNonDataflow()
 
@@ -50,7 +52,7 @@ def CallDPSRewrite() -> tvm.ir.transform.Pass:
 
     Returns
     -------
-    ret: tvm.transform.Pass
+    ret: tvm.ir.transform.Pass
     """
     return _ffi_api.CallDPSRewrite()
 
@@ -60,18 +62,18 @@ def VMMemoryLower() -> tvm.ir.transform.Pass:
 
     Returns
     -------
-    ret: tvm.transform.Pass
+    ret: tvm.ir.transform.Pass
     """
     return _ffi_api.VMMemoryLower()
 
 
 def VMShapeLower() -> tvm.ir.transform.Pass:
-    """Lower the shape expressions in relax to VM shape heap manipulations and generate related 
+    """Lower the shape expressions in relax to VM shape heap manipulations and generate related
     TIR functions to do shape calculations.
 
     Returns
     -------
-    ret: tvm.transform.Pass
+    ret: tvm.ir.transform.Pass
     """
     return _ffi_api.VMShapeLower()
 
@@ -81,10 +83,18 @@ def ToANF() -> tvm.ir.transform.Pass:
 
     Returns
     -------
-    ret: tvm.transform.Pass
+    ret: tvm.ir.transform.Pass
     """
     return _ffi_api.ToANF()
 
 
 def ResolveGlobals() -> tvm.ir.transform.Pass:
+    """Resolve global variables using string equality. This ensures all GlobalVars in the IR refer
+    to the correct GlobalVar of the input IRModule. An error is reported if any GlobalVar cannot be
+    resolved.
+
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
     return _ffi_api.ResolveGlobals()

--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from synr import ast, Transformer, to_ast
 
 import tvm
-from tvm import IRModule
+from tvm import IRModule, relax
 from tvm._ffi.base import TVMError
 from tvm.ir import GlobalVar
 from tvm.ir.function import BaseFunc
@@ -1118,5 +1118,9 @@ def ir_module(input_module: type) -> IRModule:
         func_dict = {
             name: f for name, f in input_module.__dict__.items() if isinstance(f, BaseFunc)
         }
-        return IRModule(func_dict)
+        mod = IRModule(func_dict)
+        mod = relax.transform.ResolveGlobals()(mod)
+        # FIXME(@altanh): where is the source map?
+        return mod
+
     raise TypeError("Only class definitions are supported.")

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -970,9 +970,12 @@ class RelaxTransformer(Transformer):
             var_name = expr.id.name
             if _is_registered(var_name, op_set=self._registered_ops):
                 return relay.op.get(var_name)
-            if var_name not in self.scope:
-                self.report_error("undefined variable", expr.span)
-            return self.scope[var_name]
+            if var_name in self.scope:
+                return self.scope[var_name]
+            # NOTE: this is a "hack" to get around Python eagerly parsing class method decorators
+            #       first (meaning we need to resolve them after the functions are parsed). These
+            #       GlobalVars need to be resolved using string equality only.
+            return relay.GlobalVar(var_name)
 
         elif isinstance(expr, ast.Constant):
             # FIXME(@altanh): use internal representation that doesn't have precision limits here

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -497,13 +497,18 @@ Doc RelaxScriptPrinter::PrintFunctionDef(const Doc& name, const relax::Function&
 }
 
 Doc RelaxScriptPrinter::PrintVarAnnotation(const relax::Var& var) {
+  // TODO(@altanh): we should consider moving annotation into binding
   Doc doc;
-  if (var->type_annotation.defined()) {
+  Type annotation = var->checked_type_;
+  if (!annotation.defined()) {
+    annotation = var->type_annotation.value_or(Type());
+  }
+  if (annotation.defined()) {
     doc << ": ";
-    if (const relax::DynTensorTypeNode* tty = var->type_annotation.as<relax::DynTensorTypeNode>()) {
+    if (const relax::DynTensorTypeNode* tty = annotation.as<relax::DynTensorTypeNode>()) {
       doc << PrintTensorAnnotation(GetRef<DynTensorType>(tty), var->shape_);
     } else {
-      doc << Print(var->type_annotation);
+      doc << Print(annotation);
     }
   }
   return doc;

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -362,11 +362,12 @@ void ExprMutator::VisitBinding_(const VarBindingNode* binding) {
     }
   };
 
-  if (new_var.same_as(binding->var) && new_value.same_as(binding->value)) {
-    // no-op if there is no change
-    emit(GetRef<VarBinding>(binding));
-    return;
-  }
+  // FIXME(@altanh): try to clean up all the fast paths and ty/shape infer, it's getting unwieldy
+  // if (new_var.same_as(binding->var) && new_value.same_as(binding->value)) {
+  //   // no-op if there is no change
+  //   emit(GetRef<VarBinding>(binding));
+  //   return;
+  // }
 
   {
     Var temp = WithShapeAndType(new_var, new_value->shape_, new_value->checked_type_);

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -354,9 +354,17 @@ void ExprMutator::VisitBinding_(const VarBindingNode* binding) {
   Expr new_value = this->VisitExpr(binding->value);
   Var new_var = this->VisitVarDef(binding->var);
 
+  auto emit = [this](VarBinding b) {
+    if (this->builder_->CurrentBlockIsDataFlow() && !b->var.as<DataflowVarNode>()) {
+      this->builder_->EmitOutput(b);
+    } else {
+      this->builder_->Emit(b);
+    }
+  };
+
   if (new_var.same_as(binding->var) && new_value.same_as(binding->value)) {
     // no-op if there is no change
-    builder_->Emit(GetRef<VarBinding>(binding));
+    emit(GetRef<VarBinding>(binding));
     return;
   }
 
@@ -368,11 +376,7 @@ void ExprMutator::VisitBinding_(const VarBindingNode* binding) {
     }
   }
 
-  if (builder_->CurrentBlockIsDataFlow() && !new_var.as<DataflowVarNode>()) {
-    builder_->EmitOutput(VarBinding(new_var, new_value));
-  } else {
-    builder_->Emit(VarBinding(new_var, new_value));
-  }
+  emit(VarBinding(new_var, new_value));
 }
 
 void ExprMutator::VisitBinding_(const MatchShapeNode* binding) {
@@ -387,8 +391,8 @@ void ExprMutator::VisitBinding_(const MatchShapeNode* binding) {
     if (new_value->checked_type_.defined() && new_value->checked_type_.as<DynTensorTypeNode>()) {
       new_shape = new_pattern;
     }
-    Var temp =
-        WithShapeAndType(this->VisitVarDef(binding->var), new_shape, new_value->checked_type_);
+    new_var = this->VisitVarDef(binding->var);
+    Var temp = WithShapeAndType(new_var, new_shape, new_value->checked_type_);
     if (!temp.same_as(new_var)) {
       new_var = temp;
       this->var_remap_[binding->var->vid] = new_var;

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -81,7 +81,8 @@ Type InferTypeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx) {
   auto* t1 = rhs_type.as<DynTensorTypeNode>();
   if (!t0 || !t1) {
     diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                       << "Both lhs and rhs should be DynTensor for broadcasting");
+                       << "Both lhs and rhs should be DynTensor for broadcasting, but got "
+                       << lhs_type->GetTypeKey() << " and " << rhs_type->GetTypeKey());
   }
 
   DataType output_dtype;

--- a/src/relax/transform/resolve_globals.cc
+++ b/src/relax/transform/resolve_globals.cc
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file src/relax/transform/resolve_globals.cc
+ * \brief Resolve GlobalVars using string equality.
+ */
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+
+namespace tvm {
+namespace relax {
+
+class GlobalVarResolver : public ExprMutator {
+ public:
+  GlobalVarResolver(IRModule mod, DiagnosticContext diag_ctx) : mod_(mod), diag_ctx_(diag_ctx) {}
+
+  Expr VisitExpr_(const GlobalVarNode* gvar) {
+    if (!mod_->ContainGlobalVar(gvar->name_hint)) {
+      diag_ctx_.Emit(Diagnostic::Error(gvar->span)
+                     << "undefined variable/global \"" << gvar->name_hint << "\"");
+      return GetRef<GlobalVar>(gvar);
+    }
+    return mod_->GetGlobalVar(gvar->name_hint);
+  }
+
+ private:
+  /*! \brief the IRModule used for GlobalVar lookup. */
+  IRModule mod_;
+  DiagnosticContext diag_ctx_;
+};
+
+namespace transform {
+
+Pass ResolveGlobals() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
+      [](Function f, IRModule m, PassContext pc) {
+        // TODO(@altanh): make sure pc always has diag_ctx?
+        GlobalVarResolver resolver(m, pc->diag_ctx.value());
+        return Downcast<Function>(resolver.VisitExpr(f));
+      };
+  return CreateFunctionPass(pass_func, 0, "ResolveGlobals", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.ResolveGlobals").set_body_typed(ResolveGlobals);
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -181,35 +181,33 @@ def test_call_dps_extern():
 
 
 def test_class_irmodule():
-    # FIXME(@altanh): see comment in test_parser.py
-    src = """@tvm.script.ir_module
-class MyModule:
-    @T.prim_func
-    def my_matmul(a: T.handle, b: T.handle, c: T.handle) -> None:
-        A = T.match_buffer(a, (128, 128))
-        B = T.match_buffer(b, (128, 128))
-        C = T.match_buffer(c, (128, 128))
+    @tvm.script.ir_module
+    class MyModule:
+        @T.prim_func
+        def my_matmul(a: T.handle, b: T.handle, c: T.handle) -> None:
+            A = T.match_buffer(a, (128, 128))
+            B = T.match_buffer(b, (128, 128))
+            C = T.match_buffer(c, (128, 128))
 
-        for i, j, k in T.grid(128, 128, 128):
-            with T.block():
-                vi, vj, vk = T.axis.remap("SSR", [i, j, k])
-                with T.init():
-                    C[vi, vj] = 0.0
-                C[vi, vj] += A[vi, vk] * B[vj, vk]
+            for i, j, k in T.grid(128, 128, 128):
+                with T.block():
+                    vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                    with T.init():
+                        C[vi, vj] = 0.0
+                    C[vi, vj] += A[vi, vk] * B[vj, vk]
 
-    @R.function
-    def f(x: Tensor[(n, n), _]) -> Tensor:
-        return g(x)
+        @R.function
+        def f(x: Tensor[(n, n), _]) -> Tensor:
+            return g(x)
 
-    @R.function
-    def g(y: Tensor[(n, n), _]) -> Tensor:
-        return relax.call_dps((n, n), my_matmul, (y, y))
+        @R.function
+        def g(y: Tensor[(n, n), _]) -> Tensor:
+            return relax.call_dps((n, n), my_matmul, (y, y))
 
-    @R.function
-    def h(x, y, z):
-        _ = my_matmul(x, y, z)
-        return z
-"""
+        @R.function
+        def h(x, y, z):
+            _ = my_matmul(x, y, z)
+            return z
 
-    my_module = tvm.script.relax.parser.from_source(src)
+    my_module = MyModule
     check_roundtrip(my_module)

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -361,32 +361,32 @@ def test_vm_compile_e2e():
     np.testing.assert_allclose(np.tile(inp.asnumpy(), (1, 2)), res.asnumpy())
 
 def test_vm_compile_e2e_func_param_with_shape():
-    src = """@tvm.script.ir_module
-class TestVMCompileE2E2:
-    @T.prim_func
-    def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
-        T.func_attr({"global_symbol": "tir_matmul"})
-        m = T.var("int32")
-        n = T.var("int32")
-        k = T.var("int32")
-        A = T.match_buffer(x, (m,n))
-        B = T.match_buffer(y, (n,k))
-        C = T.match_buffer(z, (m,k))
+    @tvm.script.ir_module
+    class TestVMCompileE2E2:
+        @T.prim_func
+        def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
+            T.func_attr({"global_symbol": "tir_matmul"})
+            m = T.var("int32")
+            n = T.var("int32")
+            k = T.var("int32")
+            A = T.match_buffer(x, (m,n))
+            B = T.match_buffer(y, (n,k))
+            C = T.match_buffer(z, (m,k))
 
-        for i, j, k in T.grid(m, k, n):
-            with T.block("matmul"):
-                vi, vj, vk = T.axis.remap("SSR", [i, j, k])
-                with T.init():
-                    C[vi, vj] = T.float32(0)
-                C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+            for i, j, k in T.grid(m, k, n):
+                with T.block("matmul"):
+                    vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                    with T.init():
+                        C[vi, vj] = T.float32(0)
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
 
-    @R.function
-    def func(x:Tensor[(m, n), "float32"], w:Tensor[(n, k), "float32"]) -> Tensor:
-        gv0 = R.call_dps((m, k), tir_matmul, (x, w))
-        return gv0
-"""
+        @R.function
+        def func(x:Tensor[(m, n), "float32"], w:Tensor[(n, k), "float32"]) -> Tensor:
+            gv0 = R.call_dps((m, k), tir_matmul, (x, w))
+            return gv0
 
-    mod = tvm.script.relax.parser.from_source(src)
+
+    mod = TestVMCompileE2E2
 
     target = tvm.target.Target("llvm")
     target_host = tvm.target.Target("llvm")


### PR DESCRIPTION
- added `ResolveGlobals` pass that ensures GlobalVars in IR refer to the correct ones in the IRModule, fixes #30
- modified the `ir_module` decorator to run `ResolveGlobals`
- fixed some ExprMutator bugs that were not caught by tests and added a more complex no-op test to catch the regression
- updated the printer to print checked type of vars if present (side note: it might make sense to move the `type_annotation` field to live in the binding node instead)