### PR TITLE
[Refactor] Disallow direct construction of `Binding`

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -197,9 +197,15 @@ class BindingNode : public Object {
 };
 
 class Binding : public ObjectRef {
+ protected:
+  Binding() = default;
+
  public:
-  TVM_DLL explicit Binding(Span span);
-  TVM_DEFINE_OBJECT_REF_METHODS(Binding, ObjectRef, BindingNode);
+  explicit Binding(ObjectPtr<Object> n) : ObjectRef(n) {}
+  TVM_DEFINE_DEFAULT_COPY_MOVE_AND_ASSIGN(Binding);
+  const BindingNode* operator->() const { return static_cast<const BindingNode*>(data_.get()); }
+  const BindingNode* get() const { return operator->(); }
+  using ContainerType = BindingNode;
 };
 
 /*! \brief Symbolic shape match, binds the variables of the LHS with the rhs. */

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -97,8 +97,7 @@ class DataflowVar(Var):
 
 @tvm._ffi.register_object("relax.expr.Binding")
 class Binding(Node):
-    def __init__(self, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.Binding, span)
+    ...
 
 
 @tvm._ffi.register_object("relax.expr.MatchShape")

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -85,15 +85,7 @@ TVM_REGISTER_GLOBAL("relax.DataflowVar")
       return DataflowVar(name_hint, shape_annotation, type_annotation, span);
     });
 
-Binding::Binding(Span span) {
-  ObjectPtr<BindingNode> n = make_object<BindingNode>();
-  n->span = span;
-  data_ = std::move(n);
-}
-
 TVM_REGISTER_NODE_TYPE(BindingNode);
-
-TVM_REGISTER_GLOBAL("relax.Binding").set_body_typed([](Span span) { return Binding(span); });
 
 TVM_REGISTER_NODE_TYPE(MatchShapeNode);
 


### PR DESCRIPTION
`BindingNode` is treated as an intermediate abstract class in our design, so we should disallow constructing it directly