### PR TITLE
[VM] Add VM Instruction Move

### DIFF
--- a/include/tvm/relax/vm/bytecode.h
+++ b/include/tvm/relax/vm/bytecode.h
@@ -58,6 +58,7 @@ enum class Opcode {
   Ret = 2U,
   Goto = 3U,
   If = 4U,
+  Move = 5U,
 };
 
 /*! \brief A single virtual machine instruction.
@@ -146,6 +147,12 @@ struct Instruction {
       /*! \brief The program counter offset for the false branch. */
       Index false_offset;
     };
+    struct /* Move */ {
+      /*! \brief The source register for a move operation. */
+      RegName src_register;
+      /*! \brief The destination register for a move operation. */
+      RegName dst_register;
+    };
   };
   /*!
    * \brief Construct a Call instruction.
@@ -163,7 +170,7 @@ struct Instruction {
    */
   static Instruction Ret(RegName result);
   /*!
-   * \brief Construct a goto instruction.
+   * \brief Construct a Goto instruction.
    * \param pc_offset The register containing the jump offset.
    * \return The goto instruction.
    */
@@ -177,6 +184,13 @@ struct Instruction {
    * \return The If instruction.
    */
   static Instruction If(RegName test, RegName target, Index true_offset, Index false_offset);
+  /*!
+   * \brief Construct a Move instruction.
+   * \param src_register The source register.
+   * \param dst_register The destination register.
+   * \return The Move instruction.
+   */
+  static Instruction Move(RegName src_register, RegName dst_register);
 };
 
 }  // namespace relax_vm

--- a/include/tvm/relax/vm/exec_builder.h
+++ b/include/tvm/relax/vm/exec_builder.h
@@ -66,7 +66,14 @@ class ExecBuilderNode : public Object {
    */
   void EmitRet(vm::RegName result);
   /*!
-   * \brief Emit a goto instruction.
+   * \brief Emit a Move instruction.
+   * \param src The register from which to move.
+   * \param dst The destination register.
+   */
+  void EmitMove(vm::RegName src, vm::RegName dst);
+  /*!
+   * \brief Emit an Goto instruction.
+   * \param cond The register containing the cond value.
    * \param pc_offset The program counter offset as the jump offset.
    */
   void EmitGoto(vm::Index pc_offset);

--- a/python/tvm/relax/exec_builder.py
+++ b/python/tvm/relax/exec_builder.py
@@ -106,6 +106,12 @@ class ExecBuilder(Object):
         self._check_scope()
         _ffi_api.ExecBuilderEmitRet(self, result)
 
+
+    def emit_move(self, src, dst):
+        """emit a move instruction"""
+        self._check_scope()
+        _ffi_api.ExecBuilderEmitMove(self, src, dst)
+
     def emit_goto(self, pc_offset):
         """emit a goto instruction"""
         self._check_scope()

--- a/src/relax/vm/bytecode.cc
+++ b/src/relax/vm/bytecode.cc
@@ -65,6 +65,14 @@ Instruction Instruction::If(RegName test, RegName target, Index true_branch, Ind
   instr.false_offset = false_branch;
   return instr;
 }
+
+Instruction Instruction::Move(RegName src_register, RegName dst_register) {
+  Instruction instr;
+  instr.op = Opcode::Move;
+  instr.src_register = src_register;
+  instr.dst_register = dst_register;
+  return instr;
+}
 }  // namespace relax_vm
 }  // namespace runtime
 }  // namespace tvm

--- a/src/relax/vm/exec_builder.cc
+++ b/src/relax/vm/exec_builder.cc
@@ -78,6 +78,13 @@ void ExecBuilderNode::EmitRet(RegName result) {
   exec->instr_data.push_back(result);
 }
 
+void ExecBuilderNode::EmitMove(RegName src, RegName dst) {
+  exec->instr_offset.push_back(exec->instr_data.size());
+  exec->instr_data.push_back(static_cast<ExecWord>(Opcode::Move));
+  exec->instr_data.push_back(src);
+  exec->instr_data.push_back(dst);
+}
+
 void ExecBuilderNode::EmitGoto(Index pc_offset) {
   exec->instr_offset.push_back(exec->instr_data.size());
   exec->instr_data.push_back(static_cast<ExecWord>(Opcode::Goto));
@@ -136,8 +143,13 @@ bool CheckExecutable(Executable exec) {
           }
           break;
         }
