### PR TITLE
[VM] Add control flow in VmCodeGen, add vm.builtin.copy

### DIFF
--- a/include/tvm/relax/vm/bytecode.h
+++ b/include/tvm/relax/vm/bytecode.h
@@ -140,7 +140,7 @@ struct Instruction {
       /*! \brief The register containing the cond value. */
       RegName cond;
       /*! \brief The program counter offset for the false branch. */
-      Index offset;
+      Index false_offset;
     };
   };
   /*!
@@ -167,7 +167,7 @@ struct Instruction {
   /*!
    * \brief Construct an If instruction.
    * \param cond The register containing the cond value.
-   * \param offset The program counter offset for the false branch.
+   * \param false_offset The program counter offset for the false branch.
    * \return The If instruction.
    */
   static Instruction If(RegName cond, Index false_offset);

--- a/include/tvm/relax/vm/bytecode.h
+++ b/include/tvm/relax/vm/bytecode.h
@@ -139,10 +139,8 @@ struct Instruction {
     struct /* If */ {
       /*! \brief The register containing the cond value. */
       RegName cond;
-      /*! \brief The program counter offset for the true branch. */
-      Index true_offset;
       /*! \brief The program counter offset for the false branch. */
-      Index false_offset;
+      Index offset;
     };
   };
   /*!
@@ -169,11 +167,10 @@ struct Instruction {
   /*!
    * \brief Construct an If instruction.
    * \param cond The register containing the cond value.
-   * \param true_offset The program counter offset for the true branch.
-   * \param false_offset The program counter offset for the false branch.
+   * \param offset The program counter offset for the false branch.
    * \return The If instruction.
    */
-  static Instruction If(RegName cond, Index true_offset, Index false_offset);
+  static Instruction If(RegName cond, Index false_offset);
 };
 
 }  // namespace relax_vm

--- a/include/tvm/relax/vm/bytecode.h
+++ b/include/tvm/relax/vm/bytecode.h
@@ -137,10 +137,8 @@ struct Instruction {
       Index pc_offset;
     };
     struct /* If */ {
-      /*! \brief The register containing the test value. */
-      RegName test;
-      /*! \brief The register containing the target value. */
-      RegName target;
+      /*! \brief The register containing the cond value. */
+      RegName cond;
       /*! \brief The program counter offset for the true branch. */
       Index true_offset;
       /*! \brief The program counter offset for the false branch. */
@@ -170,13 +168,12 @@ struct Instruction {
   static Instruction Goto(RegName pc_offset);
   /*!
    * \brief Construct an If instruction.
-   * \param test The register containing the test value.
-   * \param target The register containing the target value.
+   * \param cond The register containing the cond value.
    * \param true_offset The program counter offset for the true branch.
    * \param false_offset The program counter offset for the false branch.
    * \return The If instruction.
    */
-  static Instruction If(RegName test, RegName target, Index true_offset, Index false_offset);
+  static Instruction If(RegName cond, Index true_offset, Index false_offset);
 };
 
 }  // namespace relax_vm

