### PR TITLE
[BlockBuilder] Avoid generating duplicated PrimFunc

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -141,6 +141,22 @@ class BlockBuilderNode : public Object {
    */
   NameTable* name_table();
 
+  /*!
+   * \brief Add a Relax function or a TIR PrimFunc to \p context_mod_.
+   * \param func The function to be added.
+   * \param func_name The name of the function to be added.
+   * \note If the function to be added already exists in \p context_mod_, return its
+   * GlobalVar directly.
+   * \return The global var bound to the added function.
+   */
+  GlobalVar AddFunc(const BaseFunc& func, const std::string& func_name);
+
+  /*!
+   * \brief Get the context IRModule being built.
+   * \return The IRModule being built by BlockBuilder.
+   */
+  IRModule GetIRModule() const;
+
   void VisitAttrs(AttrVisitor* v) {}
 
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
@@ -149,6 +165,15 @@ class BlockBuilderNode : public Object {
 
  private:
   Var Emit(const Expr& expr, bool is_dataflow, std::string name_hint);
+
+  /*! \brief The IRModule being built by the BlockBuilder. */
+  IRModule context_mod_;
+
+  /*!
+   * \brief A hashmap to store the mapping of Relax functions and TIR PrimFuncs
+   * in \p _context_mod to their GlobalVar to avoid generating duplicated functions.
+   */
+  std::unordered_map<BaseFunc, GlobalVar, StructuralHash, StructuralEqual> func_map_;
 
  protected:
   /*!

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -149,13 +149,13 @@ class BlockBuilderNode : public Object {
    * GlobalVar directly.
    * \return The global var bound to the added function.
    */
-  GlobalVar AddFunc(const BaseFunc& func, const std::string& func_name);
+  GlobalVar AddFuncToContext(const BaseFunc& func, const String& func_name);
 
   /*!
    * \brief Get the context IRModule being built.
    * \return The IRModule being built by BlockBuilder.
    */
-  IRModule GetIRModule() const;
+  IRModule GetContextIRModule() const;
 
   void VisitAttrs(AttrVisitor* v) {}
 

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -528,7 +528,7 @@ class BlockBuilder(Object):
         ret : tvm.IRModule
             An IRModule with Relax and TIR functions being built.
         """
-        return _ffi_api.BlockBuilderGetIRModule(self)
+        return _ffi_api.BlockBuilderGetContextIRModule(self)
 
     def get_unique_name(self, name_prefix: str) -> str:
         """Generate a unique name with a specified prefix.
@@ -561,4 +561,4 @@ class BlockBuilder(Object):
         gvar : GlobalVar
             The global var bound to the added function.
         """
-        return _ffi_api.BlockBuilderAddFunc(self, func, func_name)
+        return _ffi_api.BlockBuilderAddFuncToContext(self, func, func_name)

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -541,8 +541,8 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderEndBlock")
 TVM_REGISTER_GLOBAL("relax.BlockBuilderNormalize")
     .set_body_method<BlockBuilder>(&BlockBuilderNode::Normalize);
 
-TVM_REGISTER_GLOBAL("relax.BlockBuilderEmit").set_body_typed([](BlockBuilder builder, Call call) {
-  return builder->Emit(call);
+TVM_REGISTER_GLOBAL("relax.BlockBuilderEmit").set_body_typed([](BlockBuilder builder, Expr expr) {
+  return builder->Emit(expr);
 });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitMatchShape")

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -526,7 +526,7 @@ BlockBuilderNode::BlockFrame* BlockBuilderNode::CurrentFrame() {
 
 NameTable* BlockBuilderNode::name_table() { return name_table_.get(); }
 
-GlobalVar BlockBuilderNode::AddFunc(const BaseFunc& func, const std::string& func_name) {
+GlobalVar BlockBuilderNode::AddFuncToContext(const BaseFunc& func, const String& func_name) {
   auto it = func_map_.find(func);
   if (it == func_map_.end()) {
     GlobalVar gvar = GlobalVar(func_name);
@@ -544,7 +544,7 @@ GlobalVar BlockBuilderNode::AddFunc(const BaseFunc& func, const std::string& fun
   }
 }
 
-IRModule BlockBuilderNode::GetIRModule() const { return context_mod_; }
+IRModule BlockBuilderNode::GetContextIRModule() const { return context_mod_; }
 
 BlockBuilder BlockBuilder::Create() { return BlockBuilder(make_object<BlockBuilderNode>()); }
 
@@ -581,11 +581,11 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderGetUniqueName")
       return builder->name_table()->GetUniqueName(name_hint);
     });
 
-TVM_REGISTER_GLOBAL("relax.BlockBuilderAddFunc")
-    .set_body_method<BlockBuilder>(&BlockBuilderNode::AddFunc);
+TVM_REGISTER_GLOBAL("relax.BlockBuilderAddFuncToContext")
+    .set_body_method<BlockBuilder>(&BlockBuilderNode::AddFuncToContext);
 
-TVM_REGISTER_GLOBAL("relax.BlockBuilderGetIRModule")
-    .set_body_method<BlockBuilder>(&BlockBuilderNode::GetIRModule);
+TVM_REGISTER_GLOBAL("relax.BlockBuilderGetContextIRModule")
+    .set_body_method<BlockBuilder>(&BlockBuilderNode::GetContextIRModule);
 
 }  // namespace relax
 }  // namespace tvm


### PR DESCRIPTION
Add `context_mod_` and hashmap `func_map_` to BlockBuilder context. `func_map_` is to avoid generating duplicated functions (Relax Function/TIR Primfunc) using `StructuralHash` and `StructuralEqual`.

cc @hypercubestart @junrushao1994