+        case Opcode::Move: {
+          arg_registers.emplace(instr.src_register);
+          arg_registers.emplace(instr.dst_register);
+          break;
+        }
         case Opcode::Goto: {
-          ICHECK_GT(instr.pc_offset, 0);
+          ICHECK_NE(instr.pc_offset, 0);
           break;
         }
         case Opcode::If: {
@@ -195,6 +207,9 @@ void ExecBuilderNode::Formalize() {
           }
           break;
         }
+        case Opcode::Move: {
+          break;
+        }
         case Opcode::Goto: {
           break;
         }
@@ -235,6 +250,9 @@ TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitCall")
 
 TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitRet")
     .set_body_method<ExecBuilder>(&ExecBuilderNode::EmitRet);
+
+TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitMove")
+.set_body_method<ExecBuilder>(&ExecBuilderNode::EmitMove);
 
 TVM_REGISTER_GLOBAL("relax.ExecBuilderEmitGoto")
     .set_body_method<ExecBuilder>(&ExecBuilderNode::EmitGoto);

--- a/src/relax/vm/executable.cc
+++ b/src/relax/vm/executable.cc
@@ -138,6 +138,11 @@ Instruction ExecutableNode::GetInstruction(Index i) const {
       RegName result = instr_data[offset + 1];
       return Instruction::Ret(result);
     }
+    case Opcode::Move: {
+      RegName src = instr_data[offset + 1];
+      RegName dst = instr_data[offset + 2];
+      return Instruction::Move(src, dst);
+    }
     case Opcode::Goto: {
       Index pc_offset = instr_data[offset + 1];
       return Instruction::Goto(pc_offset);
@@ -459,6 +464,12 @@ String ExecutableNode::AsText() const {
              << "ret " << RegNameToStr(instr.result) << "\n";
           break;
         }
+        case Opcode::Move: {
+          os << std::setw(6) << std::left << "move"
+             << "move " << RegNameToStr(instr.src_register) << ", "
+             <<RegNameToStr(instr.dst_register)<<"\n";
+          break;
+        }
         case Opcode::Goto: {
           os << std::setw(6) << std::left << "goto"
              << "goto " << instr.pc_offset << "\n";
@@ -505,6 +516,11 @@ String ExecutableNode::AsPython() const {
         }
         case Opcode::Ret: {
           os << "    ib.emit_ret(ib.r(" << instr.result << "))\n";
+          break;
+        }
+        case Opcode::Move: {
+          os << "    ib.emit_move(ib.r(" << instr.src_register
+          << "), ib.r(" << instr.dst_register << "))\n";
           break;
         }
         case Opcode::Goto: {

--- a/src/relax/vm/vm.cc
+++ b/src/relax/vm/vm.cc
@@ -157,6 +157,12 @@ void VirtualMachine::RunLoop() {
         WriteRegister(caller_return_register, return_value_);
         break;
       }
+      case Opcode::Move: {
+        RegType src = ReadRegister(instr.src_register);
+        WriteRegister(instr.dst_register, src);
+        pc_++;
+        break;
+      }
       case Opcode::Goto: {
         pc_ += instr.pc_offset;
         break;

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -236,6 +236,27 @@ def test_vm_storage():
     assert res.shape == shape
 
 
+def test_vm_move():
+    ib = relax.ExecBuilder()
+    with ib.function("main", num_inputs=2):
+        ib.emit_move(ib.r(0), ib.r(1))
+        ib.emit_ret(ib.r(1))
+    ex = ib.get()
+    vm = relax.VirtualMachine(ex, tvm.cpu())
+    a = tvm.nd.array(
+        np.random.rand(
+            4,
+        )
+    )
+    b = tvm.nd.array(
+        np.random.rand(
+            4,
+        )
+    )
+    res = vm["main"](a, b)
+    np.testing.assert_allclose(res.asnumpy(), a.asnumpy())
+
+
 def test_vm_goto():
     ib = relax.ExecBuilder()
     with ib.function("main", num_inputs=2):
@@ -642,6 +663,7 @@ if __name__ == "__main__":
     test_vm_constant_serialize()
     test_vm_shapeof()
     test_vm_storage()
+    test_vm_move()
     test_vm_goto()
     test_vm_if()
     test_vm_compile_stage0()


### PR DESCRIPTION
In the control flow vm codegen, we need to move the last register of if and else branch to a "dummy" register, and return the dummy register.  Another option I can think of is to modify the `dst` of the last instruction emitted from both if and else branch directly, in this way we need to expose the `dst` to vm_codegen.
