### PR TITLE
[Pass] Refactor shape lowering pass to better handle static shape cases

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -147,12 +147,12 @@ class BlockBuilderNode : public Object {
   /*!
    * \brief Add a Relax function or a TIR PrimFunc to \p context_mod_.
    * \param func The function to be added.
-   * \param func_name The name of the function to be added.
+   * \param func_name_hint The name hint of the function to be added.
    * \note If the function to be added already exists in \p context_mod_, return its
    * GlobalVar directly.
    * \return The global var bound to the added function.
    */
-  GlobalVar AddFuncToContext(const BaseFunc& func, const String& func_name);
+  GlobalVar AddFuncToContext(const BaseFunc& func, const String& func_name_hint);
 
   /*!
    * \brief Get the context IRModule being built.

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -259,7 +259,6 @@ class BlockBuilder(Object):
                         )
                     )
 
-        name = self.get_unique_name(name)
         return FunctionScope(self, name, params)
 
     def dataflow(self) -> DataflowScope:
@@ -419,8 +418,7 @@ class BlockBuilder(Object):
 
         inputs = [*te_args] + outs
         tir_func = tvm.te.create_prim_func(inputs, unbound_tir_vars)
-        func_name = self.get_unique_name(func.__name__)
-        gvar = self.add_func(tir_func, func_name)
+        gvar = self.add_func(tir_func, func.__name__)
 
         call_args = [x.op.value for x in te_args]
         output_shape = (

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -526,13 +526,14 @@ BlockBuilderNode::BlockFrame* BlockBuilderNode::CurrentFrame() {
 
 NameTable* BlockBuilderNode::name_table() { return name_table_.get(); }
 
-GlobalVar BlockBuilderNode::AddFuncToContext(const BaseFunc& func, const String& func_name) {
+GlobalVar BlockBuilderNode::AddFuncToContext(const BaseFunc& func, const String& func_name_hint) {
   auto it = func_map_.find(func);
   if (it == func_map_.end()) {
+    String func_name = name_table_->GetUniqueName(func_name_hint);
     GlobalVar gvar = GlobalVar(func_name);
     if (const tir::PrimFuncNode* prim_func = func.as<tir::PrimFuncNode>()) {
       tir::PrimFunc fn = GetRef<tir::PrimFunc>(prim_func);
-      fn = WithAttr(std::move(fn), "global_symbol", runtime::String(func_name));
+      fn = WithAttr(std::move(fn), "global_symbol", func_name);
       context_mod_->Add(gvar, fn);
     } else {
       context_mod_->Add(gvar, func);

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -28,6 +28,7 @@ namespace relax {
 
 TVM_REGISTER_NODE_TYPE(AllocStorageAttrs);
 TVM_REGISTER_NODE_TYPE(AllocTensorAttrs);
+TVM_REGISTER_NODE_TYPE(ShapeHeapAttrs);
 
 bool EqualConstInt(const PrimExpr& lhs, int64_t value) {
   if (const int64_t* pvalue = tir::as_const_int(lhs)) {

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -326,6 +326,7 @@ def test_emit_te_multiple():
     type_anno = rx.DynTensorType(2, "float32")
     x = rx.Var("x", [n, m], type_anno)
     y = rx.Var("y", [n, m], type_anno)
+    z = rx.Var("z", [128, m], type_anno)
 
     def te_func(A):
         B = te.compute((128, 128), lambda i, j: A[i, j] + 1)
@@ -334,7 +335,8 @@ def test_emit_te_multiple():
     with bb.function("rx_func", [x, y]):
         x1 = bb.emit_te(te_func, x)
         y1 = bb.emit_te(te_func, y)
-        bb.emit_func_output(y1)
+        z1 = bb.emit_te(te_func, z)
+        bb.emit_func_output(z1)
 
     mod = bb.get()
     rx_func = mod["rx_func"]
@@ -344,10 +346,11 @@ def test_emit_te_multiple():
         if isinstance(mod[gv], PrimFunc):
             prim_func.append(mod[gv])
 
-    # only one PrimFunc is generated
-    assert len(prim_func) == 1
+    # only two PrimFuncs were generated since two of them are equal so got deduped
+    assert len(prim_func) == 2
     assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "te_func"
     assert rx_func.body.blocks[0].bindings[1].value.args[1].name_hint == "te_func"
+    assert rx_func.body.blocks[0].bindings[2].value.args[1].name_hint == "te_func1"
 
 
 def test_emit_te_multiple_output():


### PR DESCRIPTION
Currently the shape lowering pass allocates a shape heap and stores the shapes into the heap for static shape cases, for example suppose we have a Relax program as below:
```python
@tvm.script.ir_module
class Module:
    @relax.function
    def foo(x: Tensor[(2, 3), "float32"]) -> Tensor[_, _]:
        # block 0
        with relax.dataflow():
            y = relax.call_tir((2, 6), "test.vm.tile", x)
            relax.output(y)
        return y
```

After building it, it becomes:
```python
@tvm.script.ir_module
class Module:
    @relax.function
    def foo(x: Tensor[(2, 3), "float32"]) -> Tensor[_, _]:
        # block 0
        shape_heap: Tensor[(5,), "int64"] = relax.call_packed("vm.builtin.alloc_shape_heap", (5,))
        sh = relax.call_packed("vm.builtin.shape_of", x)
        gv = relax.vm.builtin.store_shape(sh, shape_heap, indices=[0, 1], attrs_type_key="relax.attrs.ShapeHeapAttrs")
        # block 1
        storage = relax.vm.builtin.alloc_storage((48,), device_type=1, dtype="float32", attrs_type_key="relax.attrs.AllocStorageAttrs")
        tensor = relax.vm.builtin.alloc_tensor(storage, (2, 6), offset=0, dtype="float32", attrs_type_key="relax.attrs.AllocTensorAttrs")
        alloc = tensor
        _ = relax.call_packed("test.vm.tile", x, alloc)
        y = alloc
        # block 2
        return y
```
This PR does the following things:

- Avoid allocating shape heap for static shape only cases.

- Shrink the blocks got generated in the shape lowering pass, so the result IRModule after the vm build becomes the below, which only has one block inside the function:
```python
@tvm.script.ir_module
class Module:
    @relax.function
    def foo(x: Tensor[(2, 3), "float32"]) -> Tensor[_, _]:
        # block 0
        storage = relax.vm.builtin.alloc_storage((48,), device_type=1, dtype="float32", attrs_type_key="relax.attrs.AllocStorageAttrs")
        tensor = relax.vm.builtin.alloc_tensor(storage, (2, 6), offset=0, dtype="float32", attrs_type_key="relax.attrs.AllocTensorAttrs")
        alloc = tensor
        _ = relax.call_packed("test.vm.tile", x, alloc)
        y = alloc
        return y
```
- Fold the `GetUniqueName` logic into `AddFuncToContext`. This is to avoid having name gaps (for example: `relu1`, then jumps to `relu11` because the `GetUniqueName` is called outside the dedup code in `AddFuncToContext`) when there are duplicated PrimFuncs in between, please checkout the `test_emit_te_multiple` test case.