### PR TITLE
[Refactor] Format; Simplify PackedFunc Registration; Unify parameter order of `alloc_tensor`

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -151,12 +151,12 @@ class RelayExprNode : public BaseExprNode {
   mutable Type checked_type_ = Type(nullptr);
 
   /*!
-  * \brief Stores the result of static shape analysis. It must be a RelayExpr
-  * and ObjectRef is used here to avoid cyclic typing.
-  *
-  * \note The value will be optional if a static shape can not be inferred.
-  * use .shape() instead to acesss an always defined shape expression.
-  */
+   * \brief Stores the result of static shape analysis. It must be a RelayExpr
+   * and ObjectRef is used here to avoid cyclic typing.
+   *
+   * \note The value will be optional if a static shape can not be inferred.
+   * use .shape() instead to acesss an always defined shape expression.
+   */
   mutable Optional<ObjectRef> shape_ = Optional<ObjectRef>();
 
   /*!

--- a/include/tvm/ir/type_functor.h
+++ b/include/tvm/ir/type_functor.h
@@ -25,9 +25,9 @@
 #define TVM_IR_TYPE_FUNCTOR_H_
 
 #include <tvm/node/functor.h>
+#include <tvm/relax/type.h>
 #include <tvm/relay/adt.h>
 #include <tvm/relay/expr.h>
-#include <tvm/relax/type.h>
 
 #include <string>
 #include <utility>

--- a/include/tvm/relax/attrs/memory.h
+++ b/include/tvm/relax/attrs/memory.h
@@ -51,9 +51,7 @@ struct AllocTensorAttrs : public tvm::AttrsNode<AllocTensorAttrs> {
   DataType dtype;
 
   TVM_DECLARE_ATTRS(AllocTensorAttrs, "relax.attrs.AllocTensorAttrs") {
-    TVM_ATTR_FIELD(offset)
-        .describe("Storage offset to allocate the tensor.")
-        .set_default(0);
+    TVM_ATTR_FIELD(offset).describe("Storage offset to allocate the tensor.").set_default(0);
     TVM_ATTR_FIELD(dtype)
         .describe("The dtype of the tensor to allocate.")
         .set_default(DataType::Float(32, 1));

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -25,8 +25,8 @@
 #define TVM_RELAX_BLOCK_BUILDER_H_
 
 #include <tvm/ir/expr.h>
-#include <tvm/relax/utils.h>
 #include <tvm/relax/expr.h>
+#include <tvm/relax/utils.h>
 #include <tvm/relay/expr.h>
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/registry.h>

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -218,8 +218,7 @@ class MatchShapeNode : public BindingNode {
   }
 
   bool SEqualReduce(const MatchShapeNode* other, SEqualReducer equal) const {
-    return equal(value, other->value) && equal(pattern, other->pattern)
-      && equal(var, other->var);
+    return equal(value, other->value) && equal(pattern, other->pattern) && equal(var, other->var);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
@@ -236,8 +235,7 @@ class MatchShapeNode : public BindingNode {
 
 class MatchShape : public Binding {
  public:
-  TVM_DLL explicit MatchShape(Expr value, Array<PrimExpr> pattern,
-                              Var var, Span span = Span());
+  TVM_DLL explicit MatchShape(Expr value, Array<PrimExpr> pattern, Var var, Span span = Span());
   TVM_DEFINE_OBJECT_REF_METHODS(MatchShape, Binding, MatchShapeNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(MatchShapeNode);
 };

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -136,7 +136,6 @@ class ExprFunctor<R(const Expr& n, Args...)> {
   }
 };
 
-
 /*!
  * \brief A simple visitor wrapper around ExprFunctor.
  *  Recursively visit the content.
@@ -192,7 +191,7 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
   virtual void VisitVarDef_(const DataflowVarNode* var);
 
   virtual void VisitType(const Type& t);
-  virtual void VisitSpan(const Span& span);  
+  virtual void VisitSpan(const Span& span);
 };
 
 void PostOrderVisit(const Expr& node, std::function<void(const Expr&)> fvisit);
@@ -206,9 +205,7 @@ void PostOrderVisit(const Expr& node, std::function<void(const Expr&)> fvisit);
  */
 class ExprMutator : public ExprFunctor<Expr(const Expr&)> {
  public:
-  ExprMutator() {
-    builder_ = BlockBuilder::Create();
-  }
+  ExprMutator() { builder_ = BlockBuilder::Create(); }
 
   Expr VisitExpr(const Expr& expr) override;
   Expr VisitExpr_(const ConstantNode* op) override;
@@ -293,12 +290,9 @@ class ExprMutator : public ExprFunctor<Expr(const Expr&)> {
   }
 
   /*!
-   * \brief Create a new var with specified shape and type if the original var's shape or type does not
-   * match with the specified ones.
-   * \param var The var to be updated.
-   * \param shape The specified shape.
-   * \param type The specified type.
-   * \return The var filled with \p shape and \p type.
+   * \brief Create a new var with specified shape and type if the original var's shape or type does
+   * not match with the specified ones. \param var The var to be updated. \param shape The specified
+   * shape. \param type The specified type. \return The var filled with \p shape and \p type.
    */
   Var WithShapeAndType(Var var, Optional<ObjectRef> shape, Type type);
 

--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -39,14 +39,9 @@ namespace relax {
 
 class ShapeTypeNode : public TypeNode {
  public:
+  void VisitAttrs(tvm::AttrVisitor* v) { v->Visit("span", &span); }
 
-  void VisitAttrs(tvm::AttrVisitor* v) {
-    v->Visit("span", &span);
-  }
-
-  bool SEqualReduce(const ShapeTypeNode* other, SEqualReducer equal) const {
-    return true;
-  }
+  bool SEqualReduce(const ShapeTypeNode* other, SEqualReducer equal) const { return true; }
 
   void SHashReduce(SHashReducer hash_reduce) const { hash_reduce(0); }
 
@@ -111,13 +106,9 @@ class DynTensorType : public Type {
 
 class DimTypeNode : public TypeNode {
  public:
-  void VisitAttrs(tvm::AttrVisitor* v) {
-    v->Visit("span", &span);
-  }
+  void VisitAttrs(tvm::AttrVisitor* v) { v->Visit("span", &span); }
 
-  bool SEqualReduce(const DimTypeNode* other, SEqualReducer equal) const {
-    return true;
-  }
+  bool SEqualReduce(const DimTypeNode* other, SEqualReducer equal) const { return true; }
 
   void SHashReduce(SHashReducer hash_reduce) const { hash_reduce(0); }
 

--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -24,8 +24,8 @@
 #ifndef TVM_RELAX_UTILS_H_
 #define TVM_RELAX_UTILS_H_
 
-#include <string>
 #include <algorithm>
+#include <string>
 #include <unordered_map>
 
 namespace tvm {

--- a/include/tvm/relax/vm/bytecode.h
+++ b/include/tvm/relax/vm/bytecode.h
@@ -34,11 +34,10 @@ namespace tvm {
 namespace runtime {
 namespace relax_vm {
 
-
 /*!
  * \brief The storage type for the bytecode in the VM.
  */
-using ExecWord = int64_t; 
+using ExecWord = int64_t;
 
 /*! \brief A register name. */
 using RegName = ExecWord;
@@ -60,7 +59,6 @@ enum class Opcode {
   Goto = 3U,
   If = 4U,
 };
-
 
 /*! \brief A single virtual machine instruction.
  *
@@ -99,8 +97,7 @@ struct Instruction {
     /*! \brief Construct from the kind and value. */
     Arg(ArgKind kind, Index value) {
       // TODO(ziheng): check value?
-      this->data = (static_cast<ExecWord>(kind) << kValueBit) |
-                   (value & kValueMask);
+      this->data = (static_cast<ExecWord>(kind) << kValueBit) | (value & kValueMask);
     }
     /*!
      * \brief Get the kind of argument..
@@ -114,16 +111,14 @@ struct Instruction {
      * \brief Get the value of argument..
      * \return The value of argument.
      */
-    ExecWord value() const {
-      return data & ((static_cast<ExecWord>(1) << kValueBit) - 1);
-    }
+    ExecWord value() const { return data & ((static_cast<ExecWord>(1) << kValueBit) - 1); }
     /*! \brief The underlying stored data. */
     ExecWord data;
   };
   /*! \brief The instruction opcode. */
   Opcode op;
   /*! \brief The destination register. */
-  RegName dst; 
+  RegName dst;
   union {
     struct /* Call */ {
       /*! \brief The index into the packed function table. */
@@ -160,9 +155,7 @@ struct Instruction {
    * \param dst The destination register.
    * \return The call instruction.
    */
-  static Instruction Call(Index func_idx, Index num_args,
-                          Arg* args,
-                          RegName dst);
+  static Instruction Call(Index func_idx, Index num_args, Arg* args, RegName dst);
   /*!
    * \brief Construct a return instruction.
    * \param result The register containing the return value.

--- a/include/tvm/relax/vm/executable.h
+++ b/include/tvm/relax/vm/executable.h
@@ -19,14 +19,15 @@
 
 /*!
  * \file tvm/relax/vm/executable.h
- * \brief 
+ * \brief
  */
 #ifndef TVM_RELAX_VM_EXECUTABLE_H_
 #define TVM_RELAX_VM_EXECUTABLE_H_
 
+#include <tvm/ir/expr.h>
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/registry.h>
-#include <tvm/ir/expr.h>
+
 #include "./bytecode.h"
 
 namespace tvm {
@@ -43,7 +44,7 @@ class Executable;
  */
 struct VMFunction {
   /*! \brief The function's name. */
-  std::string name; 
+  std::string name;
   /*! \brief The start instruction index of the function. */
   Index start_instr;
   /*! \brief The number of arguments of the function. */
@@ -116,7 +117,7 @@ class ExecutableNode : public Object {
   std::vector<ExecWord> instr_data;
 
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
-  static constexpr const char* _type_key = "relax.Executable"; 
+  static constexpr const char* _type_key = "relax.Executable";
   TVM_DECLARE_FINAL_OBJECT_INFO(ExecutableNode, Object);
 
  private:
@@ -167,7 +168,6 @@ class Executable : public ObjectRef {
  public:
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Executable, ObjectRef, ExecutableNode);
 };
-
 
 }  // namespace relax_vm
 }  // namespace runtime

--- a/include/tvm/relax/vm/memory_manager.h
+++ b/include/tvm/relax/vm/memory_manager.h
@@ -112,7 +112,7 @@ class StorageObj : public Object {
   Buffer buffer;
 
   /*! \brief Allocate an NDArray from a given piece of storage. */
-  runtime::NDArray AllocNDArray(ShapeTuple shape, size_t offset, DLDataType dtype);
+  runtime::NDArray AllocNDArray(size_t offset, ShapeTuple shape, DLDataType dtype);
 
   /*! \brief The deleter for an NDArray when allocated from underlying storage. */
   static void Deleter(Object* ptr);

--- a/include/tvm/relax/vm/memory_manager.h
+++ b/include/tvm/relax/vm/memory_manager.h
@@ -112,7 +112,7 @@ class StorageObj : public Object {
   Buffer buffer;
 
   /*! \brief Allocate an NDArray from a given piece of storage. */
-  runtime::NDArray AllocNDArray(size_t offset, ShapeTuple shape, DLDataType dtype);
+  runtime::NDArray AllocNDArray(ShapeTuple shape, size_t offset, DLDataType dtype);
 
   /*! \brief The deleter for an NDArray when allocated from underlying storage. */
   static void Deleter(Object* ptr);

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -237,7 +237,7 @@ class RelaxTransformer(Transformer):
 
         # annotation with type arguments/shape annotation
         if isinstance(ty, ast.TypeApply):
-            if ty.id.name == "Tensor":
+            if ty.func_name.id.name == "Tensor":
                 # TODO(@altanh): forgetting dtype like "Tensor[(n, m)]" ends up getting parsed as
                 #                Tensor[n, m] which makes correct errors difficult here...
                 if len(ty.params) != 2:
@@ -295,7 +295,7 @@ class RelaxTransformer(Transformer):
                     )
 
                 return (relax.DynTensorType(rank=rank, dtype=dtype, span=span), shape)
-            elif ty.id.name == "Tuple":
+            elif ty.func_name.id.name == "Tuple":
                 field_types = []
                 field_shapes = []
                 for field in ty.params:

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -408,13 +408,13 @@ class TIRTextPrinter : public StmtFunctor<Doc(const Stmt&)>,
   Doc PrintBody(const Stmt& body, bool indent = true);
 };
 
-
 String AsTVMScript(const ObjectRef& mod, const String& tir_prefix = "tir", bool show_meta = false);
 
 String AsTVMScriptWithDiagnostic(const ObjectRef& mod, const String& tir_prefix, bool show_meta,
                                  runtime::TypedPackedFunc<std::string(Stmt)> annotate);
 
-Doc AsTVMScriptDoc(const ObjectRef& mod, const String& tir_prefix = "tir", bool show_meta = false, const PrimFunc& func = PrimFunc());
+Doc AsTVMScriptDoc(const ObjectRef& mod, const String& tir_prefix = "tir", bool show_meta = false,
+                   const PrimFunc& func = PrimFunc());
 
 }  // namespace tir
 }  // namespace tvm

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -24,12 +24,12 @@
 
 #include "codegen_vm.h"
 
-#include <tvm/target/target.h>
+#include <tvm/driver/driver_api.h>
 #include <tvm/relax/attrs/memory.h>
 #include <tvm/relax/attrs/shape.h>
 #include <tvm/relax/expr_functor.h>
+#include <tvm/target/target.h>
 #include <tvm/tir/function.h>
-#include <tvm/driver/driver_api.h>
 
 #include <string>
 #include <unordered_map>
@@ -46,16 +46,15 @@ using namespace relax;
  */
 class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
  public:
-  explicit CodeGenVM(ExecBuilderNode* builder) {
-    builder_ = GetRef<ExecBuilder>(builder);
-  }
+  explicit CodeGenVM(ExecBuilderNode* builder) { builder_ = GetRef<ExecBuilder>(builder); }
 
  protected:
   size_t NewRegister() { return registers_num_++; }
 
-  // TODO(@yuchen): add visitors for IfNode when goto and if instructions are introduced to relax vm.
+  // TODO(@yuchen): add visitors for IfNode when goto and if instructions are introduced to relax
+  // vm.
 
-  // TODO(@yuchen): when we support closure, this visitor should return a register that 
+  // TODO(@yuchen): when we support closure, this visitor should return a register that
   // contains the closure object.
   Instruction::Arg VisitExpr_(const FunctionNode* func_node) {
     if (func_node->name.defined()) {
@@ -94,7 +93,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
 
   Instruction::Arg VisitExpr_(const CallNode* op) {
     if (op->op.as<OpNode>()) {
-      // special case generate for the intrinsics whose attribute fields 
+      // special case generate for the intrinsics whose attribute fields
       // cannot be represented by args in the CallNode
       const Call& call = GetRef<Call>(op);
       if (op->op == alloc_storage_op_) {
@@ -106,8 +105,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
       } else if (op->op == call_tir_dyn_op_) {
         return EmitTirDynOp(call);
       } else {
-        // every "normal" operator is lowered to a global var in the IR module. The Attrs for those ops 
-        // are handled in a pass when lowering them to TIR.
+        // every "normal" operator is lowered to a global var in the IR module. The Attrs for those
+        // ops are handled in a pass when lowering them to TIR.
         LOG(FATAL) << "CodeGenVM cannot handle this intrinsic now:\n" << op->op;
       }
     }
@@ -140,9 +139,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
 
   Instruction::Arg VisitExpr_(const ShapeExprNode* op) {
     ShapeExpr sh = GetRef<ShapeExpr>(op);
-    ICHECK(IsConstantShape(sh))
-      << "should only use constant shape after shape lowering: "
-      << sh->values;
+    ICHECK(IsConstantShape(sh)) << "should only use constant shape after shape lowering: "
+                                << sh->values;
     std::vector<int64_t> shape;
     for (PrimExpr e : sh->values) {
       shape.push_back(Downcast<IntImm>(e)->value);
@@ -158,7 +156,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     // Handle args of the call
     std::vector<Instruction::Arg> args;
     args.push_back(Instruction::Arg(Instruction::kVMStateRegister));
-    for (Expr arg: call_node->args) {
+    for (Expr arg : call_node->args) {
       args.push_back(ConvertArg(arg));
     }
 
@@ -181,7 +179,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   Instruction::Arg EmitAllocTensor(const Call& call_node) {
     // Handle args of the call
     std::vector<Instruction::Arg> args;
-    for (Expr arg: call_node->args) {
+    for (Expr arg : call_node->args) {
       args.push_back(ConvertArg(arg));
     }
 
@@ -204,7 +202,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   Instruction::Arg EmitShape(const Call& call_node) {
     // Handle args of the call
     std::vector<Instruction::Arg> args;
-    for (Expr arg: call_node->args) {
+    for (Expr arg : call_node->args) {
       args.push_back(ConvertArg(arg));
     }
 
@@ -246,7 +244,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     std::vector<Instruction::Arg> args;
     args.push_back(Instruction::Arg(Instruction::kVMStateRegister));
     args.push_back(Instruction::Arg(Instruction::kConstIdx, func_name_index));
-    for (Expr arg: tir_args->fields) {
+    for (Expr arg : tir_args->fields) {
       args.push_back(ConvertArg(arg));
     }
 
@@ -269,14 +267,13 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     if (arg->IsInstance<VarNode>()) {
       Var var = Downcast<Var>(arg);
       auto reg = this->var_register_map_.find(Downcast<Var>(arg));
-      ICHECK(reg != this->var_register_map_.end())
-        << var->name_hint() << "(" << var << ")" << " not in the register map.";
+      ICHECK(reg != this->var_register_map_.end()) << var->name_hint() << "(" << var << ")"
+                                                   << " not in the register map.";
       return Instruction::Arg(Instruction::kRegister, reg->second);
     } else if (arg->IsInstance<ShapeExprNode>()) {
       ShapeExpr sh = Downcast<ShapeExpr>(arg);
-      ICHECK(IsConstantShape(sh))
-        << "should only use constant shape after shape lowering: "
-        << sh->values;
+      ICHECK(IsConstantShape(sh)) << "should only use constant shape after shape lowering: "
+                                  << sh->values;
       std::vector<int64_t> shape;
       for (PrimExpr e : sh->values) {
         shape.push_back(Downcast<IntImm>(e)->value);
@@ -325,9 +322,7 @@ void VMCodeGen::CodeGen(IRModule rx_mod) {
   }
 }
 
-Executable VMCodeGen::GetExec() { 
-  return builder_->Get();
-}
+Executable VMCodeGen::GetExec() { return builder_->Get(); }
 
 Executable CodeGen(IRModule mod) {
   auto codegen = make_object<VMCodeGen>();
@@ -336,8 +331,7 @@ Executable CodeGen(IRModule mod) {
   return exec;
 }
 
-TVM_REGISTER_GLOBAL("relax.VMCodeGen")
-.set_body_typed(CodeGen);
+TVM_REGISTER_GLOBAL("relax.VMCodeGen").set_body_typed(CodeGen);
 
 }  // namespace relax_vm
 }  // namespace relax

--- a/src/relax/backend/vm/vm_memory_lower.cc
+++ b/src/relax/backend/vm/vm_memory_lower.cc
@@ -95,7 +95,7 @@ class VMMemLowerMutator : public ExprMutator {
       Expr shape = call->args[0];
       Var tensor =
           builder_->Emit(Call(vm_alloc_tensor_op, {storage, shape}, Attrs(tensor_attr)), "tensor");
-      return tensor;
+      return std::move(tensor);
     }
 
     return GetRef<Expr>(call);

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -59,7 +59,7 @@ class VMShapeLowerMutator : public ExprMutator {
 
   void VisitBinding_(const MatchShapeNode* binding) override {
     Expr value = ExprMutator::VisitExpr(binding->value);
-    
+
     // TODO(@yuchen): match_shape overloaded semantic: value is ShapeType
     Var shape = builder_->Emit(Call(ExternFunc("vm.builtin.shape_of"), {value}), "sh");
     StoreShape(shape, binding->pattern);
@@ -171,7 +171,7 @@ class VMShapeLowerMutator : public ExprMutator {
     return ret;
   }
 
-  /*! \brief Store symbolic shape into indices of the VM shape heap. */  
+  /*! \brief Store symbolic shape into indices of the VM shape heap. */
   void StoreShape(Expr shape, Array<PrimExpr> pattern) {
     static const Op& store_shape_op = Op::Get("relax.vm.builtin.store_shape");
     auto store_shape_attr = make_object<ShapeHeapAttrs>();

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -530,32 +530,29 @@ BlockBuilder BlockBuilder::Create() { return BlockBuilder(make_object<BlockBuild
 TVM_REGISTER_GLOBAL("relax.BlockBuilderCreate").set_body_typed(BlockBuilder::Create);
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderBeginDataflowBlock")
-    .set_body_typed([](BlockBuilder builder) { builder->BeginDataflowBlock(); });
+    .set_body_method<BlockBuilder>(&BlockBuilderNode::BeginDataflowBlock);
 
-TVM_REGISTER_GLOBAL("relax.BlockBuilderBeginBindingBlock").set_body_typed([](BlockBuilder builder) {
-  builder->BeginBindingBlock();
+TVM_REGISTER_GLOBAL("relax.BlockBuilderBeginBindingBlock")
+    .set_body_method<BlockBuilder>(&BlockBuilderNode::BeginBindingBlock);
+
+TVM_REGISTER_GLOBAL("relax.BlockBuilderEndBlock")
+    .set_body_method<BlockBuilder>(&BlockBuilderNode::EndBlock);
+
+TVM_REGISTER_GLOBAL("relax.BlockBuilderNormalize")
+    .set_body_method<BlockBuilder>(&BlockBuilderNode::Normalize);
+
+TVM_REGISTER_GLOBAL("relax.BlockBuilderEmit").set_body_typed([](BlockBuilder builder, Call call) {
+  return builder->Emit(call);
 });
-
-TVM_REGISTER_GLOBAL("relax.BlockBuilderEndBlock").set_body_typed([](BlockBuilder builder) {
-  return builder->EndBlock();
-});
-
-TVM_REGISTER_GLOBAL("relax.BlockBuilderEmit")
-    .set_body_typed([](BlockBuilder builder, const Call& call) { return builder->Emit(call); });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitMatchShape")
-    .set_body_typed([](BlockBuilder builder, const Expr& value, const Array<PrimExpr>& pattern) {
+    .set_body_typed([](BlockBuilder builder, Expr value, Array<PrimExpr> pattern) {
       return builder->EmitMatchShape(value, pattern);
     });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitOutput")
     .set_body_typed([](BlockBuilder builder, const Expr& output) {
       return builder->EmitOutput(output);
-    });
-
-TVM_REGISTER_GLOBAL("relax.BlockBuilderNormalize")
-    .set_body_typed([](BlockBuilder builder, const Expr& expr) {
-      return builder->Normalize(expr);
     });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderGetUniqueName")

--- a/src/relax/ir/emit_te.cc
+++ b/src/relax/ir/emit_te.cc
@@ -20,18 +20,19 @@
 /*!
  * \file relax/src/ir/emit_te.cc
  */
-#include <tvm/relax/type.h>
 #include "./emit_te.h"
+
+#include <tvm/relax/type.h>
 
 namespace tvm {
 namespace relax {
 
 // RXPlaceholderOpNode
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
-.set_dispatch<RXPlaceholderOpNode>([](const ObjectRef& node, ReprPrinter* p) {
-  auto* op = static_cast<const RXPlaceholderOpNode*>(node.get());
-  p->stream << "rxplaceholder(" << op->name << ", " << op << ")";
-});
+    .set_dispatch<RXPlaceholderOpNode>([](const ObjectRef& node, ReprPrinter* p) {
+      auto* op = static_cast<const RXPlaceholderOpNode*>(node.get());
+      p->stream << "rxplaceholder(" << op->name << ", " << op << ")";
+    });
 
 TVM_REGISTER_NODE_TYPE(RXPlaceholderOpNode);
 
@@ -42,23 +43,20 @@ te::Tensor TETensor(Expr value, std::string name) {
 
   Expr shape_expr = value->shape();
   CHECK(shape_expr->IsInstance<ShapeExprNode>())
-    << "ValueError: Expression does not have an known symbolic shape, please consider use match_shape "
-    << "to constrain the shape before passing into te_tensor";
+      << "ValueError: Expression does not have an known symbolic shape, please consider use "
+         "match_shape "
+      << "to constrain the shape before passing into te_tensor";
   Array<PrimExpr> shape = Downcast<ShapeExpr>(shape_expr)->values;
   n->shape = shape;
   Type type = value->checked_type();
   ICHECK(type->IsInstance<DynTensorTypeNode>())
-    << "ValueError: Expression should have a inferred DynTensorType: "
-    << type->GetTypeKey();
+      << "ValueError: Expression should have a inferred DynTensorType: " << type->GetTypeKey();
   DataType dtype = Downcast<DynTensorType>(type)->dtype;
   n->dtype = dtype;
   return te::PlaceholderOp(n).output(0);
 }
 
-TVM_REGISTER_GLOBAL("relax.TETensor")
-.set_body_typed([](Expr value, std::string name) {
-  return TETensor(value, name);
-});
+TVM_REGISTER_GLOBAL("relax.TETensor").set_body_typed(TETensor);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -29,12 +29,9 @@ RelayExpr RelayExprNode::shape() const {
   return relay::Call(op, {self}, {}, {});
 }
 
-TVM_REGISTER_GLOBAL("ir.RelayExprShape").set_body_typed([](RelayExpr expr) {
-  return expr->shape();
-});
+TVM_REGISTER_GLOBAL("ir.RelayExprShape").set_body_method<RelayExpr>(&RelayExprNode::shape);
 
 namespace relax {
-
 using tvm::runtime::Optional;
 
 TVM_REGISTER_NODE_TYPE(ShapeExprNode);
@@ -65,10 +62,10 @@ Var::Var(Id vid, Optional<Expr> shape_annotation, Optional<Type> type_annotation
 }
 
 TVM_REGISTER_GLOBAL("relax.Var")
-.set_body_typed([](String name_hint, Optional<Expr> shape_annotation,
-                   Optional<Type> type_annotation, Span span) {
-  return Var(name_hint, shape_annotation, type_annotation, span);
-});
+    .set_body_typed([](String name_hint, Optional<Expr> shape_annotation,
+                       Optional<Type> type_annotation, Span span) {
+      return Var(name_hint, shape_annotation, type_annotation, span);
+    });
 
 TVM_REGISTER_NODE_TYPE(DataflowVarNode);
 
@@ -83,10 +80,10 @@ DataflowVar::DataflowVar(Id vid, Optional<Expr> shape_annotation, Optional<Type>
 }
 
 TVM_REGISTER_GLOBAL("relax.DataflowVar")
-.set_body_typed([](String name_hint, Optional<Expr> shape_annotation,
-                   Optional<Type> type_annotation, Span span) {
-  return DataflowVar(name_hint, shape_annotation, type_annotation, span);
-});
+    .set_body_typed([](String name_hint, Optional<Expr> shape_annotation,
+                       Optional<Type> type_annotation, Span span) {
+      return DataflowVar(name_hint, shape_annotation, type_annotation, span);
+    });
 
 Binding::Binding(Span span) {
   ObjectPtr<BindingNode> n = make_object<BindingNode>();
@@ -96,9 +93,7 @@ Binding::Binding(Span span) {
 
 TVM_REGISTER_NODE_TYPE(BindingNode);
 
-TVM_REGISTER_GLOBAL("relax.Binding").set_body_typed([](Span span) {
-  return Binding(span);
-});
+TVM_REGISTER_GLOBAL("relax.Binding").set_body_typed([](Span span) { return Binding(span); });
 
 TVM_REGISTER_NODE_TYPE(MatchShapeNode);
 
@@ -112,9 +107,9 @@ MatchShape::MatchShape(Expr value, Array<PrimExpr> pattern, Var var, Span span) 
 }
 
 TVM_REGISTER_GLOBAL("relax.MatchShape")
-.set_body_typed([](Expr value, Array<PrimExpr> pattern, Var var, Span span) {
-  return MatchShape(value, pattern, var, span);
-});
+    .set_body_typed([](Expr value, Array<PrimExpr> pattern, Var var, Span span) {
+      return MatchShape(value, pattern, var, span);
+    });
 
 TVM_REGISTER_NODE_TYPE(VarBindingNode);
 
@@ -185,10 +180,9 @@ Function::Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr bo
 }
 
 TVM_REGISTER_GLOBAL("relax.Function")
-.set_body_typed([](runtime::Optional<GlobalVar> name, Array<Var> params,
-                   Expr body, Type ret_type, Span span) {
-  return Function(name, params, body, ret_type, span);
-});
+    .set_body_typed([](runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
+                       Type ret_type,
+                       Span span) { return Function(name, params, body, ret_type, span); });
 
 TVM_REGISTER_NODE_TYPE(ExternFuncNode);
 

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -55,14 +55,10 @@ void ExprVisitor::VisitExpr_(const TupleNode* op) {
 }
 
 // Visit the use-site of a defined Var
-void ExprVisitor::VisitExpr_(const VarNode* op) {
-  this->VisitSpan(op->span);
-}
+void ExprVisitor::VisitExpr_(const VarNode* op) { this->VisitSpan(op->span); }
 
 // Visit the use-site of a defined DataflowVar
-void ExprVisitor::VisitExpr_(const DataflowVarNode* op) {
-  this->VisitSpan(op->span);
-}
+void ExprVisitor::VisitExpr_(const DataflowVarNode* op) { this->VisitSpan(op->span); }
 
 void ExprVisitor::VisitExpr_(const FunctionNode* op) {
   this->VisitSpan(op->span);
@@ -502,7 +498,7 @@ Var ExprMutator::VisitVarDef_(const DataflowVarNode* var) {
     } else {
       new_var->shape_ = new_shape;
     }
-    
+
     this->var_remap_[var->vid] = new_var;
     return new_var;
   }
@@ -538,7 +534,7 @@ Var ExprMutator::VisitVarDef_(const VarNode* var) {
     } else {
       new_var->shape_ = new_shape;
     }
-    
+
     this->var_remap_[var->vid] = new_var;
     return new_var;
   }

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -52,12 +52,13 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs) {
 // call_tir
 
 RELAY_REGISTER_OP("relax.call_tir")
-.set_num_inputs(4)
-.add_argument("shape", "Expr", "The output shape.")
-.add_argument("func", "Expr", "The destination-passing-style function.")
-.add_argument("args", "Tuple", "The input arguments.")
-.add_argument("packed_ints", "Expr", 
-  "ShapeExpr representing a tuple of ints to unpack during runtime. Omitted from args if unused");
+    .set_num_inputs(4)
+    .add_argument("shape", "Expr", "The output shape.")
+    .add_argument("func", "Expr", "The destination-passing-style function.")
+    .add_argument("args", "Tuple", "The input arguments.")
+    .add_argument("packed_ints", "Expr",
+                  "ShapeExpr representing a tuple of ints to unpack during runtime. Omitted from "
+                  "args if unused");
 
 Expr MakeCallTIR(Expr shape, Expr func, Tuple args, Optional<Expr> packed_ints) {
   static const Op& op = Op::Get("relax.call_tir");
@@ -73,104 +74,97 @@ Expr MakeCallTIR(Expr shape, Expr func, Tuple args, Optional<Expr> packed_ints) 
   return call;
 }
 
-TVM_REGISTER_GLOBAL("relax.op.call_tir")
-.set_body_typed(MakeCallTIR);
+TVM_REGISTER_GLOBAL("relax.op.call_tir").set_body_typed(MakeCallTIR);
 
 // shape_of
 
 RELAY_REGISTER_OP("relax.shape_of")
-.set_num_inputs(1)
-.add_argument("input", "Expr", "The input expression");
+    .set_num_inputs(1)
+    .add_argument("input", "Expr", "The input expression");
 
 Expr MakeShapeOf(Expr expr) {
   static const Op& op = Op::Get("relax.shape_of");
   return Call(op, {expr}, {}, {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.shape_of")
-.set_body_typed(MakeShapeOf);
+TVM_REGISTER_GLOBAL("relax.op.shape_of").set_body_typed(MakeShapeOf);
 
 // alloc_tensor
 
 RELAY_REGISTER_OP("relax.builtin.alloc_tensor")
-.set_num_inputs(1)
-.add_argument("shape", "Expr", "The shape of the tensor to allocate.");
+    .set_num_inputs(1)
+    .add_argument("shape", "Expr", "The shape of the tensor to allocate.");
 
 Expr MakeAllocTensor(Expr shape) {
   static const Op& op = Op::Get("relax.builtin.alloc_tensor");
   return Call(op, {shape}, {}, {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.builtin.alloc_tensor")
-.set_body_typed(MakeAllocTensor);
+TVM_REGISTER_GLOBAL("relax.op.builtin.alloc_tensor").set_body_typed(MakeAllocTensor);
 
 // vm alloc_storage
 
 RELAY_REGISTER_OP("relax.vm.builtin.alloc_storage")
-.set_attrs_type<AllocStorageAttrs>()
-.set_num_inputs(1)
-.add_argument("size", "Expr", "The size of the storage to allocate.");
+    .set_attrs_type<AllocStorageAttrs>()
+    .set_num_inputs(1)
+    .add_argument("size", "Expr", "The size of the storage to allocate.");
 
 Expr MakeVMAllocStorage(Expr size) {
   static const Op& op = Op::Get("relax.vm.builtin.alloc_storage");
   return Call(op, {size}, {}, {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_storage")
-.set_body_typed(MakeVMAllocStorage);
+TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_storage").set_body_typed(MakeVMAllocStorage);
 
 // vm alloc_tensor
 
 RELAY_REGISTER_OP("relax.vm.builtin.alloc_tensor")
-.set_attrs_type<AllocTensorAttrs>()
-.set_num_inputs(1)
-.add_argument("shape", "Expr", "The shape of the tensor to allocate.");
+    .set_attrs_type<AllocTensorAttrs>()
+    .set_num_inputs(1)
+    .add_argument("shape", "Expr", "The shape of the tensor to allocate.");
 
 Expr MakeVMAllocTensor(Expr shape) {
   static const Op& op = Op::Get("relax.vm.builtin.alloc_tensor");
   return Call(op, {shape}, {}, {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_tensor")
-.set_body_typed(MakeVMAllocTensor);
+TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_tensor").set_body_typed(MakeVMAllocTensor);
 
 // vm store_shape
 
 RELAY_REGISTER_OP("relax.vm.builtin.store_shape")
-.set_attrs_type<ShapeHeapAttrs>()
-.set_num_inputs(2)
-.add_argument("shape", "Expr", "The shape to be stored.")
-.add_argument("heap", "Expr", "The heap to store the shape.");
+    .set_attrs_type<ShapeHeapAttrs>()
+    .set_num_inputs(2)
+    .add_argument("shape", "Expr", "The shape to be stored.")
+    .add_argument("heap", "Expr", "The heap to store the shape.");
 
 Expr MakeStoreShape(Expr shape, Expr heap) {
   static const Op& op = Op::Get("relax.vm.builtin.store_shape");
   return Call(op, {shape, heap}, {}, {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.vm.builtin.store_shape")
-.set_body_typed(MakeStoreShape);
+TVM_REGISTER_GLOBAL("relax.op.vm.builtin.store_shape").set_body_typed(MakeStoreShape);
 
 // vm load_shape
 
 RELAY_REGISTER_OP("relax.vm.builtin.load_shape")
-.set_attrs_type<ShapeHeapAttrs>()
-.set_num_inputs(1)
-.add_argument("heap", "Expr", "The heap to load the shape from.");
+    .set_attrs_type<ShapeHeapAttrs>()
+    .set_num_inputs(1)
+    .add_argument("heap", "Expr", "The heap to load the shape from.");
 
 Expr MakeLoadShape(Expr heap) {
   static const Op& op = Op::Get("relax.vm.builtin.load_shape");
   return Call(op, {heap}, {}, {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.vm.builtin.load_shape")
-.set_body_typed(MakeLoadShape);
+TVM_REGISTER_GLOBAL("relax.op.vm.builtin.load_shape").set_body_typed(MakeLoadShape);
 
 // vm call_tir_dyn
 RELAY_REGISTER_OP("relax.vm.call_tir_dyn")
-.set_num_inputs(2)
-.add_argument("func", "Expr", "The destination-passing-style function.")
-.add_argument("args", "Tuple", "The input arguments (list of tensors and last argument is ShapeExpr)");
+    .set_num_inputs(2)
+    .add_argument("func", "Expr", "The destination-passing-style function.")
+    .add_argument("args", "Tuple",
+                  "The input arguments (list of tensors and last argument is ShapeExpr)");
 
-
-} // namespace relax
-} // namespace tvm
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -25,8 +25,8 @@
 #ifndef TVM_RELAX_OP_OP_COMMON_H_
 #define TVM_RELAX_OP_OP_COMMON_H_
 
-#include <tvm/relax/op_attr_types.h>
 #include <tvm/arith/analyzer.h>
+#include <tvm/relax/op_attr_types.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/op.h>
 
@@ -47,7 +47,7 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs);
  *
  * \param OpName the name of registry.
  */
-#define RELAX_REGISTER_BINARY_BROADCAST_OP(OpName)                                          \
+#define RELAX_REGISTER_BINARY_BROADCAST_OP(OpName)                                \
   TVM_REGISTER_GLOBAL("relax.op." OpName).set_body_typed([](Expr lhs, Expr rhs) { \
     static const Op& op = Op::Get("relax." OpName);                               \
     return Call(op, {lhs, rhs}, Attrs(), {});                                     \

--- a/src/relax/op/tensor/ternary.cc
+++ b/src/relax/op/tensor/ternary.cc
@@ -28,20 +28,19 @@ namespace tvm {
 namespace relax {
 
 RELAY_REGISTER_OP("relax.ewise_fma")
-.set_num_inputs(3)
-.add_argument("e1", "Expr", "The input expression")
-.add_argument("e2", "Expr", "The input expression")
-.add_argument("e3", "Expr", "The input expression")
-.set_attr<FInferShape>("FInferShape", InferShapeEwiseFMA)
-.set_attr<FInferType>("FInferType", InferTypeEwiseFMA);
+    .set_num_inputs(3)
+    .add_argument("e1", "Expr", "The input expression")
+    .add_argument("e2", "Expr", "The input expression")
+    .add_argument("e3", "Expr", "The input expression")
+    .set_attr<FInferShape>("FInferShape", InferShapeEwiseFMA)
+    .set_attr<FInferType>("FInferType", InferTypeEwiseFMA);
 
 Expr MakeEwiseFma(Expr expr1, Expr expr2, Expr expr3) {
   static const Op& op = Op::Get("relax.ewise_fma");
   return Call(op, {expr1, expr2, expr3}, {}, {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.ewise_fma")
-.set_body_typed(MakeEwiseFma);
+TVM_REGISTER_GLOBAL("relax.op.ewise_fma").set_body_typed(MakeEwiseFma);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -69,7 +69,7 @@ class CallTIRMutator : public ExprMutator {
       } else {
         builder_->Emit(Call(call->args[1], {call->args[2], tensor}), "_");
       }
-      return tensor;
+      return std::move(tensor);
     }
 
     return GetRef<Expr>(call);

--- a/src/relax/transform/fma_rewrite.cc
+++ b/src/relax/transform/fma_rewrite.cc
@@ -58,7 +58,7 @@ class EwiseFMARewriter : public ExprMutator {
       const CallNode* mul = value.as<CallNode>();
       if (mul && mul->op == multiply_op) {
         Call fma_call = Call(ewise_fma_op, {mul->args[0], mul->args[1], call->args[1]}, {}, {});
-        return fma_call;
+        return std::move(fma_call);
       }
     }
 

--- a/src/relax/vm/builtin.cc
+++ b/src/relax/vm/builtin.cc
@@ -24,12 +24,12 @@
 #include <tvm/relax/vm/memory_manager.h>
 #include <tvm/relax/vm/vm.h>
 #include <tvm/runtime/data_type.h>
+#include <tvm/runtime/device_api.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/memory.h>
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/registry.h>
-#include <tvm/runtime/device_api.h>
 
 namespace tvm {
 namespace runtime {
@@ -37,28 +37,23 @@ namespace relax_vm {
 
 using tvm::runtime::NDArray;
 
-TVM_REGISTER_GLOBAL("vm.builtin.shape_of")
-.set_body_typed([](NDArray arr) {
-  return arr.Shape();
-});
+TVM_REGISTER_GLOBAL("vm.builtin.shape_of").set_body_method(&NDArray::Shape);
 
-TVM_REGISTER_GLOBAL("vm.builtin.alloc_shape_heap")
-.set_body_typed([](ShapeTuple size) {
+TVM_REGISTER_GLOBAL("vm.builtin.alloc_shape_heap").set_body_typed([](ShapeTuple size) {
   return NDArray::Empty(size, DLDataType{kDLInt, 64, 1}, DLDevice{kDLCPU, 0});
 });
 
 TVM_REGISTER_GLOBAL("vm.builtin.store_shape")
-.set_body_typed([](ShapeTuple shape, NDArray heap, ShapeTuple indexes) {
-  int64_t* heap_data = reinterpret_cast<int64_t*>(heap.ToDLPack()->dl_tensor.data);
-  for (size_t i = 0; i < indexes.size(); ++i) {
-    int64_t heap_idx = indexes[i];
-    ICHECK(heap_idx >= 0 && heap_idx < heap.Shape()[0]);
-    heap_data[heap_idx] = shape[i];
-  }
-});
+    .set_body_typed([](ShapeTuple shape, NDArray heap, ShapeTuple indexes) {
+      int64_t* heap_data = reinterpret_cast<int64_t*>(heap.ToDLPack()->dl_tensor.data);
+      for (size_t i = 0; i < indexes.size(); ++i) {
+        int64_t heap_idx = indexes[i];
+        ICHECK(heap_idx >= 0 && heap_idx < heap.Shape()[0]);
+        heap_data[heap_idx] = shape[i];
+      }
+    });
 
-TVM_REGISTER_GLOBAL("vm.builtin.load_shape")
-.set_body_typed([](NDArray heap, ShapeTuple indexes) {
+TVM_REGISTER_GLOBAL("vm.builtin.load_shape").set_body_typed([](NDArray heap, ShapeTuple indexes) {
   int64_t* heap_data = reinterpret_cast<int64_t*>(heap.ToDLPack()->dl_tensor.data);
   std::vector<int64_t> shape;
   for (size_t i = 0; i < indexes.size(); ++i) {
@@ -70,58 +65,54 @@ TVM_REGISTER_GLOBAL("vm.builtin.load_shape")
 });
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
-.set_body_typed([](void* vm_state_ptr, ShapeTuple buffer_size, Index device_type, DLDataType dtype_hint) {
-  int alignment = runtime::kAllocAlignment;
-  ICHECK_EQ(buffer_size.size(), 1);
-  VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
-  int64_t size_imm = buffer_size[0];
-  DLOG(INFO) << "AllocStorage: allocation_size=" << size_imm << ", alignment=" << alignment
-              << ", dtype_hint=" << runtime::DLDataType2String(dtype_hint)
-              << ", device_type=" << device_type;
+    .set_body_typed([](void* vm_state_ptr, ShapeTuple buffer_size, Index device_type,
+                       DLDataType dtype_hint) {
+      int alignment = runtime::kAllocAlignment;
+      ICHECK_EQ(buffer_size.size(), 1);
+      VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
+      int64_t size_imm = buffer_size[0];
+      DLOG(INFO) << "AllocStorage: allocation_size=" << size_imm << ", alignment=" << alignment
+                 << ", dtype_hint=" << runtime::DLDataType2String(dtype_hint)
+                 << ", device_type=" << device_type;
 
-  auto storage_obj = runtime::SimpleObjAllocator().make_object<StorageObj>();
-  ICHECK_LT(static_cast<size_t>(device_type), vm_state->allocators.size())
-      << "Memory allocator for device " << device_type << " has not been initialized";
-  auto* alloc = vm_state->allocators[device_type];
-  ICHECK(alloc) << "Did you forget to init the VirtualMachine with devices?";
-  storage_obj->buffer = alloc->Alloc(size_imm, alignment, dtype_hint);
-  Storage storage(storage_obj);
-  return storage;
-});
+      auto storage_obj = runtime::SimpleObjAllocator().make_object<StorageObj>();
+      ICHECK_LT(static_cast<size_t>(device_type), vm_state->allocators.size())
+          << "Memory allocator for device " << device_type << " has not been initialized";
+      auto* alloc = vm_state->allocators[device_type];
+      ICHECK(alloc) << "Did you forget to init the VirtualMachine with devices?";
+      storage_obj->buffer = alloc->Alloc(size_imm, alignment, dtype_hint);
+      Storage storage(storage_obj);
+      return storage;
+    });
 
-TVM_REGISTER_GLOBAL("vm.builtin.alloc_tensor")
-.set_body_typed([](Storage storage, ShapeTuple shape, Index offset, DLDataType dtype) {
-  auto tensor = storage->AllocNDArray(offset, shape, dtype);
-  return tensor;
-});
+TVM_REGISTER_GLOBAL("vm.builtin.alloc_tensor").set_body_method<Storage>(&StorageObj::AllocNDArray);
 
 TVM_REGISTER_GLOBAL("vm.binary_broadcast_shape_infer")
-.set_body_typed([](ShapeTuple lhs_shape, ShapeTuple rhs_shape) {
-  std::vector<int64_t> output_shape;
-  size_t ndim0 = lhs_shape.size();
-  size_t ndim1 = rhs_shape.size();
-  size_t i = 1;
-  for (; i <= std::min(ndim0, ndim1); ++i) {
-    int64_t lhs_dim = lhs_shape[ndim0 - i];
-    int64_t rhs_dim = rhs_shape[ndim1 - i];
-    if (lhs_dim == 1 || rhs_dim == 1 || lhs_dim == rhs_dim) {
-      output_shape.push_back(std::max(lhs_dim, rhs_dim));
-    } else {
-      LOG(FATAL) << "Incompatible shapes " << lhs_shape << " and " << rhs_shape
-                  << " for broadcasting";
-    }
-  }
-  size_t max_ndim = std::max(ndim0, ndim1);
-  ShapeTuple& longer_shape = (ndim0 > ndim1) ? lhs_shape : rhs_shape;
-  for (; i <= max_ndim; ++i) {
-    output_shape.push_back(longer_shape[max_ndim - i]);
-  }
-  return ShapeTuple(output_shape.rbegin(), output_shape.rend());
-});
+    .set_body_typed([](ShapeTuple lhs_shape, ShapeTuple rhs_shape) {
+      std::vector<int64_t> output_shape;
+      size_t ndim0 = lhs_shape.size();
+      size_t ndim1 = rhs_shape.size();
+      size_t i = 1;
+      for (; i <= std::min(ndim0, ndim1); ++i) {
+        int64_t lhs_dim = lhs_shape[ndim0 - i];
+        int64_t rhs_dim = rhs_shape[ndim1 - i];
+        if (lhs_dim == 1 || rhs_dim == 1 || lhs_dim == rhs_dim) {
+          output_shape.push_back(std::max(lhs_dim, rhs_dim));
+        } else {
+          LOG(FATAL) << "Incompatible shapes " << lhs_shape << " and " << rhs_shape
+                     << " for broadcasting";
+        }
+      }
+      size_t max_ndim = std::max(ndim0, ndim1);
+      ShapeTuple& longer_shape = (ndim0 > ndim1) ? lhs_shape : rhs_shape;
+      for (; i <= max_ndim; ++i) {
+        output_shape.push_back(longer_shape[max_ndim - i]);
+      }
+      return ShapeTuple(output_shape.rbegin(), output_shape.rend());
+    });
 
-TVM_REGISTER_GLOBAL("vm.call_tir_dyn")
-.set_body([](TVMArgs args, TVMRetValue* rv) {
-  void *vm_state_ptr = args[0];
+TVM_REGISTER_GLOBAL("vm.call_tir_dyn").set_body([](TVMArgs args, TVMRetValue* rv) {
+  void* vm_state_ptr = args[0];
   VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
   runtime::Module mod_ = vm_state->mod_;
 

--- a/src/relax/vm/bytecode.cc
+++ b/src/relax/vm/bytecode.cc
@@ -22,18 +22,17 @@
  * \brief The bytecode for Relax virtual machine.
  */
 
-#include <tvm/runtime/logging.h>
 #include <tvm/relax/vm/bytecode.h>
-#include <functional>
+#include <tvm/runtime/logging.h>
 
+#include <functional>
 #include <sstream>
 
 namespace tvm {
 namespace runtime {
 namespace relax_vm {
 
-Instruction Instruction::Call(Index func_idx, Index num_args, 
-                              Instruction::Arg* args, RegName dst) {
+Instruction Instruction::Call(Index func_idx, Index num_args, Instruction::Arg* args, RegName dst) {
   Instruction instr;
   instr.op = Opcode::Call;
   instr.dst = dst;

--- a/src/relax/vm/exec_builder.cc
+++ b/src/relax/vm/exec_builder.cc
@@ -85,7 +85,7 @@ void ExecBuilderNode::EmitGoto(Index pc_offset) {
 }
 
 void ExecBuilderNode::EmitIf(vm::RegName test, vm::RegName target, vm::Index true_offset,
-                             vm::Index false_offset){
+                             vm::Index false_offset) {
   exec->instr_offset.push_back(exec->instr_data.size());
   exec->instr_data.push_back(static_cast<ExecWord>(Opcode::If));
   exec->instr_data.push_back(test);
@@ -210,11 +210,9 @@ void ExecBuilderNode::Formalize() {
   }
 }
 
-TVM_REGISTER_GLOBAL("relax.ExecBuilderCreate")
-.set_body_typed(ExecBuilderNode::Create);
+TVM_REGISTER_GLOBAL("relax.ExecBuilderCreate").set_body_typed(ExecBuilderNode::Create);
 
-TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitConstant")
-.set_body([](TVMArgs args, TVMRetValue* ret) {
+TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitConstant").set_body([](TVMArgs args, TVMRetValue* ret) {
   ExecBuilder builder = args[0];
   TVMRetValue rt;
   rt = args[1];
@@ -222,45 +220,41 @@ TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitConstant")
 });
 
 TVM_REGISTER_GLOBAL("relax.ExecBuilderFunction")
-.set_body_method<ExecBuilder>(&ExecBuilderNode::EmitFunction);
+    .set_body_method<ExecBuilder>(&ExecBuilderNode::EmitFunction);
 
 TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitCall")
-.set_body_typed([](ExecBuilder builder, String name, Array<IntImm> args, int64_t dst) {
-  std::vector<Instruction::Arg> args_;
-  for (size_t i = 0; i < args.size(); ++i) {
-    args_.push_back(static_cast<Instruction::Arg>(args[i]->value));
-  }
-  Instruction::Arg dst_(dst);
-  CHECK_EQ(dst_.kind(), Instruction::ArgKind::kRegister);
-  builder->EmitCall(name, args_, dst_.value());
-});
+    .set_body_typed([](ExecBuilder builder, String name, Array<IntImm> args, int64_t dst) {
+      std::vector<Instruction::Arg> args_;
+      for (size_t i = 0; i < args.size(); ++i) {
+        args_.push_back(static_cast<Instruction::Arg>(args[i]->value));
+      }
+      Instruction::Arg dst_(dst);
+      CHECK_EQ(dst_.kind(), Instruction::ArgKind::kRegister);
+      builder->EmitCall(name, args_, dst_.value());
+    });
 
 TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitRet")
-.set_body_method<ExecBuilder>(&ExecBuilderNode::EmitRet);
+    .set_body_method<ExecBuilder>(&ExecBuilderNode::EmitRet);
 
 TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitGoto")
-.set_body_method<ExecBuilder>(&ExecBuilderNode::EmitGoto);
+    .set_body_method<ExecBuilder>(&ExecBuilderNode::EmitGoto);
 
 TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitIf")
-.set_body_method<ExecBuilder>(&ExecBuilderNode::EmitIf);
+    .set_body_method<ExecBuilder>(&ExecBuilderNode::EmitIf);
 
-TVM_REGISTER_GLOBAL("relax.ExecBuilderR")
-.set_body_typed([](ExecBuilder builder, int64_t value) {
+TVM_REGISTER_GLOBAL("relax.ExecBuilderR").set_body_typed([](ExecBuilder builder, int64_t value) {
   return Instruction::Arg(Instruction::kRegister, value).data;
 });
 
-TVM_REGISTER_GLOBAL("relax.ExecBuilderImm")
-.set_body_typed([](ExecBuilder builder, int64_t value) {
+TVM_REGISTER_GLOBAL("relax.ExecBuilderImm").set_body_typed([](ExecBuilder builder, int64_t value) {
   return Instruction::Arg(Instruction::kImmediate, value).data;
 });
 
-TVM_REGISTER_GLOBAL("relax.ExecBuilderC")
-.set_body_typed([](ExecBuilder builder, int64_t value) {
+TVM_REGISTER_GLOBAL("relax.ExecBuilderC").set_body_typed([](ExecBuilder builder, int64_t value) {
   return Instruction::Arg(Instruction::kConstIdx, value).data;
 });
 
-TVM_REGISTER_GLOBAL("relax.ExecBuilderGet")
-.set_body_method<ExecBuilder>(&ExecBuilderNode::Get);
+TVM_REGISTER_GLOBAL("relax.ExecBuilderGet").set_body_method<ExecBuilder>(&ExecBuilderNode::Get);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/vm/executable.cc
+++ b/src/relax/vm/executable.cc
@@ -269,7 +269,7 @@ void ExecutableNode::SaveConstantSection(dmlc::Stream* strm) {
     if (it.IsObjectRef<runtime::NDArray>()) {
       strm->Write(ConstantType::kNDArray);
       runtime::SaveDLTensor(strm, it.operator DLTensor*());
-    } else if (it.IsObjectRef<ShapeTuple>()){
+    } else if (it.IsObjectRef<ShapeTuple>()) {
       ShapeTuple shape = it.operator ShapeTuple();
       strm->Write(ConstantType::kShapeTuple);
       strm->Write(shape.size());
@@ -465,10 +465,8 @@ String ExecutableNode::AsText() const {
           break;
         }
         case Opcode::If: {
-          os << std::setw(6) << std::left << "If"
-             << RegNameToStr(instr.test) << ", "
-             << RegNameToStr(instr.target) << ", "
-             << instr.true_offset << ", "
+          os << std::setw(6) << std::left << "If" << RegNameToStr(instr.test) << ", "
+             << RegNameToStr(instr.target) << ", " << instr.true_offset << ", "
              << instr.false_offset << "\n";
           break;
         }
@@ -514,10 +512,8 @@ String ExecutableNode::AsPython() const {
           break;
         }
         case Opcode::If: {
-          os << "    ib.emit_if(ib.r(" << instr.test
-          << "), ib.r(" << instr.target
-          << "), " << instr.true_offset
-          << ", " << instr.false_offset << ")\n";
+          os << "    ib.emit_if(ib.r(" << instr.test << "), ib.r(" << instr.target << "), "
+             << instr.true_offset << ", " << instr.false_offset << ")\n";
           break;
         }
         default:
@@ -531,26 +527,17 @@ String ExecutableNode::AsPython() const {
 
 TVM_REGISTER_GLOBAL("relax.Executable").set_body_typed([]() { return Executable(); });
 
-TVM_REGISTER_GLOBAL("relax.ExecutableStats").set_body_typed([](Executable exec) {
-  return exec->Stats();
-});
+TVM_REGISTER_GLOBAL("relax.ExecutableStats").set_body_method<Executable>(&ExecutableNode::Stats);
 
-TVM_REGISTER_GLOBAL("relax.ExecutableAsText").set_body_typed([](Executable exec) {
-  return exec->AsText();
-});
+TVM_REGISTER_GLOBAL("relax.ExecutableAsText").set_body_method<Executable>(&ExecutableNode::AsText);
 
-TVM_REGISTER_GLOBAL("relax.ExecutableAsPython").set_body_typed([](Executable exec) {
-  return exec->AsPython();
-});
+TVM_REGISTER_GLOBAL("relax.ExecutableAsPython")
+    .set_body_method<Executable>(&ExecutableNode::AsPython);
 
 TVM_REGISTER_GLOBAL("relax.ExecutableSaveToFile")
-    .set_body_typed([](Executable exec, std::string file_name) {
-      exec->SaveToFile(file_name);
-    });
+    .set_body_method<Executable>(&ExecutableNode::SaveToFile);
 
-TVM_REGISTER_GLOBAL("relax.ExecutableLoadFromFile").set_body_typed([](std::string file_name) {
-  return ExecutableNode::LoadFromFile(file_name);
-});
+TVM_REGISTER_GLOBAL("relax.ExecutableLoadFromFile").set_body_typed(ExecutableNode::LoadFromFile);
 
 }  // namespace relax_vm
 }  // namespace runtime

--- a/src/relax/vm/memory_manager.cc
+++ b/src/relax/vm/memory_manager.cc
@@ -76,7 +76,7 @@ inline size_t GetDataAlignment(const DLTensor& arr) {
   return align;
 }
 
-runtime::NDArray StorageObj::AllocNDArray(ShapeTuple shape, size_t offset, DLDataType dtype) {
+runtime::NDArray StorageObj::AllocNDArray(size_t offset, ShapeTuple shape, DLDataType dtype) {
   VerifyDataType(dtype);
 
   // critical zone: allocate header, cannot throw

--- a/src/relax/vm/memory_manager.cc
+++ b/src/relax/vm/memory_manager.cc
@@ -76,10 +76,10 @@ inline size_t GetDataAlignment(const DLTensor& arr) {
   return align;
 }
 
-runtime::NDArray StorageObj::AllocNDArray(size_t offset, ShapeTuple shape, DLDataType dtype) {
+runtime::NDArray StorageObj::AllocNDArray(ShapeTuple shape, size_t offset, DLDataType dtype) {
   VerifyDataType(dtype);
 
-  // crtical zone: allocate header, cannot throw
+  // critical zone: allocate header, cannot throw
   runtime::NDArray::Container* container =
       new runtime::NDArray::Container(nullptr, shape, dtype, this->buffer.device);
 

--- a/src/relax/vm/vm.cc
+++ b/src/relax/vm/vm.cc
@@ -214,7 +214,7 @@ TVM_REGISTER_GLOBAL("relax.VirtualMachine")
       return CreateVirtualMachine(exec, mod);
     });
 
-// initilize the VirtualMachine, takes variable-length arguments
+// initialize the VirtualMachine, takes variable-length arguments
 // first argument is a runtime::Module, followed by one or more device_type, device_id,
 // and the AllocatorType associated with the device.
 TVM_REGISTER_GLOBAL("relax.VirtualMachineInit").set_body([](TVMArgs args, TVMRetValue* rv) {

--- a/src/relay/ir/base.cc
+++ b/src/relay/ir/base.cc
@@ -39,9 +39,7 @@ Id::Id(String name_hint) {
   data_ = std::move(n);
 }
 
-TVM_REGISTER_GLOBAL("relay.ir.Id").set_body_typed([](String name_hint) {
-  return Id(name_hint);
-});
+TVM_REGISTER_GLOBAL("relay.ir.Id").set_body_typed([](String name_hint) { return Id(name_hint); });
 
 TVM_REGISTER_GLOBAL("ir.NodeSetSpan").set_body_typed([](ObjectRef node_ref, Span sp) {
   if (auto* rn = node_ref.as<RelayNode>()) {

--- a/src/runtime/hexagon/android/sim/hexagon_device_sim.cc
+++ b/src/runtime/hexagon/android/sim/hexagon_device_sim.cc
@@ -121,7 +121,7 @@ struct non_const_str {
     ICHECK_EQ(pointers_.size(), 1);
     return pointers_[0];
   }
-  operator char**() { return pointers_.data(); }
+  operator char* *() { return pointers_.data(); }
 
  private:
   std::vector<char*> pointers_;

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -235,7 +235,8 @@ Stmt GenerateStmtFromExternOp(const te::ExternOp& extern_op, CreateFuncInfo* inf
 }
 
 /*! \brief Use Tensor Expression to create a schedulable TensorIR func. */
-PrimFunc CreatePrimFunc(const Array<te::Tensor>& arg_list, const Optional<Array<tir::Var>> tir_var_list) {
+PrimFunc CreatePrimFunc(const Array<te::Tensor>& arg_list,
+                        const Optional<Array<tir::Var>> tir_var_list) {
   // Step 1. Create tensor read graph.
   Array<te::Operation> arg_ops;
   for (const te::Tensor& arg : arg_list) {
@@ -293,7 +294,7 @@ PrimFunc CreatePrimFunc(const Array<te::Tensor>& arg_list, const Optional<Array<
 
   // add additional arguments for tir vars that are left unbound by match buffer
   if (tir_var_list) {
-    for (const Var& v: tir_var_list.value()) {
+    for (const Var& v : tir_var_list.value()) {
       parameters.push_back(v);
     }
   }

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -133,7 +133,7 @@ def test_vm_constant_serialize():
             "vm.builtin.alloc_storage", args=[ib.vm_state(), (24,), ib.imm(1), dtype], dst=ib.r(1)
         )
         ib.emit_call(
-            "vm.builtin.alloc_tensor", args=[ib.r(1), shape, ib.imm(0), dtype], dst=ib.r(2)
+            "vm.builtin.alloc_tensor", args=[ib.r(1), ib.imm(0), shape, dtype], dst=ib.r(2)
         )
         ib.emit_call("test.vm.identity", args=[ib.r(0), ib.r(2)])
         ib.emit_ret(ib.r(2))
@@ -227,7 +227,7 @@ def test_vm_storage():
             "vm.builtin.alloc_storage", args=[ib.vm_state(), (24,), ib.imm(1), dtype], dst=ib.r(1)
         )
         ib.emit_call(
-            "vm.builtin.alloc_tensor", args=[ib.r(1), shape, ib.imm(0), dtype], dst=ib.r(2)
+            "vm.builtin.alloc_tensor", args=[ib.r(1), ib.imm(0), shape, dtype], dst=ib.r(2)
         )
         ib.emit_ret(ib.r(2))
     ex = ib.get()
@@ -257,7 +257,7 @@ def test_vm_goto():
         )
     )
     res = vm["main"](a, b)
-    np.testing.assert_allclose(res.asnumpy(), a.asnumpy() + b.asnumpy())
+    np.testing.assert_allclose(res.numpy(), a.numpy() + b.numpy())
 
 
 def test_vm_if():
@@ -281,9 +281,9 @@ def test_vm_if():
         )
     )
     res = vm["main"](True, False, a, b)
-    np.testing.assert_allclose(res.asnumpy(), a.asnumpy() * b.asnumpy())
+    np.testing.assert_allclose(res.numpy(), a.numpy() * b.numpy())
     res = vm["main"](1, 1, a, b)
-    np.testing.assert_allclose(res.asnumpy(), a.asnumpy() + b.asnumpy())
+    np.testing.assert_allclose(res.numpy(), a.numpy() + b.numpy())
 
 
 def test_vm_compile_stage0():
@@ -604,7 +604,7 @@ def test_vm_relax_dyn_tir_shape():
 
     res = vm["rx_func"](inp, inp2)
 
-    np.testing.assert_allclose(res.asnumpy(), inp2.asnumpy())
+    np.testing.assert_allclose(res.numpy(), inp2.numpy())
     os.remove("exec.tmp")
 
 


### PR DESCRIPTION
This PR simplifies the usage of `TVM_REGISTER_GLOBAL` by using `set_body_method<>` when possible. My editor seems to do clang-format upon save so it comes with some formatting stuff too.

CC: @YuchenJin 