### PR TITLE
[EmitTE] multi-output semantics for call_tir, Tuples

### DIFF
--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -41,6 +41,7 @@ DataflowBlock = expr.DataflowBlock
 SeqExpr = expr.SeqExpr
 ShapeExpr = expr.ShapeExpr
 Tuple = expr.Tuple
+TupleGetItem = expr.TupleGetItem
 Function = expr.Function
 ExternFunc = expr.ExternFunc
 Call = expr.Call

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -389,6 +389,8 @@ class BlockBuilder(Object):
         te_args = te_arg_list + te_kwarg_list
 
         te_out = func(*new_args, **new_kwargs)
+        assert (isinstance(te_out, tvm.te.tensor.Tensor) or \
+            (isinstance(te_out, (tuple, list) and all(isinstance(t, tvm.te.tensor.Tensor) for t in te_out)))), "only support te.tensor or tuple/list of te.tensor as function output"
         outs = [te_out] if isinstance(te_out, tvm.te.tensor.Tensor) else list(te_out)
         unbound_tir_vars = self._get_unbound_tir_vars(te_args + outs)
 

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -388,25 +388,24 @@ class BlockBuilder(Object):
 
         te_args = te_arg_list + te_kwarg_list
 
-        # TODO(hypercubestart, ziheng) handle multiple output case
         te_out = func(*new_args, **new_kwargs)
-        assert isinstance(te_out, tvm.te.tensor.Tensor), "only support te tensor as function output"
+        outs = [te_out] if isinstance(te_out, tvm.te.tensor.Tensor) else list(te_out)
+        unbound_tir_vars = self._get_unbound_tir_vars(te_args + outs)
 
-        unbound_tir_vars = self._get_unbound_tir_vars(te_args + [te_out])
-
-        inputs = [*te_args, te_out]
+        inputs = [*te_args] + outs
         tir_func = tvm.te.create_prim_func(inputs, unbound_tir_vars)
         func_name = self.get_unique_name(func.__name__)
         tir_func = tir_func.with_attr("global_symbol", func_name)
         gvar = GlobalVar(func_name)
         self._context_mod[gvar] = tir_func
 
-        call_args = [x.op.value for x in inputs[:-1]]
+        call_args = [x.op.value for x in te_args]
+        output_shape = outs[0].shape if isinstance(te_out, tvm.te.tensor.Tensor) else Tuple([ShapeExpr(x.shape) for x in outs])
         # add arguments for extra parameters from unbound var
         if (len(unbound_tir_vars) > 0):
-            call = call_tir(inputs[-1].shape, gvar, call_args, tir_vars=ShapeExpr(unbound_tir_vars))
+            call = call_tir(output_shape, gvar, call_args, tir_vars=ShapeExpr(unbound_tir_vars))
         else:
-            call = call_tir(inputs[-1].shape, gvar, call_args)
+            call = call_tir(output_shape, gvar, call_args)
         return _ffi_api.BlockBuilderEmit(self, call)
 
 
@@ -488,6 +487,7 @@ class BlockBuilder(Object):
         if len(block.bindings) > 0:
             self._blocks.append(block)
         seqe = rx.SeqExpr(self._blocks, self._func_ret)
