### PR TITLE
[TBD] [AST] Rename SeqExpr.body to SeqExpr.output.

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -332,24 +332,24 @@ class DataflowBlock : public BindingBlock {
 class SeqExprNode : public ExprNode {
  public:
   Array<BindingBlock> blocks;
-  Expr body;
+  Expr output;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("blocks", &blocks);
-    v->Visit("body", &body);
+    v->Visit("output", &output);
     v->Visit("shape_", &shape_);
     v->Visit("_checked_type_", &checked_type_);
     v->Visit("span", &span);
   }
 
   bool SEqualReduce(const SeqExprNode* other, SEqualReducer equal) const {
-    return equal(blocks, other->blocks) && equal(body, other->body) &&
+    return equal(blocks, other->blocks) && equal(output, other->output) &&
            equal(checked_type_, other->checked_type_) && equal(shape_, other->shape_);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
     hash_reduce(blocks);
-    hash_reduce(body);
+    hash_reduce(output);
     hash_reduce(shape_);
     hash_reduce(checked_type_);
   }
@@ -362,7 +362,7 @@ class SeqExprNode : public ExprNode {
 
 class SeqExpr : public Expr {
  public:
-  TVM_DLL explicit SeqExpr(Array<BindingBlock> blocks, Expr body, Span span = Span());
+  TVM_DLL explicit SeqExpr(Array<BindingBlock> blocks, Expr output, Span span = Span());
   TVM_DEFINE_OBJECT_REF_METHODS(SeqExpr, Expr, SeqExprNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(SeqExprNode);
 };

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -137,10 +137,10 @@ class DataflowBlock(BindingBlock):
 @tvm._ffi.register_object("relax.expr.SeqExpr")
 class SeqExpr(Expr):
     blocks: List[BindingBlock]
-    body: Expr
+    output: Expr
 
-    def __init__(self, blocks: List[BindingBlock], body: Expr, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.SeqExpr, blocks, body, span)
+    def __init__(self, blocks: List[BindingBlock], output: Expr, span: Span = None) -> None:
+        self.__init_handle_by_constructor__(_ffi_api.SeqExpr, blocks, output, span)
 
 
 @tvm._ffi.register_object("relax.expr.Function")

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -460,11 +460,11 @@ Doc RelaxScriptPrinter::PrintIfStmt(const relax::Var& var, const relay::If& ite)
   Doc doc;
   doc << "if " << Print(ite->cond) << ":" << Doc::NewLine(4);
   doc << Doc::Indent(4, Print(GetRef<SeqExpr>(true_branch)));
-  doc << Doc::Indent(4, Print(relax::VarBinding(var, true_branch->body)));
+  doc << Doc::Indent(4, Print(relax::VarBinding(var, true_branch->output)));
   doc << Doc::NewLine();
   doc << "else:" << Doc::NewLine(4);
   doc << Doc::Indent(4, Print(GetRef<SeqExpr>(false_branch)));
-  doc << Doc::Indent(4, Print(relax::VarBinding(var, false_branch->body)));
+  doc << Doc::Indent(4, Print(relax::VarBinding(var, false_branch->output)));
   return doc;
 }
 
@@ -488,7 +488,7 @@ Doc RelaxScriptPrinter::PrintFunctionDef(const Doc& name, const relax::Function&
 
   if (const relax::SeqExprNode* body = func->body.as<relax::SeqExprNode>()) {
     doc << Doc::Indent(4, Print(func->body));
-    doc << Doc::Indent(4, Doc::Text("return ") << Print(body->body)) << Doc::NewLine();
+    doc << Doc::Indent(4, Doc::Text("return ") << Print(body->output)) << Doc::NewLine();
   } else {
     doc << Doc::Indent(4, Doc::Text("return ") << Print(func->body)) << Doc::NewLine();
   }

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -88,7 +88,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
       }
     }
 
-    Instruction::Arg ret_reg = this->VisitExpr(op->body);
+    Instruction::Arg ret_reg = this->VisitExpr(op->output);
     return ret_reg;
   }
 

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -108,7 +108,7 @@ class VMShapeLowerMutator : public ExprMutator {
       blocks.push_back(builder_->EndBlock());
       blocks.insert(blocks.end(), seq->blocks.begin(), seq->blocks.end());
       builder_->BeginBindingBlock();
-      new_body = seq->body;
+      new_body = seq->output;
     }
 
     // FIXME(@yuchen): Implement vm.builtin.free_shape_heap.

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -108,8 +108,8 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     }
 
     builder_->BeginBindingBlock();
