### PR TITLE
[TESTING] pytorch-like nn.Module API to build neural network

### DIFF
--- a/apps/relax_examples/mlp.py
+++ b/apps/relax_examples/mlp.py
@@ -47,9 +47,8 @@ if __name__ == "__main__":
     mod = build_mlp(data, weight)
 
     # build and create vm executor
-    target = tvm.target.Target("llvm")
-    target_host = tvm.target.Target("llvm")
-    ex, lib = relax.vm.build(mod, target, target_host)
+    target = tvm.target.Target("llvm", host="llvm")
+    ex, lib = relax.vm.build(mod, target)
     vm = relax.VirtualMachine(ex, tvm.cpu(), mod=lib)
 
     # run the mlp model on relax vm

--- a/apps/relax_examples/mlp.py
+++ b/apps/relax_examples/mlp.py
@@ -27,7 +27,7 @@ import numpy as np
 def build_mlp(data, weight):
     bb = relax.BlockBuilder()
 
-    with bb.function([data, weight], "mlp"):
+    with bb.function("mlp", [data, weight]):
         gv0 = bb.emit_te(tvm.contrib.cblas.matmul, data, weight, transa=False, transb=False)
         gv1 = bb.emit_te(topi.nn.relu, gv0)
         bb.emit_func_output(gv1)

--- a/apps/relax_examples/nn_module.py
+++ b/apps/relax_examples/nn_module.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     output_size = 10
 
     # build a three linear-layer neural network for a classification task