--- a/include/tvm/relax/vm/exec_builder.h
+++ b/include/tvm/relax/vm/exec_builder.h
@@ -76,10 +76,9 @@ class ExecBuilderNode : public Object {
   /*!
    * \brief Emit an If instruction.
    * \param cond The register containing the cond value.
-   * \param true_offset The program counter offset for the true branch.
-   * \param false_offset The program counter offset for the false branch.
+   * \param offset The program counter offset for the false branch.
    */
-  void EmitIf(vm::RegName cond, vm::Index true_offset, vm::Index false_offset);
+  void EmitIf(vm::RegName cond, vm::Index offset);
   /*!
    * \brief Emit a constant value to the constant pool.
    * \return The index that represents the constant.

--- a/include/tvm/relax/vm/exec_builder.h
+++ b/include/tvm/relax/vm/exec_builder.h
@@ -76,9 +76,9 @@ class ExecBuilderNode : public Object {
   /*!
    * \brief Emit an If instruction.
    * \param cond The register containing the cond value.
-   * \param offset The program counter offset for the false branch.
+   * \param false_offset The program counter offset for the false branch.
    */
-  void EmitIf(vm::RegName cond, vm::Index offset);
+  void EmitIf(vm::RegName cond, vm::Index false_offset);
   /*!
    * \brief Emit a constant value to the constant pool.
    * \return The index that represents the constant.

--- a/include/tvm/relax/vm/exec_builder.h
+++ b/include/tvm/relax/vm/exec_builder.h
@@ -75,12 +75,11 @@ class ExecBuilderNode : public Object {
   void EmitGoto(vm::Index pc_offset);
   /*!
    * \brief Emit an If instruction.
-   * \param test The register containing the test value.
-   * \param target The register containing the target value.
+   * \param cond The register containing the cond value.
    * \param true_offset The program counter offset for the true branch.
    * \param false_offset The program counter offset for the false branch.
    */
-  void EmitIf(vm::RegName test, vm::RegName target, vm::Index true_offset, vm::Index false_offset);
+  void EmitIf(vm::RegName cond, vm::Index true_offset, vm::Index false_offset);
   /*!
    * \brief Emit a constant value to the constant pool.
    * \return The index that represents the constant.

--- a/include/tvm/relax/vm/executable.h
+++ b/include/tvm/relax/vm/executable.h
@@ -76,8 +76,8 @@ class ExecutableNode : public Object {
    */
   Instruction GetInstruction(Index i) const;
   /*!
-  * \brief Set j-th byte data of i-th instruction to val.
-  */
+   * \brief Set j-th byte data of i-th instruction to val.
+   */
   void SetInstructionData(Index i, Index j, ExecWord val);
   /*!
    * \brief Print the instructions as text format.

--- a/include/tvm/relax/vm/executable.h
+++ b/include/tvm/relax/vm/executable.h
@@ -76,6 +76,10 @@ class ExecutableNode : public Object {
    */
   Instruction GetInstruction(Index i) const;
   /*!
+  * \brief Set j-th byte data of i-th instruction to val.
+  */
+  void SetInstructionData(Index i, Index j, ExecWord val);
+  /*!
    * \brief Print the instructions as text format.
    */
   String AsText() const;

--- a/python/tvm/relax/exec_builder.py
+++ b/python/tvm/relax/exec_builder.py
@@ -117,10 +117,10 @@ class ExecBuilder(Object):
         self._check_scope()
         _ffi_api.ExecBuilderEmitGoto(self, pc_offset)
 
-    def emit_if(self, cond, offset):
+    def emit_if(self, cond, false_offset):
         """emit an if instruction"""
         self._check_scope()
-        _ffi_api.ExecBuilderEmitIf(self, cond, offset)
+        _ffi_api.ExecBuilderEmitIf(self, cond, false_offset)
 
     def get(self) -> Executable:
         """return the executable"""

--- a/python/tvm/relax/exec_builder.py
+++ b/python/tvm/relax/exec_builder.py
@@ -117,10 +117,10 @@ class ExecBuilder(Object):
         self._check_scope()
         _ffi_api.ExecBuilderEmitGoto(self, pc_offset)
 
-    def emit_if(self, cond, true_offset, false_offset):
+    def emit_if(self, cond, offset):
         """emit an if instruction"""
         self._check_scope()
-        _ffi_api.ExecBuilderEmitIf(self, cond, true_offset, false_offset)
+        _ffi_api.ExecBuilderEmitIf(self, cond, offset)
 
     def get(self) -> Executable:
         """return the executable"""

--- a/python/tvm/relax/exec_builder.py
+++ b/python/tvm/relax/exec_builder.py
@@ -117,10 +117,10 @@ class ExecBuilder(Object):
         self._check_scope()
         _ffi_api.ExecBuilderEmitGoto(self, pc_offset)
 
-    def emit_if(self, test, target, true_offset, false_offset):
+    def emit_if(self, cond, true_offset, false_offset):
         """emit an if instruction"""
         self._check_scope()
-        _ffi_api.ExecBuilderEmitIf(self, test, target, true_offset, false_offset)
+        _ffi_api.ExecBuilderEmitIf(self, cond, true_offset, false_offset)
 
     def get(self) -> Executable:
         """return the executable"""

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -138,7 +138,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     Instruction::Arg true_reg = this->VisitExpr(ife->true_branch);
     // Reserve a register for return
     size_t merge_register = NewRegister();
-    // Copy the output from if branch to merge register
+    // Copy the output from true branch to merge register
     builder_->EmitCall("vm.builtin.copy", {true_reg}, merge_register);
 
     // Record the offset of Goto instruction
@@ -150,14 +150,14 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     size_t false_offset = exec_->instr_offset.size() - num_instr + 1;
 
     Instruction::Arg false_reg = this->VisitExpr(ife->false_branch);
-    // Copy the output data of else branch to merge register
+    // Copy the output data of false branch to merge register
     builder_->EmitCall("vm.builtin.copy", {false_reg}, merge_register);
 
-    // Update the offsets of the If instruction emmited above
+    // Update the offsets of the If instruction emitted above
     // Jump to the behind of the next goto instruction
     exec_->SetInstructionData(if_offset, 2, static_cast<ExecWord>(false_offset));
     // Update the pc_offset of Goto instruction
-    // Jump over the else-then branch
+    // Jump over the false branch
     size_t pc_offset = exec_->instr_offset.size() - goto_offset;
     exec_->SetInstructionData(goto_offset, 1, static_cast<ExecWord>(pc_offset));
     return Instruction::Arg(Instruction::kRegister, merge_register);

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -133,7 +133,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     // Record the offset of If instruction
     size_t if_offset = exec_->instr_offset.size();
 
-    builder_->EmitIf(cond_reg.value(), 1, 3);
+    builder_->EmitIf(cond_reg.value(), 3);
     size_t num_instr = exec_->instr_offset.size();
     Instruction::Arg true_reg = this->VisitExpr(ife->true_branch);
     // Reserve a register for return
@@ -155,7 +155,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
 
     // Update the offsets of the If instruction emmited above
     // Jump to the behind of the next goto instruction
-    exec_->SetInstructionData(if_offset, 3, static_cast<ExecWord>(false_offset));
+    exec_->SetInstructionData(if_offset, 2, static_cast<ExecWord>(false_offset));
     // Update the pc_offset of Goto instruction
     // Jump over the else-then branch
     size_t pc_offset = exec_->instr_offset.size() - goto_offset;

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -95,8 +95,12 @@ class VMShapeLowerMutator : public ExprMutator {
         shape_heap_, Call(ExternFunc("vm.builtin.alloc_shape_heap"), {ShapeExpr({heap_size_})})));
     for (Var param : node->params) {
       if (param->shape_.operator bool() && param->shape_.value().as<ShapeExprNode>()) {
-        Var shape = builder_->Emit(Call(ExternFunc("vm.builtin.shape_of"), {param}), "sh");
-        StoreShape(shape, Downcast<ShapeExpr>(param->shape_.value())->values);
+        if (auto *param_type = param->checked_type_.as<DynTensorTypeNode>()) {
+          if (param_type->rank != 0) {
+            Var shape = builder_->Emit(Call(ExternFunc("vm.builtin.shape_of"), {param}), "sh");
+            StoreShape(shape, Downcast<ShapeExpr>(param->shape_.value())->values);
+          }
+        }
       }
     }
     Type ret_type = this->VisitType(node->ret_type);