-    Expr new_body = this->VisitExpr(op->body);
-    unchanged &= new_body.same_as(op->body);
+    Expr new_output = this->VisitExpr(op->output);
+    unchanged &= new_output.same_as(op->output);
     BindingBlock prologue = builder_->EndBlock();
 
     // TODO(@altanh, @yuchen): normalize nested SeqExprs and BindingBlocks
@@ -122,7 +122,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     if (unchanged) {
       return GetRef<Expr>(op);
     }
-    return SeqExpr(new_blocks, new_body);
+    return SeqExpr(new_blocks, new_output);
   }
 
   Expr VisitExpr_(const IfNode* op) final {

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -158,17 +158,17 @@ TVM_REGISTER_GLOBAL("relax.DataflowBlock").set_body_typed([](Array<Binding> bind
 
 TVM_REGISTER_NODE_TYPE(SeqExprNode);
 
-SeqExpr::SeqExpr(Array<BindingBlock> blocks, Expr body, Span span) {
+SeqExpr::SeqExpr(Array<BindingBlock> blocks, Expr output, Span span) {
   ObjectPtr<SeqExprNode> n = make_object<SeqExprNode>();
   n->blocks = std::move(blocks);
-  n->body = std::move(body);
+  n->output = std::move(output);
   n->span = span;
   data_ = std::move(n);
 }
 
 TVM_REGISTER_GLOBAL("relax.SeqExpr")
-    .set_body_typed([](Array<BindingBlock> blocks, Expr body, Span span) {
-      return SeqExpr(blocks, body, span);
+    .set_body_typed([](Array<BindingBlock> blocks, Expr output, Span span) {
+      return SeqExpr(blocks, output, span);
     });
 
 TVM_REGISTER_NODE_TYPE(FunctionNode);

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -113,7 +113,7 @@ void ExprVisitor::VisitExpr_(const SeqExprNode* op) {
   for (BindingBlock block : op->blocks) {
     this->VisitBindingBlock(block);
   }
-  this->VisitExpr(op->body);
+  this->VisitExpr(op->output);
 }
 
 void ExprVisitor::VisitType(const Type& t) {}
@@ -383,17 +383,17 @@ Expr ExprMutator::VisitExpr_(const SeqExprNode* op) {
   }
 
   builder_->BeginBindingBlock();
-  Expr body = this->VisitExpr(op->body);
+  Expr output = this->VisitExpr(op->output);
   BindingBlock prologue = builder_->EndBlock();
   if (!prologue->bindings.empty()) {
     blocks.push_back(prologue);
     all_blocks_unchanged = false;
   }
 
-  if (all_blocks_unchanged && body.same_as(op->body)) {
+  if (all_blocks_unchanged && output.same_as(op->output)) {
     return GetRef<Expr>(op);
   } else {
-    return SeqExpr(blocks, body);
+    return SeqExpr(blocks, output);
   }
 }
 

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -73,7 +73,7 @@ def test_function_single_block():
     func = ib.get()["func"]
     assert func.params[0] == x
     assert func.params[1] == y
-    assert func.body.body == gv0
+    assert func.body.output == gv0
     assert gv0.shape[0] == m
     assert gv0.shape[1] == n
     assert gv0.checked_type.rank == 2
@@ -113,7 +113,7 @@ def test_function_multi_blocks():
     assert func.params[0] == x
     assert func.params[1] == y
     assert func.name.name_hint == "func"
-    assert func.body.body == gv2
+    assert func.body.output == gv2
     assert len(func.body.blocks) == 3
     assert len(func.body.blocks[0].bindings) == 2
     assert len(func.body.blocks[1].bindings) == 1
@@ -299,7 +299,7 @@ def test_emit_te():
     assert rx_func.params[1] == y
     assert rx_func.params[2] == z
     assert rx_func.name.name_hint == "rx_func"
-    assert rx_func.body.body == out
+    assert rx_func.body.output == out
     assert len(rx_func.body.blocks) == 1
     assert len(rx_func.body.blocks[0].bindings) == 1
     assert isinstance(rx_func.body.blocks[0].bindings[0].value, rx.Call)

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -126,7 +126,7 @@ def test_seq_expr() -> None:
     blocks = [rx.BindingBlock(bindings)]
     seqe = rx.SeqExpr(blocks, x)
     assert seqe.blocks[0] == blocks[0]
-    assert seqe.body == x
+    assert seqe.output == x
 
 
 def test_shape_expr() -> None:


### PR DESCRIPTION
I feel the name of `body` field in SeqExpr is strange since the actual body is the `blocks` field. I rename it to `output` now, but I am open for other names like `value`, which is might be better than `output`.