+        # TODO: rx function can return Tuple as well, need to infer ret type
         func = rx.Function(
             self._func_params, seqe, rx.DynTensorType(-1), rx.GlobalVar(self._func_name)
         )

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -20,7 +20,7 @@ from typing import Union, List
 
 
 def call_tir(
-    shape: Union[ShapeExpr, List[int]], func: Expr, args: Union[Tuple, List[Expr]],
+    shape: Union[Tuple, ShapeExpr, List[int]], func: Expr, args: Union[Tuple, List[Expr]],
     tir_vars: ShapeExpr = None
 ) -> Call:
     """
@@ -28,8 +28,8 @@ def call_tir(
 
     Parameters
     ----------
-    shape: ShapeExpr
-        The output shape.
+    shape: Tuple[ShapeExpr] or ShapeExpr
+        The output shape. Tuple[ShapeExpr] if multiple outputs, ShapeExpr is single output.
 
     func : ExternFunc or PrimFunc
         The destination-passing-style function.

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -70,7 +70,18 @@ Expr MakeCallTIR(Expr shape, Expr func, Tuple args, Optional<Expr> packed_ints) 
     call = Call(op, {shape, func, args, packed_ints.value()}, {}, {});
   }
   call->shape_ = shape;
-  call->checked_type_ = args->fields[0]->checked_type_;
+  if (shape->IsInstance<TupleNode>()) {
+    // multiple output tensors
+    Array<Type> types;
+    for (size_t i = 0; i < Downcast<Tuple>(shape)->fields.size(); i++) {
+      // TODO: fix checked_type_ inference
+      types.push_back(args->fields[0]->checked_type_);
+    }
+    call->checked_type_ = TupleType(types);
+  } else {
+    // TODO: fix checked_type_ inference
+    call->checked_type_ = args->fields[0]->checked_type_;
+  }
   return call;
 }
 

--- a/src/relax/vm/builtin.cc
+++ b/src/relax/vm/builtin.cc
@@ -23,6 +23,7 @@
 #include <tvm/relax/vm/bytecode.h>
 #include <tvm/relax/vm/memory_manager.h>
 #include <tvm/relax/vm/vm.h>
+#include <tvm/runtime/container/adt.h>
 #include <tvm/runtime/data_type.h>
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/logging.h>
@@ -138,6 +139,14 @@ TVM_REGISTER_GLOBAL("vm.call_tir_dyn").set_body([](TVMArgs args, TVMRetValue* rv
 
   TVMArgs func_args(values.data(), tcodes.data(), values.size());
   func.CallPacked(func_args, rv);
+});
+
+TVM_REGISTER_GLOBAL("vm.runtime.TupleGetItem")
+.set_body_typed([](runtime::ADT adt, ShapeTuple index) {
+  ICHECK_EQ(index.size(), 1);
+  int idx = index[0];
+  ICHECK_LT(idx, adt.size());
+  return adt[idx];
 });
 
 }  // namespace relax_vm

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -346,9 +346,8 @@ def test_emit_te_multiple_output():
     x = rx.Var("x", [n, m], type_anno)
 
     def te_func(A):
-        B = te.compute((n, m), lambda i, j: A[i, j] + 1)
-        C = te.compute((n, m), lambda i, j: A[i, j] + 2)
-        return (B, C)
+        B0, B1 = te.compute((n, m), lambda i, j: (A[i, j] + 1, A[i, j] * 2), name="B")
+        return (B0, B1)
 
     with bb.function("rx_func", [x]):
         y = bb.emit_te(te_func, x)

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -23,7 +23,7 @@ from tvm import relay
 from tvm import relax as rx
 
 from tvm.ir.base import assert_structural_equal
-from tvm.relax import ExternFunc, op
+from tvm.relax import ExternFunc, ShapeExpr, op
 
 
 @tvm.register_func("test.blockbuilder.nop")
@@ -339,6 +339,33 @@ def test_emit_te_multiple():
     assert func.body.blocks[0].bindings[0].value.args[1].name_hint == "te_func"
     assert func.body.blocks[0].bindings[1].value.args[1].name_hint == "te_func1"
 
+def test_emit_te_multiple_output():
+    bb = rx.BlockBuilder()
+    n, m = tir.Var("n", "int64"), tir.Var("m", "int64")
+    type_anno = rx.DynTensorType(2, "float32")
+    x = rx.Var("x", [n, m], type_anno)
+
+    def te_func(A):
+        B = te.compute((n, m), lambda i, j: A[i, j] + 1)
+        C = te.compute((n, m), lambda i, j: A[i, j] + 2)
+        return (B, C)
+
+    with bb.function("rx_func", [x]):
+        y = bb.emit_te(te_func, x)
+        z = relay.TupleGetItem(y, 0)
+        bb.emit_func_output([y, z])
+
+    rx_func = bb.get()["rx_func"]
+
+    # check call tir output shape is a Tuple of ShapeExpr
+    assert rx_func.params[0] == x
+    assert rx_func.name.name_hint == "rx_func"
+    assert rx_func.body.blocks[0].bindings[0].value.op == relay.op.get("relax.call_tir")
+    assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "te_func"
+    assert isinstance(rx_func.body.blocks[0].bindings[0].value.args[0], relay.Tuple)
+    assert len(rx_func.body.blocks[0].bindings[0].value.args[0]) == 2
+    assert isinstance(rx_func.body.blocks[0].bindings[0].value.args[0][0], rx.ShapeExpr)
+    assert isinstance(rx_func.body.blocks[0].bindings[0].value.args[0][1], rx.ShapeExpr)
 
 def test_emit_te_extern():
     bb = rx.BlockBuilder()
@@ -439,8 +466,10 @@ if __name__ == "__main__":
     test_normalize()
     test_emit_te()
     test_emit_te_multiple()
+    test_emit_te_multiple_output()
     test_emit_te_extern()
     test_nested_function_fail()
     test_emit_func_output_twice_fail()
     test_func_params_twice_fail()
     test_no_func_params_fail()
+

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -18,8 +18,7 @@ from __future__ import annotations  # must import to defer parsing of annotation
 import os
 import numpy as np
 import tvm
-from tvm.relay import Call
-from tvm import relax, tir, te, relay
+from tvm import relax, tir, te
 from tvm.runtime import container
 import numpy as np
 
@@ -614,9 +613,9 @@ def test_vm_tuple():
     with bb.function("rx_func"):
         x = nn.Placeholder((n,), dtype="float32", name="x")
         y = nn.Placeholder((n,), dtype="float32", name="y")
-        tup = relay.Tuple([x, y])
-        getitem = relay.TupleGetItem(tup, 0)
-        bb.emit_func_output([tup, getitem], params=[x, y])
+        tup = relax.Tuple([x, y])
+        item = tup[0]
+        bb.emit_func_output([tup, item], params=[x, y])
 
     mod = bb.get()
     

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -19,7 +19,7 @@ import os
 import numpy as np
 import tvm
 from tvm.relay import Call
-from tvm import relax, tir, te
+from tvm import relax, tir, te, relay
 from tvm.runtime import container
 import numpy as np
 
@@ -607,6 +607,31 @@ def test_vm_relax_dyn_tir_shape():
     np.testing.assert_allclose(res.numpy(), inp2.numpy())
     os.remove("exec.tmp")
 
+def test_vm_tuple():
+    bb = relax.BlockBuilder()
+    n = tir.Var("n", "int64")
+
+    with bb.function("rx_func"):
+        x = nn.Placeholder((n,), dtype="float32", name="x")
+        y = nn.Placeholder((n,), dtype="float32", name="y")
+        tup = relay.Tuple([x, y])
+        getitem = relay.TupleGetItem(tup, 0)
+        bb.emit_func_output([tup, getitem], params=[x, y])
+
+    mod = bb.get()
+    
+    target = tvm.target.Target("llvm", host="llvm")
+    ex, lib = relax.vm.build(mod, target)
+
+    vm = relax.VirtualMachine(ex, tvm.cpu(), mod=lib)
+    shape = (5, 5)
+    inp = tvm.nd.array(np.random.rand(*shape).astype(np.float32))
+    inp2 = tvm.nd.array(np.random.rand(*shape).astype(np.float32))
+    (res1, res2), res3 = vm["rx_func"](inp, inp2)
+
+    np.testing.assert_allclose(res1.numpy(), inp.numpy())
+    np.testing.assert_allclose(res2.numpy(), inp2.numpy())
+    np.testing.assert_allclose(res3.numpy(), inp.numpy())
 
 if __name__ == "__main__":
     test_vm_execute()
@@ -631,3 +656,4 @@ if __name__ == "__main__":
     test_vm_emit_te_floor_symbolic_shape()
     test_vm_relax_symbolic_shape()
     test_vm_relax_dyn_tir_shape()
+    test_vm_tuple()


### PR DESCRIPTION
add new semantics to call_tir to support case where multiple tensors are outputted:

```python
def te_func(A):
    B = te.compute((n, m), lambda i, j: A[i, j] + 1)
    C = te.compute((n, m), lambda i, j: A[i, j] + 2)
    return (B, C)

with bb.function("rx_func", [x]):
    y = bb.emit_te(te_func, x)
    z = relay.TupleGetItem(y, 0)
    bb.emit_func_output([y, z])
```

```python
@relax.function
def rx_func(x: Tensor[(n, m), "float32"]) -> Tensor[_, "float32"]:
    # block 0
    gv: Tuple[Tensor[(_, _), "float32"], Tensor[(_, _), "float32"]] = relax.call_tir(((n, m), (n, m)), te_func, (x,))
    return (gv, gv[0])
```

The first argument of `call_tir` is a Tuple of ShapeExprs, for the output shape of each output tensor