### PR TITLE
Visit shape in Visitor/Mutator

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -35,6 +35,7 @@ using Expr = RelayExpr;
 using ExprNode = RelayExprNode;
 using relay::Call;
 using relay::CallNode;
+using relay::Constant;
 using relay::ConstantNode;
 using relay::Id;
 using relay::If;

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -293,7 +293,7 @@ class ExprMutator : public ExprFunctor<Expr(const Expr&)> {
   }
 
   /*!
-   * \brief Create a new var with specified shape and type if it's original shape or type does not
+   * \brief Create a new var with specified shape and type if the original var's shape or type does not
    * match with the specified ones.
    * \param var The var to be updated.
    * \param shape The specified shape.

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -93,9 +93,7 @@ class VMShapeLowerMutator : public ExprMutator {
     builder_->BeginBindingBlock();
     builder_->Emit(VarBinding(
         shape_heap_, Call(ExternFunc("vm.builtin.alloc_shape_heap"), {ShapeExpr({heap_size_})})));
-    Array<Var> params;
     for (Var param : node->params) {
-      params.push_back(this->VisitVarDef(param));
       if (param->shape_.operator bool() && param->shape_.value().as<ShapeExprNode>()) {
         Var shape = builder_->Emit(Call(ExternFunc("vm.builtin.shape_of"), {param}), "sh");
         StoreShape(shape, Downcast<ShapeExpr>(param->shape_.value())->values);
@@ -118,7 +116,7 @@ class VMShapeLowerMutator : public ExprMutator {
     blocks.push_back(builder_->EndBlock());
     new_body = SeqExpr(blocks, new_body);
 
-    return Function(node->name, params, new_body, ret_type);
+    return Function(node->name, node->params, new_body, ret_type);
   }
 
   tir::PrimFunc CalculateShape(ShapeExpr s) {

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -53,9 +53,7 @@ def test_fma_rewrite():
     assert structural_equal(gv0.shape, relax.ShapeExpr([m, n]))
 
     # after rewrite
-    passes = [relax.transform.FMARewrite()]
-    seq = tvm.transform.Sequential(passes)
-    new_mod = seq(mod)
+    new_mod = relax.transform.FMARewrite()(mod)
     func = new_mod["main"]
     v1 = func.body.blocks[0].bindings[1].var
     s1 = func.body.blocks[0].bindings[1].value
@@ -87,14 +85,12 @@ def test_visit_shape():
 
     relax.analysis.post_order_visit(mod["foo"], fvisit)
     
-    # should have visited ShapeExpr 6 times
-    # the first three times visited are x.shape
-    # the last three times are the callnode's shape and gv0's shape
-    assert len(shape_expr) == 6
-    assert shape_expr[0] == shape_expr[1]
-    assert shape_expr[0] == shape_expr[2]
-    assert shape_expr[3] == shape_expr[4]
-    assert shape_expr[3] == shape_expr[5]
+    # should have visited ShapeExpr 3 times
+    # the first time being visited is x.shape
+    # the last two times are the call node's shape and gv0's shape
+    assert len(shape_expr) == 3
+    assert shape_expr[0] == mod["foo"].params[0].shape
+    assert shape_expr[1] == shape_expr[2]
 
 
 def test_to_non_dataflow():

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -69,6 +69,19 @@ def test_fma_rewrite():
     assert gv0 == v0
     assert type(func.body.blocks[0].bindings[1].var) == relax.Var
 
+def test_visit_shape():
+    @tvm.script.ir_module
+    # constant fold n to 4
+    class TestVisitShape:
+        @R.function
+        def foo(x: Tensor[(m, n), "float32"]):
+            with relax.dataflow():
+                lv0 = relax.add(x, x)
+                gv0 = relax.multiply(lv0, lv0)
+                relax.output(gv0)
+            return gv0
+    
+    mod = TestVisitShape
 
 def test_to_non_dataflow():
     @tvm.script.ir_module
@@ -312,6 +325,7 @@ def test_to_anf_no_op():
 
 if __name__ == "__main__":
     test_fma_rewrite()
+    test_visit_shape()
     test_to_non_dataflow()
     test_call_dps_rewrite()
     test_vm_memory_lower()


### PR DESCRIPTION
In the current implementation, we never visit the `shape_` filed of Expr in the Visitor/Mutator, which is incorrect since the `shape_` field could get changed during the rewriting, so we need to update it when it's changed. And without visiting the shape field, the shape lowering pass had to override `VisitVarDef` to collect symbolic integers that are defined.

This PR visits the shape field of `ConstantNode`, `CallNode`, `TupleNode`, and `VarNode`(define-site), and also avoid visiting `type_annotation` in the var use-site.