@@ -197,7 +201,6 @@ class VMShapeLowerMutator : public ExprMutator {
  private:
   IRModule mod_;
   IRModule ret_mod_;
-  int shape_func_counter_{0};
 
   // function-wise members
   IntImm heap_size_;

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -95,7 +95,7 @@ class VMShapeLowerMutator : public ExprMutator {
         shape_heap_, Call(ExternFunc("vm.builtin.alloc_shape_heap"), {ShapeExpr({heap_size_})})));
     for (Var param : node->params) {
       if (param->shape_.operator bool() && param->shape_.value().as<ShapeExprNode>()) {
-        if (auto *param_type = param->checked_type_.as<DynTensorTypeNode>()) {
+        if (auto* param_type = param->checked_type_.as<DynTensorTypeNode>()) {
           if (param_type->rank != 0) {
             Var shape = builder_->Emit(Call(ExternFunc("vm.builtin.shape_of"), {param}), "sh");
             StoreShape(shape, Downcast<ShapeExpr>(param->shape_.value())->values);

--- a/src/relax/vm/builtin.cc
+++ b/src/relax/vm/builtin.cc
@@ -40,9 +40,7 @@ using tvm::runtime::NDArray;
 
 TVM_REGISTER_GLOBAL("vm.builtin.shape_of").set_body_method(&NDArray::Shape);
 
-TVM_REGISTER_GLOBAL("vm.builtin.copy").set_body_typed([](NDArray src) {
-  return src;
-});
+TVM_REGISTER_GLOBAL("vm.builtin.copy").set_body_typed([](NDArray src) { return src; });
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_shape_heap").set_body_typed([](ShapeTuple size) {
   return NDArray::Empty(size, DLDataType{kDLInt, 64, 1}, DLDevice{kDLCPU, 0});

--- a/src/relax/vm/builtin.cc
+++ b/src/relax/vm/builtin.cc
@@ -40,6 +40,10 @@ using tvm::runtime::NDArray;
 
 TVM_REGISTER_GLOBAL("vm.builtin.shape_of").set_body_method(&NDArray::Shape);
 
+TVM_REGISTER_GLOBAL("vm.builtin.copy").set_body_typed([](NDArray src) {
+  return src;
+});
+
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_shape_heap").set_body_typed([](ShapeTuple size) {
   return NDArray::Empty(size, DLDataType{kDLInt, 64, 1}, DLDevice{kDLCPU, 0});
 });

--- a/src/relax/vm/bytecode.cc
+++ b/src/relax/vm/bytecode.cc
@@ -56,11 +56,11 @@ Instruction Instruction::Goto(Index pc_offset) {
   return instr;
 }
 
-Instruction Instruction::If(RegName cond, Index offset) {
+Instruction Instruction::If(RegName cond, Index false_offset) {
   Instruction instr;
   instr.op = Opcode::If;
   instr.cond = cond;
-  instr.offset = offset;
+  instr.false_offset = false_offset;
   return instr;
 }
 }  // namespace relax_vm

--- a/src/relax/vm/bytecode.cc
+++ b/src/relax/vm/bytecode.cc
@@ -56,11 +56,10 @@ Instruction Instruction::Goto(Index pc_offset) {
   return instr;
 }
 
-Instruction Instruction::If(RegName test, RegName target, Index true_branch, Index false_branch) {
+Instruction Instruction::If(RegName cond, Index true_branch, Index false_branch) {
   Instruction instr;
   instr.op = Opcode::If;
-  instr.test = test;
-  instr.target = target;
+  instr.cond = cond;
   instr.true_offset = true_branch;
   instr.false_offset = false_branch;
   return instr;

--- a/src/relax/vm/bytecode.cc
+++ b/src/relax/vm/bytecode.cc
@@ -56,12 +56,11 @@ Instruction Instruction::Goto(Index pc_offset) {
   return instr;
 }
 
-Instruction Instruction::If(RegName cond, Index true_branch, Index false_branch) {
+Instruction Instruction::If(RegName cond, Index offset) {
   Instruction instr;
   instr.op = Opcode::If;
   instr.cond = cond;
-  instr.true_offset = true_branch;
-  instr.false_offset = false_branch;
+  instr.offset = offset;
   return instr;
 }
 }  // namespace relax_vm

--- a/src/relax/vm/exec_builder.cc
+++ b/src/relax/vm/exec_builder.cc
@@ -84,11 +84,11 @@ void ExecBuilderNode::EmitGoto(Index pc_offset) {
   exec->instr_data.push_back(pc_offset);
 }
 
-void ExecBuilderNode::EmitIf(vm::RegName cond, vm::Index offset) {
+void ExecBuilderNode::EmitIf(vm::RegName cond, vm::Index false_offset) {
   exec->instr_offset.push_back(exec->instr_data.size());
   exec->instr_data.push_back(static_cast<ExecWord>(Opcode::If));
   exec->instr_data.push_back(cond);
-  exec->instr_data.push_back(offset);
+  exec->instr_data.push_back(false_offset);
 }
 
 // helper function to check if an executable is legal by checking if registers are used properly
@@ -138,7 +138,7 @@ bool CheckExecutable(Executable exec) {
           break;
         }
         case Opcode::If: {
-          ICHECK_GT(instr.offset, 0);
+          ICHECK_GT(instr.false_offset, 1);
           arg_registers.emplace(instr.cond);
           break;
         }

--- a/src/relax/vm/exec_builder.cc
+++ b/src/relax/vm/exec_builder.cc
@@ -84,7 +84,7 @@ void ExecBuilderNode::EmitGoto(Index pc_offset) {
   exec->instr_data.push_back(pc_offset);
 }
 
-void ExecBuilderNode::EmitIf(vm::RegName cond, vm::Index true_offset, vm::Index false_offset){
+void ExecBuilderNode::EmitIf(vm::RegName cond, vm::Index true_offset, vm::Index false_offset) {
   exec->instr_offset.push_back(exec->instr_data.size());
   exec->instr_data.push_back(static_cast<ExecWord>(Opcode::If));
   exec->instr_data.push_back(cond);
@@ -135,7 +135,7 @@ bool CheckExecutable(Executable exec) {
           break;
         }
         case Opcode::Goto: {
-          ICHECK_GT(instr.pc_offset, 0);
+          ICHECK_NE(instr.pc_offset, 0);
           break;
         }
         case Opcode::If: {

--- a/src/relax/vm/exec_builder.cc
+++ b/src/relax/vm/exec_builder.cc
@@ -84,12 +84,10 @@ void ExecBuilderNode::EmitGoto(Index pc_offset) {
   exec->instr_data.push_back(pc_offset);
 }
 
-void ExecBuilderNode::EmitIf(vm::RegName test, vm::RegName target, vm::Index true_offset,
-                             vm::Index false_offset) {
+void ExecBuilderNode::EmitIf(vm::RegName cond, vm::Index true_offset, vm::Index false_offset){
   exec->instr_offset.push_back(exec->instr_data.size());
   exec->instr_data.push_back(static_cast<ExecWord>(Opcode::If));
-  exec->instr_data.push_back(test);
-  exec->instr_data.push_back(target);
+  exec->instr_data.push_back(cond);
   exec->instr_data.push_back(true_offset);
   exec->instr_data.push_back(false_offset);
 }
@@ -143,8 +141,7 @@ bool CheckExecutable(Executable exec) {
         case Opcode::If: {
           ICHECK_GT(instr.true_offset, 0);
           ICHECK_GT(instr.false_offset, 0);
-          arg_registers.emplace(instr.test);
-          arg_registers.emplace(instr.target);
+          arg_registers.emplace(instr.cond);
           break;
         }
         default:

--- a/src/relax/vm/exec_builder.cc
+++ b/src/relax/vm/exec_builder.cc
@@ -84,12 +84,11 @@ void ExecBuilderNode::EmitGoto(Index pc_offset) {
   exec->instr_data.push_back(pc_offset);
 }
 
-void ExecBuilderNode::EmitIf(vm::RegName cond, vm::Index true_offset, vm::Index false_offset) {
+void ExecBuilderNode::EmitIf(vm::RegName cond, vm::Index offset) {
   exec->instr_offset.push_back(exec->instr_data.size());
   exec->instr_data.push_back(static_cast<ExecWord>(Opcode::If));
   exec->instr_data.push_back(cond);
-  exec->instr_data.push_back(true_offset);
-  exec->instr_data.push_back(false_offset);
+  exec->instr_data.push_back(offset);
 }
 
 // helper function to check if an executable is legal by checking if registers are used properly
@@ -139,8 +138,7 @@ bool CheckExecutable(Executable exec) {
           break;
         }
         case Opcode::If: {
-          ICHECK_GT(instr.true_offset, 0);
-          ICHECK_GT(instr.false_offset, 0);
+          ICHECK_GT(instr.offset, 0);
           arg_registers.emplace(instr.cond);
           break;
         }

--- a/src/relax/vm/executable.cc
+++ b/src/relax/vm/executable.cc
@@ -143,11 +143,10 @@ Instruction ExecutableNode::GetInstruction(Index i) const {
       return Instruction::Goto(pc_offset);
     }
     case Opcode::If: {
-      RegName test = instr_data[offset + 1];
-      RegName target = instr_data[offset + 2];
-      Index true_branch = instr_data[offset + 3];
-      Index false_branch = instr_data[offset + 4];
-      return Instruction::If(test, target, true_branch, false_branch);
+      RegName cond = instr_data[offset + 1];
+      Index true_branch = instr_data[offset + 2];
+      Index false_branch = instr_data[offset + 3];
+      return Instruction::If(cond, true_branch, false_branch);
     }
     default:
       LOG(FATAL) << "should never hit this case: " << static_cast<int>(op);
@@ -465,9 +464,8 @@ String ExecutableNode::AsText() const {
           break;
         }
         case Opcode::If: {
-          os << std::setw(6) << std::left << "If" << RegNameToStr(instr.test) << ", "
-             << RegNameToStr(instr.target) << ", " << instr.true_offset << ", "
-             << instr.false_offset << "\n";
+          os << std::setw(6) << std::left << "If" << RegNameToStr(instr.cond) << ", "
+             << instr.true_offset << ", " << instr.false_offset << "\n";
           break;
         }
         default:
@@ -512,7 +510,7 @@ String ExecutableNode::AsPython() const {
           break;
         }
         case Opcode::If: {
-          os << "    ib.emit_if(ib.r(" << instr.test << "), ib.r(" << instr.target << "), "
+          os << "    ib.emit_if(ib.r(" << instr.cond << "), "
              << instr.true_offset << ", " << instr.false_offset << ")\n";
           break;
         }

--- a/src/relax/vm/executable.cc
+++ b/src/relax/vm/executable.cc
@@ -149,9 +149,8 @@ Instruction ExecutableNode::GetInstruction(Index i) const {
     }
     case Opcode::If: {
       RegName cond = instr_data[offset + 1];
-      Index true_branch = instr_data[offset + 2];
-      Index false_branch = instr_data[offset + 3];
-      return Instruction::If(cond, true_branch, false_branch);
+      Index false_branch = instr_data[offset + 2];
+      return Instruction::If(cond, false_branch);
     }
     default:
       LOG(FATAL) << "should never hit this case: " << static_cast<int>(op);
@@ -470,7 +469,7 @@ String ExecutableNode::AsText() const {
         }
         case Opcode::If: {
           os << std::setw(6) << std::left << "If" << RegNameToStr(instr.cond) << ", "
-             << instr.true_offset << ", " << instr.false_offset << "\n";
+             << instr.offset << "\n";
           break;
         }
         default:
@@ -515,8 +514,7 @@ String ExecutableNode::AsPython() const {
           break;
         }
         case Opcode::If: {
-          os << "    ib.emit_if(ib.r(" << instr.cond << "), " << instr.true_offset << ", "
-             << instr.false_offset << ")\n";
+          os << "    ib.emit_if(ib.r(" << instr.cond << "), " << instr.offset << ")\n";
           break;
         }
         default:

--- a/src/relax/vm/executable.cc
+++ b/src/relax/vm/executable.cc
@@ -123,6 +123,11 @@ std::string ExecutableNode::Stats() const {
   return oss.str();
 }
 
+void ExecutableNode::SetInstructionData(Index i, Index j, ExecWord val) {
+  Index instr_idx = instr_offset[i];
+  instr_data[instr_idx + j] = val;
+}
+
 Instruction ExecutableNode::GetInstruction(Index i) const {
   size_t offset = instr_offset[i];
   Opcode op = static_cast<Opcode>(instr_data[offset]);

--- a/src/relax/vm/executable.cc
+++ b/src/relax/vm/executable.cc
@@ -149,8 +149,8 @@ Instruction ExecutableNode::GetInstruction(Index i) const {
     }
     case Opcode::If: {
       RegName cond = instr_data[offset + 1];
-      Index false_branch = instr_data[offset + 2];
-      return Instruction::If(cond, false_branch);
+      Index false_offset = instr_data[offset + 2];
+      return Instruction::If(cond, false_offset);
     }
     default:
       LOG(FATAL) << "should never hit this case: " << static_cast<int>(op);
@@ -469,7 +469,7 @@ String ExecutableNode::AsText() const {
         }
         case Opcode::If: {
           os << std::setw(6) << std::left << "If" << RegNameToStr(instr.cond) << ", "
-             << instr.offset << "\n";
+             << instr.false_offset << "\n";
           break;
         }
         default:
@@ -514,7 +514,7 @@ String ExecutableNode::AsPython() const {
           break;
         }
         case Opcode::If: {
-          os << "    ib.emit_if(ib.r(" << instr.cond << "), " << instr.offset << ")\n";
+          os << "    ib.emit_if(ib.r(" << instr.cond << "), " << instr.false_offset << ")\n";
           break;
         }
         default:

--- a/src/relax/vm/executable.cc
+++ b/src/relax/vm/executable.cc
@@ -515,8 +515,8 @@ String ExecutableNode::AsPython() const {
           break;
         }
         case Opcode::If: {
-          os << "    ib.emit_if(ib.r(" << instr.cond << "), "
-             << instr.true_offset << ", " << instr.false_offset << ")\n";
+          os << "    ib.emit_if(ib.r(" << instr.cond << "), " << instr.true_offset << ", "
+             << instr.false_offset << ")\n";
           break;
         }
         default:

--- a/src/relax/vm/vm.cc
+++ b/src/relax/vm/vm.cc
@@ -165,8 +165,8 @@ void VirtualMachine::RunLoop() {
         if (cond_val != 0) {
           pc_++;
         } else {
-          ICHECK_NE(instr.offset, 0);
-          pc_ += instr.offset;
+          ICHECK_GT(instr.false_offset, 1);
+          pc_ += instr.false_offset;
         }
         break;
       }

--- a/src/relax/vm/vm.cc
+++ b/src/relax/vm/vm.cc
@@ -161,9 +161,8 @@ void VirtualMachine::RunLoop() {
         break;
       }
       case Opcode::If: {
-        int64_t test_val = ReadRegister(instr.test);
-        int64_t target_val = ReadRegister(instr.target);
-        if (test_val == target_val) {
+        int64_t cond_val = ReadRegister(instr.cond);
+        if (cond_val != 0) {
           ICHECK_NE(instr.true_offset, 0);
           pc_ += instr.true_offset;
         } else {

--- a/src/relax/vm/vm.cc
+++ b/src/relax/vm/vm.cc
@@ -163,11 +163,10 @@ void VirtualMachine::RunLoop() {
       case Opcode::If: {
         int64_t cond_val = ReadRegister(instr.cond);
         if (cond_val != 0) {
-          ICHECK_NE(instr.true_offset, 0);
-          pc_ += instr.true_offset;
+          pc_++;
         } else {
-          ICHECK_NE(instr.false_offset, 0);
-          pc_ += instr.false_offset;
+          ICHECK_NE(instr.offset, 0);
+          pc_ += instr.offset;
         }
         break;
       }

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -261,12 +261,12 @@ def test_vm_goto():
 
 def test_vm_if():
     ib = relax.ExecBuilder()
-    with ib.function("main", num_inputs=4):
-        ib.emit_if(ib.r(0), ib.r(1), 1, 3)
-        ib.emit_call("test.vm.add", args=[ib.r(2), ib.r(3)], dst=ib.r(4))
+    with ib.function("main", num_inputs=3):
+        ib.emit_if(ib.r(0), 1, 3)
+        ib.emit_call("test.vm.add", args=[ib.r(1), ib.r(2)], dst=ib.r(3))
         ib.emit_goto(2)
-        ib.emit_call("test.vm.mul", args=[ib.r(2), ib.r(3)], dst=ib.r(4))
-        ib.emit_ret(ib.r(4))
+        ib.emit_call("test.vm.mul", args=[ib.r(1), ib.r(2)], dst=ib.r(3))
+        ib.emit_ret(ib.r(3))
     ex = ib.get()
     vm = relax.VirtualMachine(ex, tvm.cpu())
     a = tvm.nd.array(
@@ -279,10 +279,10 @@ def test_vm_if():
             4,
         )
     )
-    res = vm["main"](True, False, a, b)
-    np.testing.assert_allclose(res.numpy(), a.numpy() * b.numpy())
-    res = vm["main"](1, 1, a, b)
-    np.testing.assert_allclose(res.numpy(), a.numpy() + b.numpy())
+    res = vm["main"](False, a, b)
+    np.testing.assert_allclose(res.asnumpy(), a.asnumpy() * b.asnumpy())
+    res = vm["main"](1, a, b)
+    np.testing.assert_allclose(res.asnumpy(), a.asnumpy() + b.asnumpy())
 
 
 def test_vm_if_codegen():
@@ -305,8 +305,8 @@ def test_vm_if_codegen():
             4,
         )
     )
-    cond1  = tvm.nd.array(True)
-    cond2  = tvm.nd.array(False)
+    cond1 = tvm.nd.array(True)
+    cond2 = tvm.nd.array(False)
 
     res = vm["ife"](cond1, inp)
     np.testing.assert_allclose(res.asnumpy(), inp.asnumpy() + inp.asnumpy())
@@ -635,6 +635,7 @@ def test_vm_relax_dyn_tir_shape():
     np.testing.assert_allclose(res.numpy(), inp2.numpy())
     os.remove("exec.tmp")
 
+
 def test_vm_tuple():
     bb = relax.BlockBuilder()
     n = tir.Var("n", "int64")
@@ -647,7 +648,7 @@ def test_vm_tuple():
         bb.emit_func_output([tup, item], params=[x, y])
 
     mod = bb.get()
-    
+
     target = tvm.target.Target("llvm", host="llvm")
     ex, lib = relax.vm.build(mod, target)
 
@@ -660,6 +661,7 @@ def test_vm_tuple():
     np.testing.assert_allclose(res1.numpy(), inp.numpy())
     np.testing.assert_allclose(res2.numpy(), inp2.numpy())
     np.testing.assert_allclose(res3.numpy(), inp.numpy())
+
 
 if __name__ == "__main__":
     test_vm_execute()

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -279,7 +279,7 @@ def test_vm_goto():
 def test_vm_if():
     ib = relax.ExecBuilder()
     with ib.function("main", num_inputs=3):
-        ib.emit_if(ib.r(0), 1, 3)
+        ib.emit_if(ib.r(0), 3)
         ib.emit_call("test.vm.add", args=[ib.r(1), ib.r(2)], dst=ib.r(3))
         ib.emit_goto(2)
         ib.emit_call("test.vm.mul", args=[ib.r(1), ib.r(2)], dst=ib.r(3))


### PR DESCRIPTION
follow-up pr of #61 

Add `EmitIf` and `EmitGoto` in VMCodeGen
Add packed func `vm.builtin.copy`. Add `SetInstructionData` in executable to help modify the emitted instruction data
Merge `test` and `target` registers into one `cond` register.