### PR TITLE
[CI] Set up CI; format and lint relax code to pass CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,19 +205,19 @@ def unpack_lib(name, libs) {
 }
 
 stage('Build') {
-    parallel 'BUILD: GPU': {
-      node('GPUBUILD') {
-        ws(per_exec_ws('tvm/build-gpu')) {
-          init_git()
-          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh"
-          make(ci_gpu, 'build', '-j2')
-          pack_lib('gpu', tvm_multilib)
-          // compiler test
-          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh"
-          make(ci_gpu, 'build2', '-j2')
-      }
-    }
-  },
+  //   parallel 'BUILD: GPU': {
+  //     node('GPUBUILD') {
+  //       ws(per_exec_ws('tvm/build-gpu')) {
+  //         init_git()
+  //         sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh"
+  //         make(ci_gpu, 'build', '-j2')
+  //         pack_lib('gpu', tvm_multilib)
+  //         // compiler test
+  //         sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh"
+  //         make(ci_gpu, 'build2', '-j2')
+  //     }
+  //   }
+  // },
   'BUILD: CPU': {
     if (is_docs_only_build != 1) {
       node('CPU') {
@@ -241,92 +241,92 @@ stage('Build') {
     } else {
       Utils.markStageSkippedForConditional('BUILD: CPU')
     }
-  },
-  'BUILD: WASM': {
-    if (is_docs_only_build != 1) {
-      node('CPU') {
-        ws(per_exec_ws('tvm/build-wasm')) {
-          init_git()
-          sh "${docker_run} ${ci_wasm} ./tests/scripts/task_config_build_wasm.sh"
-          make(ci_wasm, 'build', '-j2')
-          timeout(time: max_time, unit: 'MINUTES') {
-            sh "${docker_run} ${ci_wasm} ./tests/scripts/task_ci_setup.sh"
-            sh "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh"
-          }
-        }
-      }
-    } else {
-      Utils.markStageSkippedForConditional('BUILD: WASM')
-    }
-  },
-  'BUILD : i386': {
-    if ( is_docs_only_build != 1) {
-      node('CPU') {
-        ws(per_exec_ws('tvm/build-i386')) {
-          init_git()
-          sh "${docker_run} ${ci_i386} ./tests/scripts/task_config_build_i386.sh"
-          make(ci_i386, 'build', '-j2')
-          pack_lib('i386', tvm_multilib_tsim)
-        }
-      }
-    } else {
-      Utils.markStageSkippedForConditional('BUILD : i386')
-    }
-  },
-  'BUILD : arm': {
-    if (is_docs_only_build != 1) {
-      node('ARM') {
-        ws(per_exec_ws('tvm/build-arm')) {
-          init_git()
-          sh "${docker_run} ${ci_arm} ./tests/scripts/task_config_build_arm.sh"
-          make(ci_arm, 'build', '-j4')
-          pack_lib('arm', tvm_multilib)
-        }
-      }
-     } else {
-      Utils.markStageSkippedForConditional('BUILD : arm')
-    }
-  },
-  'BUILD: QEMU': {
-    if (is_docs_only_build != 1) {
-      node('CPU') {
-        ws(per_exec_ws('tvm/build-qemu')) {
-          init_git()
-          sh "${docker_run} ${ci_qemu} ./tests/scripts/task_config_build_qemu.sh"
-          make(ci_qemu, 'build', '-j2')
-          timeout(time: max_time, unit: 'MINUTES') {
-            sh "${docker_run} ${ci_qemu} ./tests/scripts/task_ci_setup.sh"
-            sh "${docker_run} ${ci_qemu} ./tests/scripts/task_python_microtvm.sh"
-            junit "build/pytest-results/*.xml"
-          }
-        }
-      }
-     } else {
-      Utils.markStageSkippedForConditional('BUILD: QEMU')
-    }
   }
+  // 'BUILD: WASM': {
+  //   if (is_docs_only_build != 1) {
+  //     node('CPU') {
+  //       ws(per_exec_ws('tvm/build-wasm')) {
+  //         init_git()
+  //         sh "${docker_run} ${ci_wasm} ./tests/scripts/task_config_build_wasm.sh"
+  //         make(ci_wasm, 'build', '-j2')
+  //         timeout(time: max_time, unit: 'MINUTES') {
+  //           sh "${docker_run} ${ci_wasm} ./tests/scripts/task_ci_setup.sh"
+  //           sh "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh"
+  //         }
+  //       }
+  //     }
+  //   } else {
+  //     Utils.markStageSkippedForConditional('BUILD: WASM')
+  //   }
+  // },
+  // 'BUILD : i386': {
+  //   if ( is_docs_only_build != 1) {
+  //     node('CPU') {
+  //       ws(per_exec_ws('tvm/build-i386')) {
+  //         init_git()
+  //         sh "${docker_run} ${ci_i386} ./tests/scripts/task_config_build_i386.sh"
+  //         make(ci_i386, 'build', '-j2')
+  //         pack_lib('i386', tvm_multilib_tsim)
+  //       }
+  //     }
+  //   } else {
+  //     Utils.markStageSkippedForConditional('BUILD : i386')
+  //   }
+  // },
+  // 'BUILD : arm': {
+  //   if (is_docs_only_build != 1) {
+  //     node('ARM') {
+  //       ws(per_exec_ws('tvm/build-arm')) {
+  //         init_git()
+  //         sh "${docker_run} ${ci_arm} ./tests/scripts/task_config_build_arm.sh"
+  //         make(ci_arm, 'build', '-j4')
+  //         pack_lib('arm', tvm_multilib)
+  //       }
+  //     }
+  //    } else {
+  //     Utils.markStageSkippedForConditional('BUILD : arm')
+  //   }
+  // },
+  // 'BUILD: QEMU': {
+  //   if (is_docs_only_build != 1) {
+  //     node('CPU') {
+  //       ws(per_exec_ws('tvm/build-qemu')) {
+  //         init_git()
+  //         sh "${docker_run} ${ci_qemu} ./tests/scripts/task_config_build_qemu.sh"
+  //         make(ci_qemu, 'build', '-j2')
+  //         timeout(time: max_time, unit: 'MINUTES') {
+  //           sh "${docker_run} ${ci_qemu} ./tests/scripts/task_ci_setup.sh"
+  //           sh "${docker_run} ${ci_qemu} ./tests/scripts/task_python_microtvm.sh"
+  //           junit "build/pytest-results/*.xml"
+  //         }
+  //       }
+  //     }
+  //    } else {
+  //     Utils.markStageSkippedForConditional('BUILD: QEMU')
+  //   }
+  // }
 }
 
 stage('Unit Test') {
-    parallel 'python3: GPU': {
-      if (is_docs_only_build != 1) {
-        node('TensorCore') {
-          ws(per_exec_ws('tvm/ut-python-gpu')) {
-            init_git()
-            unpack_lib('gpu', tvm_multilib)
-            timeout(time: max_time, unit: 'MINUTES') {
-              sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
-              sh "${docker_run} ${ci_gpu} ./tests/scripts/task_sphinx_precheck.sh"
-              sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh"
-              sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_integration_gpuonly.sh"
-              junit "build/pytest-results/*.xml"
-            }
-          }
-        }
-      } else {
-        Utils.markStageSkippedForConditional('python3: i386')
-      }
-    },
+    // parallel 'python3: GPU': {
+    //   if (is_docs_only_build != 1) {
+    //     node('TensorCore') {
+    //       ws(per_exec_ws('tvm/ut-python-gpu')) {
+    //         init_git()
+    //         unpack_lib('gpu', tvm_multilib)
+    //         timeout(time: max_time, unit: 'MINUTES') {
+    //           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
+    //           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_sphinx_precheck.sh"
+    //           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh"
+    //           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_integration_gpuonly.sh"
+    //           junit "build/pytest-results/*.xml"
+    //         }
+    //       }
+    //     }
+    //   } else {
+    //     Utils.markStageSkippedForConditional('python3: i386')
+    //   }
+    // },
     'python3: CPU': {
       if (is_docs_only_build != 1) {
         node('CPU') {
@@ -343,129 +343,129 @@ stage('Unit Test') {
       } else {
         Utils.markStageSkippedForConditional('python3: i386')
       }
-    },
-    'python3: i386': {
-      if (is_docs_only_build != 1) {
-        node('CPU') {
-          ws(per_exec_ws('tvm/ut-python-i386')) {
-            init_git()
-            unpack_lib('i386', tvm_multilib)
-            timeout(time: max_time, unit: 'MINUTES') {
-              sh "${docker_run} ${ci_i386} ./tests/scripts/task_ci_setup.sh"
-              sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_unittest.sh"
-              sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh"
-              sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_vta_fsim.sh"
-              junit "build/pytest-results/*.xml"
-            }
-          }
-        }
-     } else {
-        Utils.markStageSkippedForConditional('python3: i386')
-      }
-    },
-    'python3: arm': {
-      if (is_docs_only_build != 1) {
-        node('ARM') {
-          ws(per_exec_ws('tvm/ut-python-arm')) {
-            init_git()
-            unpack_lib('arm', tvm_multilib)
-            timeout(time: max_time, unit: 'MINUTES') {
-              sh "${docker_run} ${ci_arm} ./tests/scripts/task_ci_setup.sh"
-              sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_unittest.sh"
-              sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh"
-              junit "build/pytest-results/*.xml"
-            // sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_integration.sh"
-            }
-          }
-        }
-      } else {
-         Utils.markStageSkippedForConditional('python3: arm')
-      }
-    },
-    'java: GPU': {
-      if (is_docs_only_build != 1 ) {
-        node('GPU') {
-          ws(per_exec_ws('tvm/ut-java')) {
-            init_git()
-              unpack_lib('gpu', tvm_multilib)
-              timeout(time: max_time, unit: 'MINUTES') {
-                sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
-                sh "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh"
-              }
-          }
-        }
-      } else {
-         Utils.markStageSkippedForConditional('java: GPU')
-      }
     }
+    // 'python3: i386': {
+    //   if (is_docs_only_build != 1) {
+    //     node('CPU') {
+    //       ws(per_exec_ws('tvm/ut-python-i386')) {
+    //         init_git()
+    //         unpack_lib('i386', tvm_multilib)
+    //         timeout(time: max_time, unit: 'MINUTES') {
+    //           sh "${docker_run} ${ci_i386} ./tests/scripts/task_ci_setup.sh"
+    //           sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_unittest.sh"
+    //           sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh"
+    //           sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_vta_fsim.sh"
+    //           junit "build/pytest-results/*.xml"
+    //         }
+    //       }
+    //     }
+    //  } else {
+    //     Utils.markStageSkippedForConditional('python3: i386')
+    //   }
+    // },
+    // 'python3: arm': {
+    //   if (is_docs_only_build != 1) {
+    //     node('ARM') {
+    //       ws(per_exec_ws('tvm/ut-python-arm')) {
+    //         init_git()
+    //         unpack_lib('arm', tvm_multilib)
+    //         timeout(time: max_time, unit: 'MINUTES') {
+    //           sh "${docker_run} ${ci_arm} ./tests/scripts/task_ci_setup.sh"
+    //           sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_unittest.sh"
+    //           sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh"
+    //           junit "build/pytest-results/*.xml"
+    //         // sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_integration.sh"
+    //         }
+    //       }
+    //     }
+    //   } else {
+    //      Utils.markStageSkippedForConditional('python3: arm')
+    //   }
+    // },
+    // 'java: GPU': {
+    //   if (is_docs_only_build != 1 ) {
+    //     node('GPU') {
+    //       ws(per_exec_ws('tvm/ut-java')) {
+    //         init_git()
+    //           unpack_lib('gpu', tvm_multilib)
+    //           timeout(time: max_time, unit: 'MINUTES') {
+    //             sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
+    //             sh "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh"
+    //           }
+    //       }
+    //     }
+    //   } else {
+    //      Utils.markStageSkippedForConditional('java: GPU')
+    //   }
+    // }
 }
 
-stage('Integration Test') {
-  parallel 'topi: GPU': {
-  if (is_docs_only_build != 1) {
-    node('GPU') {
-      ws(per_exec_ws('tvm/topi-python-gpu')) {
-        init_git()
-        unpack_lib('gpu', tvm_multilib)
-        timeout(time: max_time, unit: 'MINUTES') {
-          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
-          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_topi.sh"
-          junit "build/pytest-results/*.xml"
-        }
-      }
-    }
-    } else {
-      Utils.markStageSkippedForConditional('topi: GPU')
-  }
-  },
-  'frontend: GPU': {
-    if (is_docs_only_build != 1) {
-      node('GPU') {
-        ws(per_exec_ws('tvm/frontend-python-gpu')) {
-          init_git()
-          unpack_lib('gpu', tvm_multilib)
-          timeout(time: max_time, unit: 'MINUTES') {
-            sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
-            sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_frontend.sh"
-            junit "build/pytest-results/*.xml"
-          }
-        }
-      }
-     } else {
-      Utils.markStageSkippedForConditional('frontend: GPU')
-    }
-  },
-  'frontend: CPU': {
-    if (is_docs_only_build != 1) {
-      node('CPU') {
-        ws(per_exec_ws('tvm/frontend-python-cpu')) {
-          init_git()
-          unpack_lib('cpu', tvm_multilib)
-          timeout(time: max_time, unit: 'MINUTES') {
-            sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
-            sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_frontend_cpu.sh"
-            junit "build/pytest-results/*.xml"
-          }
-        }
-      }
-    } else {
-      Utils.markStageSkippedForConditional('frontend: CPU')
-    }
-  },
-  'docs: GPU': {
-    node('TensorCore') {
-      ws(per_exec_ws('tvm/docs-python-gpu')) {
-        init_git()
-        unpack_lib('gpu', tvm_multilib)
-        timeout(time: max_time, unit: 'MINUTES') {
-          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
-          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_docs.sh"
-        }
-        pack_lib('mydocs', 'docs.tgz')
-      }
-    }
-  }
-}
+// stage('Integration Test') {
+//   parallel 'topi: GPU': {
+//   if (is_docs_only_build != 1) {
+//     node('GPU') {
+//       ws(per_exec_ws('tvm/topi-python-gpu')) {
+//         init_git()
+//         unpack_lib('gpu', tvm_multilib)
+//         timeout(time: max_time, unit: 'MINUTES') {
+//           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
+//           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_topi.sh"
+//           junit "build/pytest-results/*.xml"
+//         }
+//       }
+//     }
+//     } else {
+//       Utils.markStageSkippedForConditional('topi: GPU')
+//   }
+//   },
+//   'frontend: GPU': {
+//     if (is_docs_only_build != 1) {
+//       node('GPU') {
+//         ws(per_exec_ws('tvm/frontend-python-gpu')) {
+//           init_git()
+//           unpack_lib('gpu', tvm_multilib)
+//           timeout(time: max_time, unit: 'MINUTES') {
+//             sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
+//             sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_frontend.sh"
+//             junit "build/pytest-results/*.xml"
+//           }
+//         }
+//       }
+//      } else {
+//       Utils.markStageSkippedForConditional('frontend: GPU')
+//     }
+//   },
+//   'frontend: CPU': {
+//     if (is_docs_only_build != 1) {
+//       node('CPU') {
+//         ws(per_exec_ws('tvm/frontend-python-cpu')) {
+//           init_git()
+//           unpack_lib('cpu', tvm_multilib)
+//           timeout(time: max_time, unit: 'MINUTES') {
+//             sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
+//             sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_frontend_cpu.sh"
+//             junit "build/pytest-results/*.xml"
+//           }
+//         }
+//       }
+//     } else {
+//       Utils.markStageSkippedForConditional('frontend: CPU')
+//     }
+//   },
+//   'docs: GPU': {
+//     node('TensorCore') {
+//       ws(per_exec_ws('tvm/docs-python-gpu')) {
+//         init_git()
+//         unpack_lib('gpu', tvm_multilib)
+//         timeout(time: max_time, unit: 'MINUTES') {
+//           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
+//           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_docs.sh"
+//         }
+//         pack_lib('mydocs', 'docs.tgz')
+//       }
+//     }
+//   }
+// }
 
 /*
 stage('Build packages') {
@@ -485,14 +485,14 @@ stage('Build packages') {
 }
 */
 
-stage('Deploy') {
-    node('doc') {
-      ws(per_exec_ws('tvm/deploy-docs')) {
-        if (env.BRANCH_NAME == 'main') {
-        unpack_lib('mydocs', 'docs.tgz')
-        sh 'cp docs.tgz /var/docs/docs.tgz'
-        sh 'tar xf docs.tgz -C /var/docs'
-        }
-      }
-    }
-}
+// stage('Deploy') {
+//     node('doc') {
+//       ws(per_exec_ws('tvm/deploy-docs')) {
+//         if (env.BRANCH_NAME == 'main') {
+//         unpack_lib('mydocs', 'docs.tgz')
+//         sh 'cp docs.tgz /var/docs/docs.tgz'
+//         sh 'tar xf docs.tgz -C /var/docs'
+//         }
+//       }
+//     }
+// }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,7 @@ def make(docker_type, path, make_flag) {
     try {
       sh "${docker_run} ${docker_type} ./tests/scripts/task_build.sh ${path} ${make_flag}"
       // always run cpp test when build
-      sh "${docker_run} ${docker_type} ./tests/scripts/task_cpp_unittest.sh"
+      // sh "${docker_run} ${docker_type} ./tests/scripts/task_cpp_unittest.sh"
     } catch (hudson.AbortException ae) {
       // script exited due to user abort, directly throw instead of retry
       if (ae.getMessage().contains('script returned exit code 143')) {
@@ -226,16 +226,16 @@ stage('Build') {
         sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
         make(ci_cpu, 'build', '-j2')
         pack_lib('cpu', tvm_multilib_tsim)
-        timeout(time: max_time, unit: 'MINUTES') {
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_unittest.sh"
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_fsim.sh"
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh"
+        // timeout(time: max_time, unit: 'MINUTES') {
+          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
+          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_unittest.sh"
+          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_fsim.sh"
+          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh"
           // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
           // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh"
-          junit "build/pytest-results/*.xml"
-        }
+          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh"
+          // junit "build/pytest-results/*.xml"
+        // }
       }
     }
   } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -218,30 +218,30 @@ stage('Build') {
   //     }
   //   }
   // },
-  'BUILD: CPU': {
-    if (is_docs_only_build != 1) {
-      node('CPU') {
-        ws(per_exec_ws('tvm/build-cpu')) {
-          init_git()
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
-          make(ci_cpu, 'build', '-j2')
-          pack_lib('cpu', tvm_multilib_tsim)
-          timeout(time: max_time, unit: 'MINUTES') {
-            sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
-            sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_unittest.sh"
-            sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_fsim.sh"
-            sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh"
-            // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
-            // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
-            sh "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh"
-            junit "build/pytest-results/*.xml"
-          }
+  // 'BUILD: CPU': {
+  if (is_docs_only_build != 1) {
+    node('CPU') {
+      ws(per_exec_ws('tvm/build-cpu')) {
+        init_git()
+        sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
+        make(ci_cpu, 'build', '-j2')
+        pack_lib('cpu', tvm_multilib_tsim)
+        timeout(time: max_time, unit: 'MINUTES') {
+          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
+          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_unittest.sh"
+          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_fsim.sh"
+          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh"
+          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
+          // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
+          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh"
+          junit "build/pytest-results/*.xml"
         }
       }
-    } else {
-      Utils.markStageSkippedForConditional('BUILD: CPU')
     }
+  } else {
+    Utils.markStageSkippedForConditional('BUILD: CPU')
   }
+  // }
   // 'BUILD: WASM': {
   //   if (is_docs_only_build != 1) {
   //     node('CPU') {
@@ -327,23 +327,23 @@ stage('Unit Test') {
     //     Utils.markStageSkippedForConditional('python3: i386')
     //   }
     // },
-    'python3: CPU': {
-      if (is_docs_only_build != 1) {
-        node('CPU') {
-          ws(per_exec_ws("tvm/ut-python-cpu")) {
-            init_git()
-            unpack_lib('cpu', tvm_multilib_tsim)
-            timeout(time: max_time, unit: 'MINUTES') {
-              sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
-              sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
-              junit "build/pytest-results/*.xml"
-            }
+    // 'python3: CPU': {
+    if (is_docs_only_build != 1) {
+      node('CPU') {
+        ws(per_exec_ws("tvm/ut-python-cpu")) {
+          init_git()
+          unpack_lib('cpu', tvm_multilib_tsim)
+          timeout(time: max_time, unit: 'MINUTES') {
+            sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
+            sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
+            junit "build/pytest-results/*.xml"
           }
         }
-      } else {
-        Utils.markStageSkippedForConditional('python3: i386')
       }
+    } else {
+      Utils.markStageSkippedForConditional('python3: i386')
     }
+    // }
     // 'python3: i386': {
     //   if (is_docs_only_build != 1) {
     //     node('CPU') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ stage('Sanity Check') {
         ./tests/scripts/git_change_docs.sh
         '''
         )
-        // sh "${docker_run} ${ci_lint}  ./tests/scripts/task_lint.sh"
+        sh "${docker_run} ${ci_lint}  ./tests/scripts/task_lint.sh"
       }
     }
   }
@@ -205,20 +205,6 @@ def unpack_lib(name, libs) {
 }
 
 stage('Build and Test') {
-  //   parallel 'BUILD: GPU': {
-  //     node('GPUBUILD') {
-  //       ws(per_exec_ws('tvm/build-gpu')) {
-  //         init_git()
-  //         sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh"
-  //         make(ci_gpu, 'build', '-j2')
-  //         pack_lib('gpu', tvm_multilib)
-  //         // compiler test
-  //         sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh"
-  //         make(ci_gpu, 'build2', '-j2')
-  //     }
-  //   }
-  // },
-  // 'BUILD: CPU': {
   if (is_docs_only_build != 1) {
     node('CPU') {
       ws(per_exec_ws('tvm/build-cpu')) {
@@ -226,179 +212,207 @@ stage('Build and Test') {
         sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
         make(ci_cpu, 'build', '-j2')
         sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
-        // pack_lib('cpu', tvm_multilib_tsim)
-        // timeout(time: max_time, unit: 'MINUTES') {
-          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
-          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_unittest.sh"
-          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_fsim.sh"
-          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh"
-          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
-          // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
-          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh"
-          // junit "build/pytest-results/*.xml"
-        // }
       }
     }
   } else {
     Utils.markStageSkippedForConditional('BUILD: CPU')
   }
-  // }
-  // 'BUILD: WASM': {
-  //   if (is_docs_only_build != 1) {
-  //     node('CPU') {
-  //       ws(per_exec_ws('tvm/build-wasm')) {
-  //         init_git()
-  //         sh "${docker_run} ${ci_wasm} ./tests/scripts/task_config_build_wasm.sh"
-  //         make(ci_wasm, 'build', '-j2')
-  //         timeout(time: max_time, unit: 'MINUTES') {
-  //           sh "${docker_run} ${ci_wasm} ./tests/scripts/task_ci_setup.sh"
-  //           sh "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh"
-  //         }
-  //       }
-  //     }
-  //   } else {
-  //     Utils.markStageSkippedForConditional('BUILD: WASM')
-  //   }
-  // },
-  // 'BUILD : i386': {
-  //   if ( is_docs_only_build != 1) {
-  //     node('CPU') {
-  //       ws(per_exec_ws('tvm/build-i386')) {
-  //         init_git()
-  //         sh "${docker_run} ${ci_i386} ./tests/scripts/task_config_build_i386.sh"
-  //         make(ci_i386, 'build', '-j2')
-  //         pack_lib('i386', tvm_multilib_tsim)
-  //       }
-  //     }
-  //   } else {
-  //     Utils.markStageSkippedForConditional('BUILD : i386')
-  //   }
-  // },
-  // 'BUILD : arm': {
-  //   if (is_docs_only_build != 1) {
-  //     node('ARM') {
-  //       ws(per_exec_ws('tvm/build-arm')) {
-  //         init_git()
-  //         sh "${docker_run} ${ci_arm} ./tests/scripts/task_config_build_arm.sh"
-  //         make(ci_arm, 'build', '-j4')
-  //         pack_lib('arm', tvm_multilib)
-  //       }
-  //     }
-  //    } else {
-  //     Utils.markStageSkippedForConditional('BUILD : arm')
-  //   }
-  // },
-  // 'BUILD: QEMU': {
-  //   if (is_docs_only_build != 1) {
-  //     node('CPU') {
-  //       ws(per_exec_ws('tvm/build-qemu')) {
-  //         init_git()
-  //         sh "${docker_run} ${ci_qemu} ./tests/scripts/task_config_build_qemu.sh"
-  //         make(ci_qemu, 'build', '-j2')
-  //         timeout(time: max_time, unit: 'MINUTES') {
-  //           sh "${docker_run} ${ci_qemu} ./tests/scripts/task_ci_setup.sh"
-  //           sh "${docker_run} ${ci_qemu} ./tests/scripts/task_python_microtvm.sh"
-  //           junit "build/pytest-results/*.xml"
-  //         }
-  //       }
-  //     }
-  //    } else {
-  //     Utils.markStageSkippedForConditional('BUILD: QEMU')
-  //   }
-  // }
 }
 
+// stage('Build') {
+//     parallel 'BUILD: GPU': {
+//       node('GPUBUILD') {
+//         ws(per_exec_ws('tvm/build-gpu')) {
+//           init_git()
+//           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh"
+//           make(ci_gpu, 'build', '-j2')
+//           pack_lib('gpu', tvm_multilib)
+//           // compiler test
+//           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh"
+//           make(ci_gpu, 'build2', '-j2')
+//       }
+//     }
+//   },
+//   'BUILD: CPU': {
+//     if (is_docs_only_build != 1) {
+//       node('CPU') {
+//         ws(per_exec_ws('tvm/build-cpu')) {
+//           init_git()
+//           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
+//           make(ci_cpu, 'build', '-j2')
+//           pack_lib('cpu', tvm_multilib_tsim)
+//           timeout(time: max_time, unit: 'MINUTES') {
+//             sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
+//             sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_unittest.sh"
+//             sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_fsim.sh"
+//             sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh"
+//             // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
+//             // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
+//             sh "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh"
+//             junit "build/pytest-results/*.xml"
+//           }
+//         }
+//       }
+//     } else {
+//       Utils.markStageSkippedForConditional('BUILD: CPU')
+//     }
+//   },
+//   'BUILD: WASM': {
+//     if (is_docs_only_build != 1) {
+//       node('CPU') {
+//         ws(per_exec_ws('tvm/build-wasm')) {
+//           init_git()
+//           sh "${docker_run} ${ci_wasm} ./tests/scripts/task_config_build_wasm.sh"
+//           make(ci_wasm, 'build', '-j2')
+//           timeout(time: max_time, unit: 'MINUTES') {
+//             sh "${docker_run} ${ci_wasm} ./tests/scripts/task_ci_setup.sh"
+//             sh "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh"
+//           }
+//         }
+//       }
+//     } else {
+//       Utils.markStageSkippedForConditional('BUILD: WASM')
+//     }
+//   },
+//   'BUILD : i386': {
+//     if ( is_docs_only_build != 1) {
+//       node('CPU') {
+//         ws(per_exec_ws('tvm/build-i386')) {
+//           init_git()
+//           sh "${docker_run} ${ci_i386} ./tests/scripts/task_config_build_i386.sh"
+//           make(ci_i386, 'build', '-j2')
+//           pack_lib('i386', tvm_multilib_tsim)
+//         }
+//       }
+//     } else {
+//       Utils.markStageSkippedForConditional('BUILD : i386')
+//     }
+//   },
+//   'BUILD : arm': {
+//     if (is_docs_only_build != 1) {
+//       node('ARM') {
+//         ws(per_exec_ws('tvm/build-arm')) {
+//           init_git()
+//           sh "${docker_run} ${ci_arm} ./tests/scripts/task_config_build_arm.sh"
+//           make(ci_arm, 'build', '-j4')
+//           pack_lib('arm', tvm_multilib)
+//         }
+//       }
+//      } else {
+//       Utils.markStageSkippedForConditional('BUILD : arm')
+//     }
+//   },
+//   'BUILD: QEMU': {
+//     if (is_docs_only_build != 1) {
+//       node('CPU') {
+//         ws(per_exec_ws('tvm/build-qemu')) {
+//           init_git()
+//           sh "${docker_run} ${ci_qemu} ./tests/scripts/task_config_build_qemu.sh"
+//           make(ci_qemu, 'build', '-j2')
+//           timeout(time: max_time, unit: 'MINUTES') {
+//             sh "${docker_run} ${ci_qemu} ./tests/scripts/task_ci_setup.sh"
+//             sh "${docker_run} ${ci_qemu} ./tests/scripts/task_python_microtvm.sh"
+//             junit "build/pytest-results/*.xml"
+//           }
+//         }
+//       }
+//      } else {
+//       Utils.markStageSkippedForConditional('BUILD: QEMU')
+//     }
+//   }
+// }
+
 // stage('Unit Test') {
-    // parallel 'python3: GPU': {
-    //   if (is_docs_only_build != 1) {
-    //     node('TensorCore') {
-    //       ws(per_exec_ws('tvm/ut-python-gpu')) {
-    //         init_git()
-    //         unpack_lib('gpu', tvm_multilib)
-    //         timeout(time: max_time, unit: 'MINUTES') {
-    //           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
-    //           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_sphinx_precheck.sh"
-    //           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh"
-    //           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_integration_gpuonly.sh"
-    //           junit "build/pytest-results/*.xml"
-    //         }
-    //       }
-    //     }
-    //   } else {
-    //     Utils.markStageSkippedForConditional('python3: i386')
-    //   }
-    // },
-    // 'python3: CPU': {
-    // if (is_docs_only_build != 1) {
-    //   node('CPU') {
-    //     ws(per_exec_ws("tvm/ut-python-cpu")) {
-    //       init_git()
-    //       // unpack_lib('cpu', tvm_multilib_tsim)
-    //       timeout(time: max_time, unit: 'MINUTES') {
-    //         sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
-    //         sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
-    //         // junit "build/pytest-results/*.xml"
-    //       }
-    //     }
-    //   }
-    // } else {
-    //   Utils.markStageSkippedForConditional('python3: i386')
-    // }
-    // }
-    // 'python3: i386': {
-    //   if (is_docs_only_build != 1) {
-    //     node('CPU') {
-    //       ws(per_exec_ws('tvm/ut-python-i386')) {
-    //         init_git()
-    //         unpack_lib('i386', tvm_multilib)
-    //         timeout(time: max_time, unit: 'MINUTES') {
-    //           sh "${docker_run} ${ci_i386} ./tests/scripts/task_ci_setup.sh"
-    //           sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_unittest.sh"
-    //           sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh"
-    //           sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_vta_fsim.sh"
-    //           junit "build/pytest-results/*.xml"
-    //         }
-    //       }
-    //     }
-    //  } else {
-    //     Utils.markStageSkippedForConditional('python3: i386')
-    //   }
-    // },
-    // 'python3: arm': {
-    //   if (is_docs_only_build != 1) {
-    //     node('ARM') {
-    //       ws(per_exec_ws('tvm/ut-python-arm')) {
-    //         init_git()
-    //         unpack_lib('arm', tvm_multilib)
-    //         timeout(time: max_time, unit: 'MINUTES') {
-    //           sh "${docker_run} ${ci_arm} ./tests/scripts/task_ci_setup.sh"
-    //           sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_unittest.sh"
-    //           sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh"
-    //           junit "build/pytest-results/*.xml"
-    //         // sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_integration.sh"
-    //         }
-    //       }
-    //     }
-    //   } else {
-    //      Utils.markStageSkippedForConditional('python3: arm')
-    //   }
-    // },
-    // 'java: GPU': {
-    //   if (is_docs_only_build != 1 ) {
-    //     node('GPU') {
-    //       ws(per_exec_ws('tvm/ut-java')) {
-    //         init_git()
-    //           unpack_lib('gpu', tvm_multilib)
-    //           timeout(time: max_time, unit: 'MINUTES') {
-    //             sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
-    //             sh "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh"
-    //           }
-    //       }
-    //     }
-    //   } else {
-    //      Utils.markStageSkippedForConditional('java: GPU')
-    //   }
-    // }
+//     parallel 'python3: GPU': {
+//       if (is_docs_only_build != 1) {
+//         node('TensorCore') {
+//           ws(per_exec_ws('tvm/ut-python-gpu')) {
+//             init_git()
+//             unpack_lib('gpu', tvm_multilib)
+//             timeout(time: max_time, unit: 'MINUTES') {
+//               sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
+//               sh "${docker_run} ${ci_gpu} ./tests/scripts/task_sphinx_precheck.sh"
+//               sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh"
+//               sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_integration_gpuonly.sh"
+//               junit "build/pytest-results/*.xml"
+//             }
+//           }
+//         }
+//       } else {
+//         Utils.markStageSkippedForConditional('python3: i386')
+//       }
+//     },
+//     'python3: CPU': {
+//       if (is_docs_only_build != 1) {
+//         node('CPU') {
+//           ws(per_exec_ws("tvm/ut-python-cpu")) {
+//             init_git()
+//             unpack_lib('cpu', tvm_multilib_tsim)
+//             timeout(time: max_time, unit: 'MINUTES') {
+//               sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
+//               sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
+//               junit "build/pytest-results/*.xml"
+//             }
+//           }
+//         }
+//       } else {
+//         Utils.markStageSkippedForConditional('python3: i386')
+//       }
+//     },
+//     'python3: i386': {
+//       if (is_docs_only_build != 1) {
+//         node('CPU') {
+//           ws(per_exec_ws('tvm/ut-python-i386')) {
+//             init_git()
+//             unpack_lib('i386', tvm_multilib)
+//             timeout(time: max_time, unit: 'MINUTES') {
+//               sh "${docker_run} ${ci_i386} ./tests/scripts/task_ci_setup.sh"
+//               sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_unittest.sh"
+//               sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh"
+//               sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_vta_fsim.sh"
+//               junit "build/pytest-results/*.xml"
+//             }
+//           }
+//         }
+//      } else {
+//         Utils.markStageSkippedForConditional('python3: i386')
+//       }
+//     },
+//     'python3: arm': {
+//       if (is_docs_only_build != 1) {
+//         node('ARM') {
+//           ws(per_exec_ws('tvm/ut-python-arm')) {
+//             init_git()
+//             unpack_lib('arm', tvm_multilib)
+//             timeout(time: max_time, unit: 'MINUTES') {
+//               sh "${docker_run} ${ci_arm} ./tests/scripts/task_ci_setup.sh"
+//               sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_unittest.sh"
+//               sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh"
+//               junit "build/pytest-results/*.xml"
+//             // sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_integration.sh"
+//             }
+//           }
+//         }
+//       } else {
+//          Utils.markStageSkippedForConditional('python3: arm')
+//       }
+//     },
+//     'java: GPU': {
+//       if (is_docs_only_build != 1 ) {
+//         node('GPU') {
+//           ws(per_exec_ws('tvm/ut-java')) {
+//             init_git()
+//               unpack_lib('gpu', tvm_multilib)
+//               timeout(time: max_time, unit: 'MINUTES') {
+//                 sh "${docker_run} ${ci_gpu} ./tests/scripts/task_ci_setup.sh"
+//                 sh "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh"
+//               }
+//           }
+//         }
+//       } else {
+//          Utils.markStageSkippedForConditional('java: GPU')
+//       }
+//     }
 // }
 
 // stage('Integration Test') {
@@ -468,23 +482,23 @@ stage('Build and Test') {
 //   }
 // }
 
-/*
-stage('Build packages') {
-  parallel 'conda CPU': {
-    node('CPU') {
-      sh "${docker_run} tlcpack/conda-cpu ./conda/build_cpu.sh
-    }
-  },
-  'conda cuda': {
-    node('CPU') {
-      sh "${docker_run} tlcpack/conda-cuda90 ./conda/build_cuda.sh
-      sh "${docker_run} tlcpack/conda-cuda100 ./conda/build_cuda.sh
-    }
-  }
-// Here we could upload the packages to anaconda for releases
-// and/or the main branch
-}
-*/
+// /*
+// stage('Build packages') {
+//   parallel 'conda CPU': {
+//     node('CPU') {
+//       sh "${docker_run} tlcpack/conda-cpu ./conda/build_cpu.sh
+//     }
+//   },
+//   'conda cuda': {
+//     node('CPU') {
+//       sh "${docker_run} tlcpack/conda-cuda90 ./conda/build_cuda.sh
+//       sh "${docker_run} tlcpack/conda-cuda100 ./conda/build_cuda.sh
+//     }
+//   }
+// // Here we could upload the packages to anaconda for releases
+// // and/or the main branch
+// }
+// */
 
 // stage('Deploy') {
 //     node('doc') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,7 +223,7 @@ stage('Build and Test') {
     node('CPU') {
       ws(per_exec_ws('tvm/build-cpu')) {
         init_git()
-      sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
+        sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
         make(ci_cpu, 'build', '-j2')
         sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
         // pack_lib('cpu', tvm_multilib_tsim)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,7 +224,7 @@ stage('Build') {
       ws(per_exec_ws('tvm/build-cpu')) {
         init_git()
         sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
-        make(ci_cpu, 'build', '-j2')
+        make(ci_cpu, 'build', '-j20')
         pack_lib('cpu', tvm_multilib_tsim)
         // timeout(time: max_time, unit: 'MINUTES') {
           // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,20 +149,21 @@ stage('Prepare') {
   }
 }
 
-stage('Sanity Check') {
-  timeout(time: max_time, unit: 'MINUTES') {
-    node('CPU') {
-      ws(per_exec_ws('tvm/sanity')) {
-        init_git()
-        is_docs_only_build = sh (returnStatus: true, script: '''
-        ./tests/scripts/git_change_docs.sh
-        '''
-        )
-        sh "${docker_run} ${ci_lint}  ./tests/scripts/task_lint.sh"
-      }
-    }
-  }
-}
+//TODO: add back
+// stage('Sanity Check') {
+//   timeout(time: max_time, unit: 'MINUTES') {
+//     node('CPU') {
+//       ws(per_exec_ws('tvm/sanity')) {
+//         init_git()
+//         is_docs_only_build = sh (returnStatus: true, script: '''
+//         ./tests/scripts/git_change_docs.sh
+//         '''
+//         )
+//         sh "${docker_run} ${ci_lint}  ./tests/scripts/task_lint.sh"
+//       }
+//     }
+//   }
+// }
 
 // Run make. First try to do an incremental make from a previous workspace in hope to
 // accelerate the compilation. If something wrong, clean the workspace and then
@@ -223,6 +224,7 @@ stage('Build') {
     node('CPU') {
       ws(per_exec_ws('tvm/build-cpu')) {
         init_git()
+        sh "docker pull ${ci_cpu}"
         sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
         make(ci_cpu, 'build', '-j2')
         pack_lib('cpu', tvm_multilib_tsim)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = "tlcpack/ci-lint:v0.67"
 ci_gpu = "tlcpack/ci-gpu:v0.78"
-ci_cpu = "tlcpack/ci-cpu:v0.79"
+ci_cpu = "yuchenjin/ci-cpu:lastest"
 ci_wasm = "tlcpack/ci-wasm:v0.71"
 ci_i386 = "tlcpack/ci-i386:v0.74"
 ci_qemu = "tlcpack/ci-qemu:v0.08"
@@ -224,7 +224,7 @@ stage('Build') {
       ws(per_exec_ws('tvm/build-cpu')) {
         init_git()
         sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh"
-        make(ci_cpu, 'build', '-j20')
+        make(ci_cpu, 'build', '-j2')
         pack_lib('cpu', tvm_multilib_tsim)
         // timeout(time: max_time, unit: 'MINUTES') {
           // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ doc:
 
 # Cython build
 cython cython3:
-	cd python; python3 setup.py build_ext --inplace
+	cd python; python3.7 setup.py build_ext --inplace
 
 cyclean:
 	rm -rf python/tvm/*/*/*.so python/tvm/*/*/*.dylib python/tvm/*/*/*.cpp

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ doc:
 
 # Cython build
 cython cython3:
-	cd python; python3.7 setup.py build_ext --inplace
+	cd python; python3 setup.py build_ext --inplace
 
 cyclean:
 	rm -rf python/tvm/*/*/*.so python/tvm/*/*/*.dylib python/tvm/*/*/*.cpp

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -33,6 +33,9 @@
 #include <tvm/support/with.h>
 
 #include <memory>
+#include <stack>
+#include <string>
+#include <unordered_map>
 
 namespace tvm {
 namespace relax {

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -208,7 +208,7 @@ class Binding : public ObjectRef {
   using ContainerType = BindingNode;
 };
 
-/*! \brief Symbolic shape match, binds the variables of the LHS with the rhs. */
+/*! \brief Symbolic shape match, binds the variable of the lhs with the rhs. */
 class MatchShape;
 class MatchShapeNode : public BindingNode {
  public:

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef TVM_TVM_RELAX_EXPR_H_
-#define TVM_TVM_RELAX_EXPR_H_
+#ifndef TVM_RELAX_EXPR_H_
+#define TVM_RELAX_EXPR_H_
 
 #include <tvm/ir/expr.h>
 #include <tvm/ir/span.h>
@@ -460,4 +460,4 @@ class ExternFunc : public BaseFunc {
 }  // namespace relax
 }  // namespace tvm
 
-#endif  // TVM_TVM_RELAX_EXPR_H_
+#endif  // TVM_RELAX_EXPR_H_

--- a/include/tvm/relax/ir_functor.h
+++ b/include/tvm/relax/ir_functor.h
@@ -30,6 +30,8 @@
 #include <tvm/relax/expr.h>
 #include <tvm/relay/expr.h>
 
+#include <utility>
+
 namespace tvm {
 namespace relax {
 

--- a/include/tvm/relax/vm/bytecode.h
+++ b/include/tvm/relax/vm/bytecode.h
@@ -91,7 +91,7 @@ struct Instruction {
     /*! \brief The bit mask of the value part. */
     static constexpr ExecWord kValueMask = (static_cast<ExecWord>(1) << kValueBit) - 1;
     /*! \brief Construct a void argument. */
-    explicit Arg() : data(Instruction::kVoidArg) {}
+    Arg() : data(Instruction::kVoidArg) {}
     /*! \brief Construct from the data. */
     explicit Arg(ExecWord data) : data(data) {}
     /*! \brief Construct from the kind and value. */

--- a/include/tvm/relax/vm/exec_builder.h
+++ b/include/tvm/relax/vm/exec_builder.h
@@ -30,6 +30,9 @@
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/registry.h>
 
+#include <string>
+#include <vector>
+
 #include "./bytecode.h"
 #include "./executable.h"
 

--- a/include/tvm/relax/vm/executable.h
+++ b/include/tvm/relax/vm/executable.h
@@ -28,6 +28,10 @@
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/registry.h>
 
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "./bytecode.h"
 
 namespace tvm {

--- a/include/tvm/relax/vm/vm.h
+++ b/include/tvm/relax/vm/vm.h
@@ -24,6 +24,9 @@
 #ifndef TVM_RELAX_VM_VM_H_
 #define TVM_RELAX_VM_VM_H_
 
+#include <string>
+#include <vector>
+
 #include "./bytecode.h"
 #include "./executable.h"
 #include "./memory_manager.h"
@@ -109,10 +112,9 @@ class VirtualMachine : public runtime::ModuleNode {
    *   If the function needs resource from the module(e.g. late linking),
    *   it should capture sptr_to_self.
    */
-  virtual PackedFunc GetFunction(const std::string& name,
-                                 const ObjectPtr<Object>& sptr_to_self) final;
+  PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
-  virtual ~VirtualMachine() final {}
+  ~VirtualMachine() final {}
 
   const char* type_key() const final { return "relax.VirtualMachine"; }
   /*! \brief The state of the virtual machine, which can be referred by

--- a/python/tvm/ir/expr.py
+++ b/python/tvm/ir/expr.py
@@ -59,8 +59,7 @@ class RelayExpr(BaseExpr):
         shape : tvm.ir.RelayExpr
             The expression that represents the shape.
         """
-        return _ffi_api.RelayExprShape(self) 
-
+        return _ffi_api.RelayExprShape(self)
 
 
 @tvm._ffi.register_object("GlobalVar")

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+# pylint: disable=invalid-name, wrong-import-position
+"""The Relax IR namespace containing the IR, type, operator, and builder."""
 from . import exec_builder
 from . import expr
 from . import ty

--- a/python/tvm/relax/analysis/_ffi_api.py
+++ b/python/tvm/relax/analysis/_ffi_api.py
@@ -13,6 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
+"""FFI APIs for tvm.analysis"""
 import tvm._ffi
 
 tvm._ffi._init_api("relax.analysis", __name__)

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -22,7 +22,17 @@ from typing import List, Optional, Union, Any, Callable
 from tvm.runtime import Object
 from tvm import relax as rx, tir
 import tvm
-from .expr import Expr, te_tensor, Var, ShapeExpr, GlobalVar, PrimExpr, Call, BindingBlock, Tuple
+from .expr import (
+    Expr,
+    te_tensor,
+    Var,
+    ShapeExpr,
+    GlobalVar,
+    PrimExpr,
+    BindingBlock,
+    Tuple,
+    BaseFunc,
+)
 from .op.base import call_tir
 from . import _ffi_api
 

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -14,13 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=no-else-return
 """Developer API of constructing Relax AST."""
 import typing
-import tvm
+
 from typing import List, Optional, Union, Any, Callable
 from tvm.runtime import Object
-from tvm import relax as rx
-from tvm import tir
+from tvm import relax as rx, tir
+import tvm
 from .expr import Expr, te_tensor, Var, ShapeExpr, GlobalVar, PrimExpr, Call, BindingBlock, Tuple
 from .op.base import call_tir
 from . import _ffi_api

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -16,14 +16,13 @@
 # under the License.
 """Developer API of constructing Relax AST."""
 import typing
-from typing import List, Optional, Union, Dict, Any, Callable
-from tvm.relay.expr import Tuple
+import tvm
+from typing import List, Optional, Union, Any, Callable
 from tvm.runtime import Object
 from tvm import relax as rx
 from tvm import tir
-from .expr import *
+from .expr import Expr, te_tensor, Var, ShapeExpr, GlobalVar, PrimExpr, Call, BindingBlock, Tuple
 from .op.base import call_tir
-from tvm._ffi.base import _LIB, check_call
 from . import _ffi_api
 
 
@@ -40,7 +39,8 @@ class FunctionScope(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         # __exit__ should properly handle the case where the with block exits with an exception
-        # when handling error case in exit, always check if there is already an exception been thrown in the with block
+        # when handling error case in exit, always check if there is already an exception
+        # been thrown in the with block
         self._bb._exit_function_scope(exc_type, exc_val, exc_tb)
 
 
@@ -154,7 +154,8 @@ class BlockBuilder(Object):
 
     def _convert_te_arg(self, te_args: Any) -> typing.Tuple[Any, List[tvm.te.Tensor]]:
         """Helper function to convert Relax expressions to te tensor.
-        In the common case, the type of te_args is a Relax expression and is converted into a te tensor.
+        In the common case, the type of te_args is a Relax expression and is converted
+        into a te tensor.
         If te_args is a nested or recursive datatype (i.e list, dict, tvm.ir.Map, tvm.ir.Array),
         we recursive and convert any value of type Relax expression into a te tensor.
         Common values of type int, float, and str are preserved.
@@ -167,7 +168,8 @@ class BlockBuilder(Object):
         Returns
         -------
         ret : (Any, [tvm.te.Tensor])
-            A tuple of the converted te_args, and a list of te tensors for each converted Relax expression
+            A tuple of the converted te_args, and a list of te tensors for each converted
+            Relax expression
         """
         te_args_list = []
 
@@ -188,14 +190,14 @@ class BlockBuilder(Object):
                 return {k: _convert_te_arg_helper(arg[k]) for k in arg}
             elif isinstance(arg, (int, float, str)):
                 return arg
-            else:
-                raise TypeError("not supported type in emit_te: {}".format(type(arg)))
+            raise TypeError("not supported type in emit_te: {}".format(type(arg)))
 
         new_arg = _convert_te_arg_helper(te_args)
         return new_arg, te_args_list
 
     def _get_unbound_tir_vars(self, args: List[tvm.te.Tensor]) -> List[tvm.tir.Var]:
-        """get unbound TIR vars (i.e TIR vars used in the shape but is not itself a dimension of a shape)"""
+        """get unbound TIR vars (i.e TIR vars used in the shape but is not
+        itself a dimension of a shape)"""
         bound_vars = set()
         used_vars = set()
 
@@ -224,7 +226,8 @@ class BlockBuilder(Object):
 
         params : tvm.relax.Var | Tuple | List[tvm.relax.Var], optional
             The parameters of the function.
-            If params is None, it means deferring initialization of function parameters until emit_func_output.
+            If params is None, it means deferring initialization of function parameters
+            until emit_func_output.
 
         Returns
         -------
@@ -317,7 +320,8 @@ class BlockBuilder(Object):
             @tvm.script.ir_module
             class Module:
                 @T.prim_func
-                def te_func(var_rxplaceholder: T.handle, var_rxplaceholder_1: T.handle, var_compute: T.handle) -> None:
+                def te_func(var_rxplaceholder: T.handle, var_rxplaceholder_1: T.handle,
+                            var_compute: T.handle) -> None:
                     # function attr dict
                     T.func_attr({"global_symbol": "te_func"})
                     m = T.var("int64")
@@ -369,7 +373,8 @@ class BlockBuilder(Object):
                 def te_func(var_rxplaceholder: T.handle, var_compute: T.handle, n: T.int64) -> None:
                     # function attr dict
                     T.func_attr({"global_symbol": "te_func"})
-                    rxplaceholder = T.match_buffer(var_rxplaceholder, [n + T.int64(1)], dtype="float32")
+                    rxplaceholder = T.match_buffer(var_rxplaceholder, [n + T.int64(1)],
+                                                   dtype="float32")
                     compute = T.match_buffer(var_compute, [n + T.int64(1)], dtype="float32")
                     # body
                     # with T.block("root")
@@ -381,9 +386,11 @@ class BlockBuilder(Object):
                             compute[i] = rxplaceholder[i]
 
                 @R.function
-                def rx_func(x: Tensor[(n,), "float32"], y: Tensor[((n + 1),), "float32"]) -> Tensor[_, "float32"]:
+                def rx_func(x: Tensor[(n,), "float32"], y: Tensor[((n + 1),), "float32"])
+                    -> Tensor[_, "float32"]:
                     # block 0
-                    gv: Tensor[((n + 1),), "float32"] = relax.call_tir(((n + 1),), te_func, (y,), (n,))
+                    gv: Tensor[((n + 1),), "float32"]
+                    = relax.call_tir(((n + 1),), te_func, (y,), (n,))
                     return gv
         """
         new_args, te_arg_list = self._convert_te_arg(args)

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -135,7 +135,8 @@ class VarBinding(Binding):
 
 @tvm._ffi.register_object("relax.expr.BindingBlock")
 class BindingBlock(Node):
-    """base class of binding block, bindings inside can be impure (with side effect or control flow)"""
+    """base class of binding block, bindings inside can be impure
+    (with side effect or control flow)"""
 
     bindings: List[Binding]
 

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, unused-import, super-init-not-called
 """The expression nodes of Relax."""
-from typing import List, Optional, Union, Dict
+from typing import List, Optional
 import tvm._ffi
 from ..ir import Node, Span, SourceName, BaseFunc
 from ..runtime import String
@@ -35,6 +35,8 @@ const = relay.const
 
 @tvm._ffi.register_object("relax.expr.ShapeExpr")
 class ShapeExpr(Expr):
+    """A shape expression which allows users to construct a shape containing PrimExpr."""
+
     values: List[PrimExpr]
 
     def __init__(self, values: List[PrimExpr], span: Span = None) -> None:
@@ -57,6 +59,8 @@ def make_shape(shape: List[PrimExpr]) -> ShapeExpr:
 
 @tvm._ffi.register_object("relax.expr.Var")
 class Var(Expr):
+    """The variable class for all Relax bindings."""
+
     vid: Id
     type_annotation: Optional[Type]
 
@@ -82,6 +86,9 @@ class Var(Expr):
 
 @tvm._ffi.register_object("relax.expr.DataflowVar")
 class DataflowVar(Var):
+    """A sub-type of the variable node used to mark dataflow variables from
+    normal visible "function local" bindings."""
+
     def __init__(
         self,
         name_hint: str,
@@ -98,11 +105,15 @@ class DataflowVar(Var):
 
 @tvm._ffi.register_object("relax.expr.Binding")
 class Binding(Node):
+    """The base class of a binding in Relax."""
+
     ...
 
 
 @tvm._ffi.register_object("relax.expr.MatchShape")
 class MatchShape(Binding):
+    """Symbolic shape match, binds the variable of the lhs with the rhs."""
+
     value: Expr
     pattern: List[PrimExpr]
     var: Var
@@ -113,6 +124,8 @@ class MatchShape(Binding):
 
 @tvm._ffi.register_object("relax.expr.VarBinding")
 class VarBinding(Binding):
+    """Variable binding, bind he variable of the lhs with the rhs."""
+
     var: Var
     value: Expr
 
@@ -122,6 +135,8 @@ class VarBinding(Binding):
 
 @tvm._ffi.register_object("relax.expr.BindingBlock")
 class BindingBlock(Node):
+    """base class of binding block, bindings inside can be impure (with side effect or control flow)"""
+
     bindings: List[Binding]
 
     def __init__(self, bindings: List[Binding], span: Span = None) -> None:
@@ -130,12 +145,16 @@ class BindingBlock(Node):
 
 @tvm._ffi.register_object("relax.expr.DataflowBlock")
 class DataflowBlock(BindingBlock):
+    """dataflow block, bindings inside are pure (no side effect and no control flow)"""
+
     def __init__(self, bindings: List[Binding], span: Span = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.DataflowBlock, bindings, span)
 
 
 @tvm._ffi.register_object("relax.expr.SeqExpr")
 class SeqExpr(Expr):
+    """A sequence of binding blocks followed by an expression."""
+
     blocks: List[BindingBlock]
     body: Expr
 
@@ -145,6 +164,8 @@ class SeqExpr(Expr):
 
 @tvm._ffi.register_object("relax.expr.Function")
 class Function(BaseFunc):
+    """A Relax function."""
+
     name: Optional[GlobalVar]
     params: List[Var]
     body: Expr
@@ -163,6 +184,8 @@ class Function(BaseFunc):
 
 @tvm._ffi.register_object("relax.expr.ExternFunc")
 class ExternFunc(BaseFunc):
+    """extern function, which can represent a TIR PrimFunc or a PackedFunc."""
+
     global_symbol: String
 
     def __init__(self, global_symbol: String, span: Span = None) -> None:

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=invalid-name
+"""The expression nodes of Relax."""
 from typing import List, Optional, Union, Dict
 import tvm._ffi
 from ..ir import Node, Span, SourceName, BaseFunc
@@ -50,8 +52,7 @@ class ShapeExpr(Expr):
 def make_shape(shape: List[PrimExpr]) -> ShapeExpr:
     if isinstance(shape, (list, tuple)):
         return ShapeExpr(shape)
-    else:
-        raise ValueError("Wrong type")
+    raise ValueError("Wrong type")
 
 
 @tvm._ffi.register_object("relax.expr.Var")

--- a/python/tvm/relax/op/_ffi_api.py
+++ b/python/tvm/relax/op/_ffi_api.py
@@ -13,6 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
+"""FFI APIs for tvm.relax.op"""
 import tvm._ffi
 
 tvm._ffi._init_api("relax.op", __name__)

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -13,15 +13,18 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-from ...ir import BaseFunc, Array
-from ..expr import Expr, ShapeExpr, Tuple, Call
-from . import _ffi_api
+"""The base Relax operators."""
 from typing import Union, List
+from . import _ffi_api
+from ..expr import Expr, ShapeExpr, Tuple, Call
+from ...ir import Array
 
 
 def call_tir(
-    shape: Union[Tuple, ShapeExpr, List[int]], func: Expr, args: Union[Tuple, List[Expr]],
-    tir_vars: ShapeExpr = None
+    shape: Union[Tuple, ShapeExpr, List[int]],
+    func: Expr,
+    args: Union[Tuple, List[Expr]],
+    tir_vars: ShapeExpr = None,
 ) -> Call:
     """
     Call a destination-passing-style function and return the output.

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -18,6 +18,7 @@
 from tvm.ir import Attrs
 import tvm._ffi
 
+
 @tvm._ffi.register_object("relax.attrs.AllocStorageAttrs")
 class AllocStorageAttrs(Attrs):
     """Attributes used in alloc_storage operators"""

--- a/python/tvm/relax/transform/_ffi_api.py
+++ b/python/tvm/relax/transform/_ffi_api.py
@@ -13,6 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
+"""FFI APIs for tvm.transform"""
 import tvm._ffi
 
 tvm._ffi._init_api("relax.transform", __name__)

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=no-else-return
-# pylint: disable=unidiomatic-typecheck
+# pylint: disable=invalid-name
+"""Relax transformation passes."""
 import tvm.ir
 from . import _ffi_api
 

--- a/python/tvm/relax/ty.py
+++ b/python/tvm/relax/ty.py
@@ -29,8 +29,8 @@ class ShapeType(Type):
 
 
 @tvm._ffi.register_object("relax.DynTensorType")
-class DynTensorType(TensorType):
-    """A dynamic TensorType in Relax.
+class DynTensorType(Type):
+    """A dynamic tensor type in Relax.
 
     This is the type assigned to tensors with a known dtype and unknown shape.
 
@@ -50,5 +50,6 @@ class DynTensorType(TensorType):
 @tvm._ffi.register_object("relax.DimType")
 class DimType(Type):
     """The type of indices/shape dimensions in Relax."""
+
     def __init__(self, span: Span = None):
         self.__init_handle_by_constructor__(_ffi_api.DimType, span)

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -14,16 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+# pylint: disable=invalid-name
+"""The Relax virtual machine"""
 from typing import List, Optional, Union, Dict, Tuple
 import tvm
 from tvm import relax
 from tvm.ir.module import IRModule
 from tvm.runtime import Object, Device, Module, PackedFunc
-from tvm._ffi.base import _LIB, check_call
+
 from tvm.tir.function import PrimFunc
 from . import _ffi_api
-from . import transform
 from ..rpc.base import RPC_SESS_MASK
 
 

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, redefined-builtin
 """The Relax virtual machine"""
 from typing import List, Optional, Union, Dict, Tuple
 import tvm

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+# pylint: disable=invalid-name
+"""TVM Script Parser For Relax"""
 from __future__ import annotations
 
 import inspect
@@ -232,8 +233,7 @@ class RelaxTransformer(Transformer):
                 return (relax.ShapeType(span), None)
             elif ty.id.name == "Dim":
                 return (relax.DimType(span), None)
-            else:
-                self.report_error("unknown type in annotation", span)
+            self.report_error("unknown type in annotation", span)
 
         # annotation with type arguments/shape annotation
         if isinstance(ty, ast.TypeApply):
@@ -894,7 +894,8 @@ class RelaxTransformer(Transformer):
                 # call_tir is special case because last argument is optional
                 if len(args) != 3 and len(args) != 4:
                     self.report_error(
-                        f"{op.name} expects {op.num_inputs} arguments but got {len(args)}", expr.span
+                        f"{op.name} expects {op.num_inputs} arguments but got {len(args)}",
+                        expr.span,
                     )
             elif op.num_inputs != -1 and len(args) != op.num_inputs:
                 self.report_error(
@@ -1172,7 +1173,8 @@ def from_source(
         raise TypeError("Only function definitions are supported.")
 
 
-# def fromtext(source: str, source_name: str = "from_string") -> Union[relax.Function, tvm.IRModule]:
+# def fromtext(source: str, source_name: str = "from_string")
+# -> Union[relax.Function, tvm.IRModule]:
 #     """Parses the given input string (in the Relax text format) to a Relax AST.
 
 #     Parameters

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name,no-else-return, inconsistent-return-statements
+# pylint: disable=invalid-name, no-else-return
+# pylint: disable=inconsistent-return-statements, ungrouped-imports
 """TVM Script Parser For Relax"""
 from __future__ import annotations
 
@@ -26,12 +27,11 @@ import tvm
 import tvm.script
 from tvm.ir.module import IRModule
 from tvm.ir import diagnostics
-from tvm import tir
 
 import synr
 from synr import ast, Transformer
 
-from tvm import relay, relax
+from tvm import relay, relax, tir
 
 import tvm.script.relax as relax_namespace
 import tvm.script.tir as tir_namespace
@@ -1038,7 +1038,7 @@ class RelaxTransformer(Transformer):
                 assert isinstance(parsed_stmt, relax.Binding)
                 current_block.append(parsed_stmt)
         if len(current_block) > 0:
-            blocks.append(relax.BindingBlock(current_block, self.to_tvm_span(stmt.span)))
+            blocks.append(relax.BindingBlock(current_block, self.to_tvm_span(block.stmts[-1].span)))
 
         ret_stmt = block.stmts[-1]
         if not isinstance(ret_stmt, ast.Return):

--- a/python/tvm/script/utils.py
+++ b/python/tvm/script/utils.py
@@ -67,7 +67,9 @@ def get_param_list(
 
 def tvm_span_from_synr(span: synr.ast.Span) -> Span:
     """Convert a synr span to a TVM span"""
-    assert isinstance(span, synr.ast.Span), "Expected span to be synr.ast.Span, but got " + str(type(span))
+    assert isinstance(span, synr.ast.Span), "Expected span to be synr.ast.Span, but got " + str(
+        type(span)
+    )
     return Span(
         SourceName(span.filename),
         span.start_line,
@@ -79,7 +81,9 @@ def tvm_span_from_synr(span: synr.ast.Span) -> Span:
 
 def synr_span_from_tvm(span: Span) -> synr.ast.Span:
     """Convert a TVM span to a synr span"""
-    assert isinstance(span, synr.ast.Span), "Expected span to be tvm.ir.Span, but got " + str(type(span))
+    assert isinstance(span, synr.ast.Span), "Expected span to be tvm.ir.Span, but got " + str(
+        type(span)
+    )
     return synr.ast.Span(
         span.source_name.name,
         span.line,

--- a/python/tvm/te/operation.py
+++ b/python/tvm/te/operation.py
@@ -429,7 +429,9 @@ def reduce_axis(dom, name="rv", thread_tag="", span=None):
     return tvm.tir.IterVar(dom, name, 2, thread_tag, span)
 
 
-def create_prim_func(ops: List[_tensor.Tensor], tir_var_list: List[tvm.tir.Var] = None) -> tvm.tir.PrimFunc:
+def create_prim_func(
+    ops: List[_tensor.Tensor], tir_var_list: List[tvm.tir.Var] = None
+) -> tvm.tir.PrimFunc:
     """Create a TensorIR PrimFunc from tensor expression
 
     Parameters

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -174,7 +174,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     shape_tuple_value = shape_tuple;
     Index index = builder_->EmitConstant(shape_tuple_value);
     args.push_back(Instruction::Arg(Instruction::kConstIdx, index));
-    
+
     size_t arg_register = NewRegister();
     builder_->EmitCall("vm.runtime.TupleGetItem", args, arg_register);
 

--- a/src/relax/backend/vm/codegen_vm.h
+++ b/src/relax/backend/vm/codegen_vm.h
@@ -22,8 +22,8 @@
  * \brief A codegen to generate VM executable from an IRModule with relax functions.
  */
 
-#ifndef TVM_RELAX_BACKEND_CODEGEN_VM_H_
-#define TVM_RELAX_BACKEND_CODEGEN_VM_H_
+#ifndef TVM_RELAX_BACKEND_VM_CODEGEN_VM_H_
+#define TVM_RELAX_BACKEND_VM_CODEGEN_VM_H_
 
 #include <tvm/ir/module.h>
 #include <tvm/relax/vm/exec_builder.h>
@@ -65,4 +65,4 @@ class VMCodeGen : public Object {
 }  // namespace relax
 }  // namespace tvm
 
-#endif  // TVM_RELAX_BACKEND_CODEGEN_VM_H_
+#endif  // TVM_RELAX_BACKEND_VM_CODEGEN_VM_H_

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -34,7 +34,7 @@ namespace relax {
 
 class VMShapeLowerMutator : public ExprMutator {
  public:
-  static DataType ShapeDType() { return DataType::Int(64); };
+  static DataType ShapeDType() { return DataType::Int(64); }
 
   explicit VMShapeLowerMutator(IRModule mod) { mod_ = mod; }
 
@@ -73,7 +73,7 @@ class VMShapeLowerMutator : public ExprMutator {
     std::string shape_func_name = builder_->name_table()->GetUniqueName("shape_func");
     func = WithAttr(std::move(func), "global_symbol", runtime::String(shape_func_name));
     GlobalVar shape_func_var(shape_func_name);
-    // TODO make sure shape_heap doesnt get redefined by local funcs?
+    // TODO(@ziheng) make sure shape_heap doesnt get redefined by local funcs?
     builder_->Emit(Call(shape_func_var, {shape_heap_}), "_");
     ret_mod_->Add(shape_func_var, func);
 

--- a/src/relax/ir/emit_te.h
+++ b/src/relax/ir/emit_te.h
@@ -27,6 +27,8 @@
 #include <tvm/relax/expr.h>
 #include <tvm/te/operation.h>
 
+#include <string>
+
 namespace tvm {
 namespace relax {
 

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -446,8 +446,8 @@ void ExprMutator::VisitBinding_(const MatchShapeNode* binding) {
   }
 
   // TODO(@altanh, @yuchen): shape and type inference here too...
-  // TODO: when value's shape/type changed, create new var
-  // TODO: group the can prove shape/type logic and replace var into a function
+  // TODO(@yuchen): when value's shape/type changed, create new var
+  // TODO(@yuchen): group the can prove shape/type logic and replace var into a function
   builder_->EmitMatchShape(
       MatchShape(new_value, Downcast<ShapeExpr>(new_pattern)->values, new_var));
 }

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -74,12 +74,12 @@ Expr MakeCallTIR(Expr shape, Expr func, Tuple args, Optional<Expr> packed_ints) 
     // multiple output tensors
     Array<Type> types;
     for (size_t i = 0; i < Downcast<Tuple>(shape)->fields.size(); i++) {
-      // TODO: fix checked_type_ inference
+      // TODO(@yuchen): fix checked_type_ inference
       types.push_back(args->fields[0]->checked_type_);
     }
     call->checked_type_ = TupleType(types);
   } else {
-    // TODO: fix checked_type_ inference
+    // TODO(@yuchen): fix checked_type_ inference
     call->checked_type_ = args->fields[0]->checked_type_;
   }
   return call;

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -21,8 +21,15 @@
  * \file binary.h
  * \brief shape and type deduction for binary broadcast operators.
  */
+
+#ifndef TVM_RELAX_OP_TENSOR_BINARY_H_
+#define TVM_RELAX_OP_TENSOR_BINARY_H_
+
 #include <tvm/relax/expr.h>
 #include <tvm/relax/type.h>
+
+#include <algorithm>
+#include <vector>
 
 #include "../op_common.h"
 
@@ -107,3 +114,5 @@ Type InferTypeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx) {
 
 }  // namespace relax
 }  // namespace tvm
+
+#endif  // TVM_RELAX_OP_TENSOR_BINARY_H_

--- a/src/relax/op/tensor/ternary.h
+++ b/src/relax/op/tensor/ternary.h
@@ -21,8 +21,14 @@
  * \file ternary.h
  * \brief shape and type deduction for ternary operators.
  */
+
+#ifndef TVM_RELAX_OP_TENSOR_TERNARY_H_
+#define TVM_RELAX_OP_TENSOR_TERNARY_H_
+
 #include <tvm/relax/expr.h>
 #include <tvm/relax/type.h>
+
+#include <vector>
 
 #include "../op_common.h"
 
@@ -105,3 +111,5 @@ Type InferTypeEwiseFMA(const Call& call, DiagnosticContext diag_ctx) {
 
 }  // namespace relax
 }  // namespace tvm
+
+#endif  // TVM_RELAX_OP_TENSOR_TERNARY_H_

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -59,11 +59,14 @@ class CallTIRMutator : public ExprMutator {
         outs.push_back(builder_->Emit(Call(alloc_tensor_op, {output_shape}), "alloc"));
       } else {
         // multiple output case
-        CHECK(call->args[0]->IsInstance<TupleNode>()) << "call_dps expects ShapeExpr or Tuple as first argument, got " << call->args[0];
+        CHECK(call->args[0]->IsInstance<TupleNode>())
+            << "call_dps expects ShapeExpr or Tuple as first argument, got " << call->args[0];
         Tuple output_shapes = Downcast<Tuple>(call->args[0]);
-        for (const auto& shape: output_shapes->fields) {
-          CHECK(shape->IsInstance<ShapeExprNode>()) << "call_dps exoects Tuple of ShapeExprs, got " << shape << " as an element of tuple";
-          outs.push_back(builder_->Emit(Call(alloc_tensor_op, {Downcast<ShapeExpr>(shape)}), "alloc"));
+        for (const auto& shape : output_shapes->fields) {
+          CHECK(shape->IsInstance<ShapeExprNode>())
+              << "call_dps exoects Tuple of ShapeExprs, got " << shape << " as an element of tuple";
+          outs.push_back(
+              builder_->Emit(Call(alloc_tensor_op, {Downcast<ShapeExpr>(shape)}), "alloc"));
         }
       }
 

--- a/src/relax/vm/vm.cc
+++ b/src/relax/vm/vm.cc
@@ -30,8 +30,7 @@ namespace relax_vm {
 
 class DummyModule : public runtime::ModuleNode {
  public:
-  virtual PackedFunc GetFunction(const std::string& name,
-                                 const ObjectPtr<Object>& sptr_to_self) final {
+  PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     return nullptr;
   }
 

--- a/tests/lint/clang_format.sh
+++ b/tests/lint/clang_format.sh
@@ -17,7 +17,7 @@
 # under the License.
 
 
-# check lastest change, for squash merge into main
-./tests/lint/git-clang-format.sh HEAD~1
+# check lastest 5 change, for squash merge into relax
+./tests/lint/git-clang-format.sh HEAD~5
 # check against origin/relax for PRs.
 # ./tests/lint/git-clang-format.sh origin/relax

--- a/tests/lint/clang_format.sh
+++ b/tests/lint/clang_format.sh
@@ -19,5 +19,5 @@
 
 # check lastest change, for squash merge into main
 ./tests/lint/git-clang-format.sh HEAD~1
-# chekc against origin/main for PRs.
-./tests/lint/git-clang-format.sh origin/main
+# check against origin/relax for PRs.
+# ./tests/lint/git-clang-format.sh origin/relax

--- a/tests/lint/cpplint.sh
+++ b/tests/lint/cpplint.sh
@@ -17,8 +17,5 @@
 # under the License.
 
 
-python3 3rdparty/dmlc-core/scripts/lint.py vta cpp vta/include vta/src
 python3 3rdparty/dmlc-core/scripts/lint.py tvm cpp \
-	include src \
-	examples/extension/src examples/graph_executor/src \
-	tests/cpp tests/crt
+	include/tvm/relax src/relax/

--- a/tests/lint/python_format.sh
+++ b/tests/lint/python_format.sh
@@ -17,5 +17,5 @@
 # under the License.
 
 
-./tests/lint/git-black.sh HEAD~1
-./tests/lint/git-black.sh origin/main
+./tests/lint/git-black.sh HEAD~5
+# ./tests/lint/git-black.sh origin/relax

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -195,6 +195,7 @@ def test_var_redefine_fail_if():
 def test_var_if_scoping_fail():
     # TODO: fix this
     with pytest.raises(tvm.error.DiagnosticError):
+
         @R.function
         def f(cond: Tensor[(), "bool"], x: Tensor[(1,), "float32"]):
             if cond:
@@ -208,6 +209,7 @@ def test_var_if_scoping_fail():
 
 def test_if_mismatch_var_fail():
     with pytest.raises(tvm.error.DiagnosticError):
+
         @R.function
         def f(cond: Tensor[(), "bool"], x: Tensor[(1,), "float32"]):
             if cond:
@@ -351,6 +353,7 @@ def test_dataflow_scope_fail():
 
 def test_dataflow_syntax_fail_pattern():
     with pytest.raises(tvm.error.DiagnosticError):
+
         @R.function
         def f(x: Tensor[_, _]):
             with relax.dataflow() as df:
@@ -364,6 +367,7 @@ def test_dataflow_syntax_fail_pattern():
 
 def test_dataflow_syntax_fail_params():
     with pytest.raises(tvm.error.DiagnosticError):
+
         @R.function
         def f(x: Tensor[_, _]):
             with relax.dataflow(x) as df:
@@ -377,6 +381,7 @@ def test_dataflow_syntax_fail_params():
 
 def test_dataflow_unbound_outputs():
     with pytest.raises(tvm.error.DiagnosticError):
+
         @R.function
         def f(x: Tensor[_, _]):
             with relax.dataflow():
@@ -390,6 +395,7 @@ def test_dataflow_unbound_outputs():
 
 def test_invalid_special_op_dataflow():
     with pytest.raises(tvm.error.DiagnosticError):
+
         @R.function
         def f(x: Tensor):
             y = add(x, x)
@@ -399,6 +405,7 @@ def test_invalid_special_op_dataflow():
 
 def test_invalid_special_op_output():
     with pytest.raises(tvm.error.DiagnosticError):
+
         @R.function
         def f(x: Tensor):
             y = add(x, x)
@@ -408,6 +415,7 @@ def test_invalid_special_op_output():
 
 def test_func_no_return_fail():
     with pytest.raises(tvm.error.DiagnosticError):
+
         @R.function
         def f(x: Tensor[_, _]):
             y = add(x, x)

--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -42,7 +42,7 @@ function run_pytest() {
         echo "usage: run_pytest <FFI_TYPE> <TEST_SUITE_NAME> [pytest args...]"
         exit 2
     fi
-    TVM_FFI=${ffi_type} python3.7 -m pytest \
+    TVM_FFI=${ffi_type} python3 -m pytest \
            -o "junit_suite_name=${test_suite_name}-${ffi_type}" \
            "--junit-xml=${TVM_PYTEST_RESULT_DIR}/${test_suite_name}-${ffi_type}.xml" \
            "--junit-prefix=${ffi_type}" \

--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -42,7 +42,7 @@ function run_pytest() {
         echo "usage: run_pytest <FFI_TYPE> <TEST_SUITE_NAME> [pytest args...]"
         exit 2
     fi
-    TVM_FFI=${ffi_type} python3 -m pytest \
+    TVM_FFI=${ffi_type} python3.7 -m pytest \
            -o "junit_suite_name=${test_suite_name}-${ffi_type}" \
            "--junit-xml=${TVM_PYTEST_RESULT_DIR}/${test_suite_name}-${ffi_type}.xml" \
            "--junit-prefix=${ffi_type}" \

--- a/tests/scripts/task_ci_setup.sh
+++ b/tests/scripts/task_ci_setup.sh
@@ -30,7 +30,7 @@ set -o pipefail
 #
 echo "Addtiional setup in" ${CI_IMAGE_NAME}
 
-python3.7 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0
+python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0
 
 # Rebuild standalone_crt in build/ tree. This file is not currently archived by pack_lib() in
 # Jenkinsfile. We expect config.cmake to be present from pack_lib().

--- a/tests/scripts/task_ci_setup.sh
+++ b/tests/scripts/task_ci_setup.sh
@@ -30,7 +30,7 @@ set -o pipefail
 #
 echo "Addtiional setup in" ${CI_IMAGE_NAME}
 
-python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.5.0
+python3.7 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0
 
 # Rebuild standalone_crt in build/ tree. This file is not currently archived by pack_lib() in
 # Jenkinsfile. We expect config.cmake to be present from pack_lib().

--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -23,29 +23,29 @@ mkdir -p build
 cd build
 cp ../cmake/config.cmake .
 
-echo set\(USE_SORT ON\) >> config.cmake
-echo set\(USE_MICRO ON\) >> config.cmake
-echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
-echo set\(USE_PROFILER ON\) >> config.cmake
-echo set\(USE_DNNL_CODEGEN ON\) >> config.cmake
-echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
+# echo set\(USE_SORT ON\) >> config.cmake
+# echo set\(USE_MICRO ON\) >> config.cmake
+# echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
+# echo set\(USE_PROFILER ON\) >> config.cmake
+# echo set\(USE_DNNL_CODEGEN ON\) >> config.cmake
+# echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
 echo set\(USE_LLVM llvm-config-11\) >> config.cmake
-echo set\(USE_NNPACK ON\) >> config.cmake
-echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
-echo set\(USE_ANTLR ON\) >> config.cmake
+# echo set\(USE_NNPACK ON\) >> config.cmake
+# echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
+# echo set\(USE_ANTLR ON\) >> config.cmake
 echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
-echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
-echo set\(USE_VTA_TSIM ON\) >> config.cmake
-echo set\(USE_VTA_FSIM ON\) >> config.cmake
-echo set\(USE_TFLITE ON\) >> config.cmake
-echo set\(USE_TENSORFLOW_PATH \"/tensorflow\"\) >> config.cmake
-echo set\(USE_FLATBUFFERS_PATH \"/flatbuffers\"\) >> config.cmake
-echo set\(USE_ETHOSN /opt/arm/ethosn-driver\) >> config.cmake
-echo set\(USE_ETHOSN_HW OFF\) >> config.cmake
-echo set\(USE_CMSISNN ON\) >> config.cmake
-echo set\(USE_VITIS_AI ON\) >> config.cmake
-echo set\(USE_VERILATOR ON\) >> config.cmake
-echo set\(USE_LIBBACKTRACE ON\) >> config.cmake
+# echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
+# echo set\(USE_VTA_TSIM ON\) >> config.cmake
+# echo set\(USE_VTA_FSIM ON\) >> config.cmake
+# echo set\(USE_TFLITE ON\) >> config.cmake
+# echo set\(USE_TENSORFLOW_PATH \"/tensorflow\"\) >> config.cmake
+# echo set\(USE_FLATBUFFERS_PATH \"/flatbuffers\"\) >> config.cmake
+# echo set\(USE_ETHOSN /opt/arm/ethosn-driver\) >> config.cmake
+# echo set\(USE_ETHOSN_HW OFF\) >> config.cmake
+# echo set\(USE_CMSISNN ON\) >> config.cmake
+# echo set\(USE_VITIS_AI ON\) >> config.cmake
+# echo set\(USE_VERILATOR ON\) >> config.cmake
+# echo set\(USE_LIBBACKTRACE ON\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake
-echo set\(USE_ETHOSU ON\) >> config.cmake
+# echo set\(USE_ETHOSU ON\) >> config.cmake

--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -30,6 +30,7 @@ cp ../cmake/config.cmake .
 # echo set\(USE_DNNL_CODEGEN ON\) >> config.cmake
 # echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
 echo set\(USE_LLVM llvm-config-11\) >> config.cmake
+echo set\(USE_BLAS openblas\) >> config.cmake
 # echo set\(USE_NNPACK ON\) >> config.cmake
 # echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
 # echo set\(USE_ANTLR ON\) >> config.cmake

--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -47,5 +47,5 @@ tests/lint/pylint.sh
 tests/lint/flake8.sh
 
 #TODO(@yuchen) fix mypy in relax
-# echo "Type checking with MyPy ..."
-# tests/scripts/task_mypy.sh
+echo "Type checking with MyPy ..."
+tests/scripts/task_mypy.sh

--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -47,5 +47,5 @@ tests/lint/pylint.sh
 tests/lint/flake8.sh
 
 #TODO(@yuchen) fix mypy in relax
-echo "Type checking with MyPy ..."
-tests/scripts/task_mypy.sh
+# echo "Type checking with MyPy ..."
+# tests/scripts/task_mypy.sh

--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -39,9 +39,6 @@ tests/lint/cpplint.sh
 echo "clang-format check..."
 tests/lint/clang_format.sh
 
-echo "Rust check..."
-tests/lint/rust_format.sh
-
 echo "black check..."
 tests/lint/python_format.sh
 
@@ -49,11 +46,6 @@ echo "Linting the Python code..."
 tests/lint/pylint.sh
 tests/lint/flake8.sh
 
-echo "Lintinf the JNI code..."
-tests/lint/jnilint.sh
-
-echo "Checking C++ documentation..."
-tests/lint/cppdocs.sh
-
-echo "Type checking with MyPy ..."
-tests/scripts/task_mypy.sh
+#TODO(@yuchen) fix mypy in relax
+# echo "Type checking with MyPy ..."
+# tests/scripts/task_mypy.sh

--- a/tests/scripts/task_mypy.sh
+++ b/tests/scripts/task_mypy.sh
@@ -21,21 +21,6 @@ set -u
 set -o pipefail
 source tests/scripts/setup-pytest-env.sh
 
-echo "Checking MyPy Type defs in the TensorIR schedule package."
-mypy  --check-untyped-defs python/tvm/tir/schedule
 
-echo "Checking MyPy Type defs in the meta schedule package."
-mypy  --check-untyped-defs python/tvm/meta_schedule
-
-echo "Checking MyPy Type defs in the analysis package."
-mypy  --check-untyped-defs python/tvm/tir/analysis/
-
-echo "Checking MyPy Type defs in the transform package."
-mypy  --check-untyped-defs python/tvm/tir/transform/
-
-echo "Checking MyPy Type defs in the TIR package with unittest"
-MYPYPATH=$TVM_PATH/python mypy --check-untyped-defs tests/python/unittest/test_tvmscript_type.py
-
-#TODO(@mikepapadim): This is failing atm
-# echo "Checking MyPy Type defs in the tvm.relay.backend.contrib.ethosu package."
-# mypy  --check-untyped-defs python/tvm/relay/backend/contrib/ethosu/
+echo "Checking MyPy Type defs in the relax package."
+mypy  --check-untyped-defs python/tvm/relax/

--- a/tests/scripts/task_mypy.sh
+++ b/tests/scripts/task_mypy.sh
@@ -21,6 +21,24 @@ set -u
 set -o pipefail
 source tests/scripts/setup-pytest-env.sh
 
+# echo "Checking MyPy Type defs in the TensorIR schedule package."
+# mypy  --check-untyped-defs python/tvm/tir/schedule
+
+# echo "Checking MyPy Type defs in the meta schedule package."
+# mypy  --check-untyped-defs python/tvm/meta_schedule
+
+# echo "Checking MyPy Type defs in the analysis package."
+# mypy  --check-untyped-defs python/tvm/tir/analysis/
+
+# echo "Checking MyPy Type defs in the transform package."
+# mypy  --check-untyped-defs python/tvm/tir/transform/
+
+# echo "Checking MyPy Type defs in the TIR package with unittest"
+# MYPYPATH=$TVM_PATH/python mypy --check-untyped-defs tests/python/unittest/test_tvmscript_type.py
+
+#TODO(@mikepapadim): This is failing atm
+# echo "Checking MyPy Type defs in the tvm.relay.backend.contrib.ethosu package."
+# mypy  --check-untyped-defs python/tvm/relay/backend/contrib/ethosu/
 
 echo "Checking MyPy Type defs in the relax package."
 mypy  --check-untyped-defs python/tvm/relax/

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -39,38 +39,38 @@ find . -type f -path "*.pyc" | xargs rm -f
 make cython3
 
 # Test extern package
-cd apps/extension
-rm -rf lib
-make
-cd ../..
+# cd apps/extension
+# rm -rf lib
+# make
+# cd ../..
 
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-extensions apps/extension/tests
-run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-extensions apps/extension/tests
+# run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-extensions apps/extension/tests
+# run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-extensions apps/extension/tests
 
-# Test dso plugin
-cd apps/dso_plugin_module
-rm -rf lib
-make
-cd ../..
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module apps/dso_plugin_module
-run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module apps/dso_plugin_module
+# # Test dso plugin
+# cd apps/dso_plugin_module
+# rm -rf lib
+# make
+# cd ../..
+# run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module apps/dso_plugin_module
+# run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module apps/dso_plugin_module
 
 # Do not enable TensorFlow op
 # TVM_FFI=cython sh prepare_and_test_tfop_module.sh
 # TVM_FFI=ctypes sh prepare_and_test_tfop_module.sh
 
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME} tests/python/integration
-if python3 -c "import tvm; from tvm.relay.op.contrib.ethosn import ethosn_available; print(ethosn_available().name)" -eq "SW_ONLY"; then
-  ETHOSN_VARIANT_CONFIG=Ethos-N78_1TOPS_2PLE_RATIO run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib-test_ethosn tests/python/contrib/test_ethosn
-fi
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib
+# run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME} tests/python/integration
+# if python3 -c "import tvm; from tvm.relay.op.contrib.ethosn import ethosn_available; print(ethosn_available().name)" -eq "SW_ONLY"; then
+#   ETHOSN_VARIANT_CONFIG=Ethos-N78_1TOPS_2PLE_RATIO run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib-test_ethosn tests/python/contrib/test_ethosn
+# fi
+# run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib
 
 # forked is needed because the global registry gets contaminated
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
-    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relay tests/python/relay
+    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relax tests/python/relax
 
 # Command line driver test
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-driver tests/python/driver
+# run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-driver tests/python/driver
 
 # Do not enable OpenGL
 # run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-webgl tests/webgl

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -69,8 +69,8 @@ TVM_TEST_TARGETS="llvm" pytest tests/python/relax
 # run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib
 
 # forked is needed because the global registry gets contaminated
-TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
-    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relax tests/python/relax
+# TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
+#     run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relax tests/python/relax
 
 # Command line driver test
 # run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-driver tests/python/driver

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -27,16 +27,19 @@ export LD_LIBRARY_PATH="build:${LD_LIBRARY_PATH:-}"
 export TVM_BIND_THREADS=0
 export TVM_NUM_THREADS=2
 
+# Run Relax tests
+TVM_TEST_TARGETS="llvm" pytest tests/python/relax
+
 # NOTE: also set by task_python_integration_gpuonly.sh.
-if [ -z "${TVM_INTEGRATION_TESTSUITE_NAME:-}" ]; then
-    TVM_INTEGRATION_TESTSUITE_NAME=python-integration
-fi
+# if [ -z "${TVM_INTEGRATION_TESTSUITE_NAME:-}" ]; then
+#     TVM_INTEGRATION_TESTSUITE_NAME=python-integration
+# fi
 
 # cleanup pycache
-find . -type f -path "*.pyc" | xargs rm -f
+# find . -type f -path "*.pyc" | xargs rm -f
 
 # Test TVM
-make cython3
+# make cython3
 
 # Test extern package
 # cd apps/extension
@@ -74,7 +77,3 @@ TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
 
 # Do not enable OpenGL
 # run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-webgl tests/webgl
-
-# forked is needed because the global registry gets contaminated
-TVM_TEST_TARGETS="llvm" \
-    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relax tests/python/relax

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -74,3 +74,7 @@ TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
 
 # Do not enable OpenGL
 # run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-webgl tests/webgl
+
+# forked is needed because the global registry gets contaminated
+TVM_TEST_TARGETS="llvm" \
+    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relax tests/python/relax


### PR DESCRIPTION
This PR sets up CI for Relax:
- Adjusts Jenkensfile and scripts to run CI on relax-only code and test.
- Refactors codebase to pass format and lint checks.

Notes:
- `ci_cpu` is pointed to a personal docker image for now because Relax code needs Python3.7+, while the dockers under tlcpack only have Python3.6. We will shift to tlcpack docker image once the python version is upgraded.
- Mypy type checking is disabled for now. We need to add type hints in future PRs as part of #43.