-    with builder.function(name="main"):
+    with builder.function("main"):
         model = nn.Sequential(
             nn.Linear(input_size, hidden_sizes[0]),
             nn.ReLU(),

--- a/apps/relax_examples/nn_module.py
+++ b/apps/relax_examples/nn_module.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Example code on creating, compiling, and running a neural network with pytorch-like API
+
+
+import tvm
+from tvm.relay import Call
+from tvm import relax, tir
+from tvm.relax.testing import nn
+from tvm.script import relax as R
+import numpy as np
+
+
+if __name__ == "__main__":
+    builder = nn.Builder()
+    n = tir.Var("n", "int64")
+
+    input_size = n
+    hidden_sizes = [128, 32]
+    output_size = 10
+
+    # build a three linear-layer neural network for a classification task
+    with builder.func("main"):
+        model = nn.Sequential(
+            nn.Linear(input_size, hidden_sizes[0]),
+            nn.ReLU(),
+            nn.Linear(hidden_sizes[0], hidden_sizes[1]),
+            nn.ReLU(),
+            nn.Linear(hidden_sizes[1], output_size),
+            nn.LogSoftmax(),
+        )
+        data = nn.Placeholder((n, 1), name="data")
+        result = model(data)
+        builder.finalize([data] + model.parameters(), result)
+
+    # get and print the IRmodule being built
+    mod = builder.get()
+    print(R.parser.astext(mod))
+
+    # build and create vm executor
+    target = tvm.target.Target("llvm")
+    target_host = tvm.target.Target("llvm")
+    ex, lib = relax.vm.build(mod, target, target_host)
+    vm = relax.VirtualMachine(ex, tvm.cpu(), mod=lib)
+
+    # init parameters
+    # TODO(@yuchen): implment init_params() to initialize parameters
+    n = 784
+    linear_weight0 = tvm.nd.array(np.random.rand(n, 128).astype(np.float32))
+    linear_bias0 = tvm.nd.array(np.random.rand(128,).astype(np.float32))
+    linear_weight1 = tvm.nd.array(np.random.rand(hidden_sizes[0], hidden_sizes[1]).astype(np.float32))
+    linear_bias1 = tvm.nd.array(np.random.rand(hidden_sizes[1],).astype(np.float32))
+    linear_weight2 = tvm.nd.array(np.random.rand(hidden_sizes[1], output_size).astype(np.float32))
+    linear_bias2 = tvm.nd.array(np.random.rand(output_size,).astype(np.float32))
+    params = [linear_weight0, linear_bias0, linear_weight1, linear_bias1, linear_weight2, linear_bias2]
+
+    data = tvm.nd.array(np.random.rand(n, 1).astype(np.float32))
+    res = vm["main"](data, *params)
+    print(res)

--- a/apps/relax_examples/nn_module.py
+++ b/apps/relax_examples/nn_module.py
@@ -67,10 +67,3 @@ if __name__ == "__main__":
     data = tvm.nd.array(np.random.rand(3, input_size).astype(np.float32))
     res = vm["main"](data, *params)
     print(res)
-
-    with builder.function(name="hmm"):
-        linear_layer = nn.Linear(20, 20)
-        data = nn.Placeholder((10,), name="data")
-        output = model(data)
-        params = [data] + model.parameters()
-        builder.emit_func_output(output, params=params)

--- a/apps/relax_examples/nn_module.py
+++ b/apps/relax_examples/nn_module.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
     linear_bias2 = tvm.nd.array(np.random.rand(output_size,).astype(np.float32))
     params = [linear_weight0, linear_bias0, linear_weight1, linear_bias1, linear_weight2, linear_bias2]
 
+    # run the model on relax vm
     data = tvm.nd.array(np.random.rand(n, 1).astype(np.float32))
     res = vm["main"](data, *params)
     print(res)

--- a/apps/relax_examples/nn_module.py
+++ b/apps/relax_examples/nn_module.py
@@ -55,9 +55,8 @@ if __name__ == "__main__":
     print(R.parser.astext(mod))
 
     # build the IRModule and create relax vm
-    target = tvm.target.Target("llvm")
-    target_host = tvm.target.Target("llvm")
-    ex, lib = relax.vm.build(mod, target, target_host)
+    target = tvm.target.Target("llvm", host="llvm")
+    ex, lib = relax.vm.build(mod, target)
     vm = relax.VirtualMachine(ex, tvm.cpu(), mod=lib)
 
     # init parameters

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -106,6 +106,9 @@ class BlockBuilder(Object):
     def _end_block(self) -> BindingBlock:
         return _ffi_api.BlockBuilderEndBlock(self)
 
+    def _get_unique_name(self, name_hint: str) -> str:
+        return _ffi_api.BlockBuilderGetUniqueName(self, name_hint)
+
     def _convert_te_arg(self,
         te_args: Any
     ) -> typing.Tuple[Any, List[tvm.te.Tensor]]:

--- a/python/tvm/relax/testing/nn.py
+++ b/python/tvm/relax/testing/nn.py
@@ -1,0 +1,184 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+from typing import List, Optional, Union, Dict, Any, Callable
+from tvm.relay import Call
+from tvm import relax, topi
+
+
+class FunctionScope(object):
+    """Auxiliary scope for relax function"""
+
+    def __init__(self):
+        self._ib = current_builder()
+
+    def __enter__(self):
+        self._ib._begin_binding_block()
+
+    def __exit__(self, ptype, value, trace):
+        self._ib._blocks = []
+
+
+class Builder:
+    """A builder to build Relax IR with a pytorch-like nn.Module API."""
+
+    current = None
+
+    def __init__(self):
+        Builder.current = relax.BlockBuilder()
+
+    def func(self, name: str) -> FunctionScope:
+        Builder.current._func_name = name
+        return FunctionScope()
+
+    def finalize(self, args, result):
+        if Builder.current:
+            block = Builder.current._end_block()
+            if len(block.bindings) > 0:
+                Builder.current._blocks.append(block)
+            seqe = relax.SeqExpr(Builder.current._blocks, result)
+            gvar = relax.GlobalVar(Builder.current._func_name)
+            func = relax.Function(args, seqe, relax.DynTensorType(-1, "float32"), gvar)
+            gvar = relax.GlobalVar(Builder.current._func_name)
+            Builder.current._context_mod[gvar] = func
+            return func
+        else:
+            raise ValueError("block builder has not been initialized")
+
+    def get(self):
+        return Builder.current.get()
+
+
+def current_builder():
+    return Builder.current
+
+
+def emit_te(func: Callable, *args: Any, **kwargs: Any) -> relax.Var:
+    return current_builder().emit_te(func, *args, **kwargs)
+
+
+class Placeholder(relax.Var):
+    """A placeholder variable that can represent model input."""
+
+    def __init__(self, shape, dtype="float32", name="data"):
+        if isinstance(shape, (list, tuple)):
+            rank = len(shape)
+        type_anno = relax.DynTensorType(rank, dtype)
+        super().__init__(current_builder()._get_unique_name(name), shape, type_anno)
+
+
+class Parameter(relax.Var):
+    """A special kind of relax Var that represents model parameter(weight)."""
+
+    def __init__(self, shape, dtype="float32", name="param"):
+        if isinstance(shape, (list, tuple)):
+            rank = len(shape)
+        # TODO: handle other cases
+        type_anno = relax.DynTensorType(rank, dtype)
+        super().__init__(current_builder()._get_unique_name(name), shape, type_anno)
+
+
+class Module:
+    """Base class for all model modules.
+
+    A neural network or a layer can subclass this class.
+    """
+
+    def parameters(self) -> List[Parameter]:
+        """Return the list of parameters in the module."""
+        return _unpack_params(self.__dict__)
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+
+def _unpack_params(value: object) -> List[relax.Var]:
+    if isinstance(value, Parameter):
+        return [value]
+    elif isinstance(value, Module):
+        return value.parameters()
+    elif isinstance(value, dict):
+        params = []
+        for k, v in value.items():
+            params += _unpack_params(v)
+        return params
+    elif isinstance(value, (list, tuple)):
+        params = []
+        for v in value:
+            params += _unpack_params(v)
+        return params
+    else:
+        return []
+
+
+class Sequential(Module):
+    """A sequential container that concatenates modules in it.
+
+    Example
+    -------
+
+    .. code-block:: python
+
+    model = nn.Sequential(
+                nn.Conv2d(1, 20, 5),
+                nn.ReLU(),
+                nn.Conv2d(20, 64, 5),
+                nn.ReLU()
+            )
+    """
+
+    def __init__(self, *modules: Module):
+        self.modules = modules
+
+    def forward(self, input: relax.Var) -> relax.Var:
+        for module in self.modules:
+            input = module(input)
+        return input
+
+
+class ReLU(Module):
+    """Applies the rectified linear unit activation function on the input."""
+
+    def forward(self, input: relax.Var) -> relax.Var:
+        return emit_te(topi.nn.relu, input)
+
+
+class LogSoftmax(Module):
+    """Applies log softmax activation function on the input."""
+
+    def forward(self, input: relax.Var) -> relax.Var:
+        return emit_te(topi.nn.log_softmax, input)
+
+
+class Linear(Module):
+    """Applies a linear transformation to the input data: :math:`y = xA + b`."""
+
+    def __init__(self, in_features, out_features, bias=True):
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = Parameter((in_features, out_features), name="linear_weight")
+        if bias:
+            self.bias = Parameter((out_features,), name="linear_bias")
+        else:
+            self.bias = None
+
+    def forward(self, input: relax.Var) -> relax.Var:
+        y = emit_te(topi.matmul, input, self.weight)
+        if self.bias is not None:
+            y = emit_te(topi.add, y, self.bias)
+        return y

--- a/python/tvm/relax/testing/nn.py
+++ b/python/tvm/relax/testing/nn.py
@@ -21,14 +21,8 @@ from tvm import relax, topi, tir
 import numpy as np
 
 
-def current_builder():
-    if relax.BlockBuilder.current is None:
-        raise ValueError("BlockBuilder.current is not initialized.")
-    return relax.BlockBuilder.current
-
-
 def emit_te(func: Callable, *args: Any, **kwargs: Any) -> relax.Var:
-    return current_builder().emit_te(func, *args, **kwargs)
+    return relax.BlockBuilder.current().emit_te(func, *args, **kwargs)
 
 
 class Placeholder(relax.Var):
@@ -36,10 +30,10 @@ class Placeholder(relax.Var):
 
     def __init__(self, shape, dtype="float32", name="data"):
         if not isinstance(shape, (list, tuple)):
-            raise ValueError("the shape of Placeholder must be a list or a tuple")
+            raise TypeError("the shape of Placeholder is expected to be a list or a tuple")
         rank = len(shape)
         type_anno = relax.DynTensorType(rank, dtype)
-        super().__init__(current_builder().get_unique_name(name), shape, type_anno)
+        super().__init__(relax.BlockBuilder.current().get_unique_name(name), shape, type_anno)
 
 
 class Parameter(relax.Var):
@@ -47,10 +41,10 @@ class Parameter(relax.Var):
 
     def __init__(self, shape, dtype="float32", name="param"):
         if not isinstance(shape, (list, tuple)):
-            raise ValueError("the shape of Parameter must be a list or a tuple")
+            raise TypeError("the shape of Parameter is expected to be a list or a tuple")
         rank = len(shape)
         type_anno = relax.DynTensorType(rank, dtype)
-        super().__init__(current_builder().get_unique_name(name), shape, type_anno)
+        super().__init__(relax.BlockBuilder.current().get_unique_name(name), shape, type_anno)
 
 
 class Module:
@@ -124,10 +118,10 @@ def init_params(mod: tvm.IRModule) -> List[tvm.nd.array]:
                 if isinstance(i, tir.IntImm):
                     shape.append(int(i))
                 else:
-                    raise ValueError("cannot initialize for unknown-shape parameters.")
+                    raise TypeError("cannot initialize for unknown-shape parameters.")
             params.append(tvm.nd.array(np.random.rand(*shape).astype(np.float32)))
         else:
-            raise ValueError("cannot initialize for unknown-shape parameters.")
+            raise TypeError("cannot initialize for unknown-shape parameters.")
     return params
 
 

--- a/python/tvm/relax/testing/nn.py
+++ b/python/tvm/relax/testing/nn.py
@@ -88,7 +88,7 @@ class Parameter(relax.Var):
     def __init__(self, shape, dtype="float32", name="param"):
         if isinstance(shape, (list, tuple)):
             rank = len(shape)
-        # TODO: handle other cases
+        # TODO(@yuchen): handle other cases
         type_anno = relax.DynTensorType(rank, dtype)
         super().__init__(current_builder()._get_unique_name(name), shape, type_anno)
 
@@ -131,21 +131,20 @@ class Sequential(Module):
 
     Example
     -------
-
     .. code-block:: python
 
-    model = nn.Sequential(
-                nn.Conv2d(1, 20, 5),
-                nn.ReLU(),
-                nn.Conv2d(20, 64, 5),
-                nn.ReLU()
-            )
+        model = nn.Sequential(
+                    nn.Conv2d(1, 20, 5),
+                    nn.ReLU(),
+                    nn.Conv2d(20, 64, 5),
+                    nn.ReLU()
+                )
     """
 
     def __init__(self, *modules: Module):
         self.modules = modules
 
-    def forward(self, input: relax.Var) -> relax.Var:
+    def forward(self, input: relax.Expr) -> relax.Var:
         for module in self.modules:
             input = module(input)
         return input
@@ -154,14 +153,14 @@ class Sequential(Module):
 class ReLU(Module):
     """Applies the rectified linear unit activation function on the input."""
 
-    def forward(self, input: relax.Var) -> relax.Var:
+    def forward(self, input: relax.Expr) -> relax.Var:
         return emit_te(topi.nn.relu, input)
 
 
 class LogSoftmax(Module):
     """Applies log softmax activation function on the input."""
 
-    def forward(self, input: relax.Var) -> relax.Var:
+    def forward(self, input: relax.Expr) -> relax.Var:
         return emit_te(topi.nn.log_softmax, input)
 
 
@@ -177,7 +176,7 @@ class Linear(Module):
         else:
             self.bias = None
 
-    def forward(self, input: relax.Var) -> relax.Var:
+    def forward(self, input: relax.Expr) -> relax.Var:
         y = emit_te(topi.matmul, input, self.weight)
         if self.bias is not None:
             y = emit_te(topi.add, y, self.bias)

--- a/python/tvm/relax/testing/nn.py
+++ b/python/tvm/relax/testing/nn.py
@@ -102,7 +102,10 @@ def _unpack_params(value: object) -> List[relax.Var]:
         for v in value:
             params += _unpack_params(v)
         return params
-    return []
+    elif isinstance(value, (int, float, str)):
+        return []
+    else:
+        raise TypeError("not supported type when unpacking parameters: {}".format(type(value)))
 
 
 def init_params(mod: tvm.IRModule) -> List[tvm.nd.array]:
@@ -110,7 +113,7 @@ def init_params(mod: tvm.IRModule) -> List[tvm.nd.array]:
     shape_dict = {v.name_hint: v.shape_ for v in mod["main"].params}
     params = []
     for k, v in shape_dict.items():
-        if k == "data":
+        if k.startswith("data"):
             continue
         if isinstance(v, relax.ShapeExpr):
             shape = []

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -202,5 +202,9 @@ def _split_tir_relax(mod: tvm.IRModule) -> Tuple[tvm.IRModule, tvm.IRModule]:
         elif isinstance(mod[gv], relax.Function):
             rx_mod[gv] = mod[gv]
         else:
-            raise ValueError("An IRModule should contain relax function and/or TIR primfunc.")
+            raise TypeError(
+                "IRModule is expected to contain PrimFunc or Function, but gets {}".format(
+                    type(mod[gv])
+                )
+            )
     return rx_mod, tir_mod

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -47,7 +47,7 @@ def test_post_order_visit():
     x = rx.Var("x", [m, n], dtype0)
     y = rx.Var("y", [n], dtype1)
     ib = rx.BlockBuilder()
-    with ib.function([x, y], "func"):
+    with ib.function("func", [x, y]):
         with ib.dataflow() as df:
             lv0 = ib.emit(rx.op.add(x, y))
             lv1 = ib.emit(rx.op.multiply(lv0, y))

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -35,7 +35,7 @@ def test_fma_rewrite():
     x = relax.Var("x", [m, n], dtype0)
     y = relax.Var("y", [m, n], dtype1)
     ib = relax.BlockBuilder()
-    with ib.function([x, y], "func"):
+    with ib.function("func", [x, y]):
         with ib.dataflow() as df:
             lv0 = ib.emit(relax.op.multiply(x, y))
             gv0 = ib.emit_output(relax.op.add(lv0, y))

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -402,7 +402,7 @@ def test_vm_emit_te_extern():
     x = relax.Var("x", [n, m], type_anno)
     y = relax.Var("y", [m, n], type_anno)
     
-    with bb.function([x, y], "rx_cblas_matmul"):
+    with bb.function("rx_cblas_matmul", [x, y]):
         out = bb.emit_te(tvm.contrib.cblas.matmul, x, y, transa=False, transb=False)
         bb.emit_func_output(out)
     
@@ -430,7 +430,7 @@ def test_vm_emit_te_concat():
         C = te.compute((n + m), lambda i: tvm.tir.if_then_else(i < n, A[i], B[i-n]))
         return C
 
-    with bb.function([x, y], "rx_func"):
+    with bb.function("rx_func", [x, y]):
         x1 = bb.emit_te(te_func, x, y)
         bb.emit_func_output(x1)
 
@@ -456,7 +456,7 @@ def test_vm_emit_te_floor_symbolic_shape():
         C = te.compute((tir.floordiv(n, 2),), lambda i: A[i] + 1)
         return C
 
-    with bb.function([x], "rx_func"):
+    with bb.function("rx_func", [x]):
         x1 = bb.emit_te(te_func, x)
         bb.emit_func_output(x1)
 
@@ -487,7 +487,7 @@ def test_vm_relax_symbolic_shape():
         C = te.compute((n, ), lambda i: A[i] + B[i // 2])
         return C
 
-    with bb.function([x, y], "rx_func"):
+    with bb.function("rx_func", [x, y]):
         x1 = bb.emit_te(te_func, x, y)
         bb.emit_func_output(x1)
 

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -35,24 +35,24 @@ def move(src):
 
 @tvm.register_func("test.vm.add")
 def add(a, b):
-    ret = a.asnumpy() + b.asnumpy()
+    ret = a.numpy() + b.numpy()
     return tvm.nd.array(ret)
 
 
 @tvm.register_func("test.vm.mul")
 def mul(a, b):
-    ret = a.asnumpy() * b.asnumpy()
+    ret = a.numpy() * b.numpy()
     return tvm.nd.array(ret)
 
 
 @tvm.register_func("test.vm.identity")
 def identity_packed(a, b):
-    b[:] = tvm.nd.array(a.asnumpy())
+    b[:] = tvm.nd.array(a.numpy())
 
 
 @tvm.register_func("test.vm.tile")
 def tile_packed(a, b):
-    b[:] = tvm.nd.array(np.tile(a.asnumpy(), (1, 2)))
+    b[:] = tvm.nd.array(np.tile(a.numpy(), (1, 2)))
 
 
 def test_vm_execute():
@@ -73,7 +73,7 @@ def test_vm_execute():
         )
     )
     add_res = vm["func0"](a, b)
-    np.testing.assert_allclose(add_res.asnumpy(), a.asnumpy() + b.asnumpy())
+    np.testing.assert_allclose(add_res.numpy(), a.numpy() + b.numpy())
 
 
 def test_vm_multiple_func():
@@ -98,8 +98,8 @@ def test_vm_multiple_func():
     )
     mul_res = vm["func1"](a, b)
     add_res = vm["func0"](a, b)
-    np.testing.assert_allclose(add_res.asnumpy(), a.asnumpy() + b.asnumpy())
-    np.testing.assert_allclose(mul_res.asnumpy(), a.asnumpy() * b.asnumpy())
+    np.testing.assert_allclose(add_res.numpy(), a.numpy() + b.numpy())
+    np.testing.assert_allclose(mul_res.numpy(), a.numpy() * b.numpy())
 
 
 def test_vm_serialize():
@@ -138,7 +138,7 @@ def test_vm_constant_serialize():
     assert exec0.astext() == exec1.astext()
     vm = relax.VirtualMachine(exec0, tvm.cpu())
     res = vm["main"](inp)
-    np.testing.assert_allclose(inp.asnumpy(), res.asnumpy())
+    np.testing.assert_allclose(inp.numpy(), res.numpy())
     os.remove("exec.tmp")
 
 
@@ -244,7 +244,7 @@ def test_vm_compile_stage0():
     inp2 = tvm.nd.array(np.random.rand(3,4).astype(np.float32))
     vm = relax.VirtualMachine(ex, tvm.cpu(), mod=lib)
     vm["foo"](inp1, inp2)
-    np.testing.assert_allclose(inp2.asnumpy(), inp1.asnumpy())
+    np.testing.assert_allclose(inp2.numpy(), inp1.numpy())
 
 
 def test_vm_compile_stage1():
@@ -331,7 +331,7 @@ def test_vm_compile_stage3():
     shape = (32, 16)
     inp = tvm.nd.array(np.random.rand(*shape).astype(np.float32))
     res = vm["foo"](inp)
-    np.testing.assert_allclose(inp.asnumpy(), res.asnumpy())
+    np.testing.assert_allclose(inp.numpy(), res.numpy())
 
 
 def test_vm_compile_e2e():
@@ -354,7 +354,7 @@ def test_vm_compile_e2e():
     shape = (32, 16)
     inp = tvm.nd.array(np.random.rand(*shape).astype(np.float32))
     res = vm["foo"](inp)
-    np.testing.assert_allclose(np.tile(inp.asnumpy(), (1, 2)), res.asnumpy())
+    np.testing.assert_allclose(np.tile(inp.numpy(), (1, 2)), res.numpy())
 
 def test_vm_compile_e2e_func_param_with_shape():
     @tvm.script.ir_module
@@ -391,8 +391,8 @@ def test_vm_compile_e2e_func_param_with_shape():
     data = tvm.nd.array(np.random.rand(32, 16).astype(np.float32))
     weight = tvm.nd.array(np.random.rand(16, 32).astype(np.float32))
     res = vm["func"](data, weight)
-    expected = np.dot(data.asnumpy(), weight.asnumpy())
-    np.testing.assert_allclose(expected, res.asnumpy(), rtol=1e-4, atol=1e-4)
+    expected = np.dot(data.numpy(), weight.numpy())
+    np.testing.assert_allclose(expected, res.numpy(), rtol=1e-4, atol=1e-4)
 
 
 def test_vm_emit_te_extern():
@@ -415,8 +415,8 @@ def test_vm_emit_te_extern():
     data = tvm.nd.array(np.random.rand(16, 32).astype(np.float32))
     weight = tvm.nd.array(np.random.rand(32, 16).astype(np.float32))
     res = vm["rx_cblas_matmul"](data, weight)
-    expected = np.dot(data.asnumpy(), weight.asnumpy())
-    np.testing.assert_allclose(expected, res.asnumpy(), rtol=1e-4, atol=1e-4)
+    expected = np.dot(data.numpy(), weight.numpy())
+    np.testing.assert_allclose(expected, res.numpy(), rtol=1e-4, atol=1e-4)
 
 def test_vm_emit_te_concat():
     # concatenate of two vectors of size (n,) and (m,)
@@ -444,7 +444,7 @@ def test_vm_emit_te_concat():
     inp2 = tvm.nd.array(np.random.rand(2, ).astype(np.float32))
     res = vm["rx_func"](inp, inp2)
 
-    np.testing.assert_allclose(res.asnumpy(), np.append(inp.asnumpy(), inp2.asnumpy()))
+    np.testing.assert_allclose(res.numpy(), np.append(inp.numpy(), inp2.numpy()))
 
 def test_vm_emit_te_floor_symbolic_shape():
     bb = relax.BlockBuilder()
@@ -472,9 +472,9 @@ def test_vm_emit_te_floor_symbolic_shape():
 
     def expected_output():
         output_shape = (shape[0] // 2, )
-        return inp.asnumpy()[:output_shape[0]] + 1
+        return inp.numpy()[:output_shape[0]] + 1
 
-    np.testing.assert_allclose(res.asnumpy(), expected_output())
+    np.testing.assert_allclose(res.numpy(), expected_output())
 
 def test_vm_relax_symbolic_shape():
     bb = relax.BlockBuilder()
@@ -504,9 +504,9 @@ def test_vm_relax_symbolic_shape():
     res = vm["rx_func"](inp, inp2)
 
     def expected_output():
-        return inp.asnumpy() + np.repeat(inp2.asnumpy(), 2)[:5]
+        return inp.numpy() + np.repeat(inp2.numpy(), 2)[:5]
 
-    np.testing.assert_allclose(res.asnumpy(), expected_output())
+    np.testing.assert_allclose(res.numpy(), expected_output())
 
 if __name__ == "__main__":
     test_vm_execute()


### PR DESCRIPTION
Implements a pytorch-like `nn.Module` API to construct relax workloads for quick testing and benchmarking. A neural network or a layer can subclass `nn.Module` and implement `forward` function to define the forward computation using `emit_te`.

Code example:
```python
# build a three linear-layer neural network for a classification task
with builder.function("main"):
  model = nn.Sequential(
    nn.Linear(input_size, hidden_sizes[0]),
    nn.ReLU(),
    nn.Linear(hidden_sizes[0], hidden_sizes[1]),
    nn.ReLU(),
    nn.Linear(hidden_sizes[1], output_size),
    nn.LogSoftmax(),
  )
  data = nn.Placeholder((n, input_size), name="data")
  output = model(data)
  params = [data] + model.parameters()
  builder.emit_func_output(output, params=params) 

# get and print the IRmodule being built
mod = builder.get()
```