### PR TITLE
[BugFix] Fix missing allocating slots for constant shapes; Print ShapeExpr in ReprPrinter

### DIFF
--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -32,6 +32,7 @@ RelayExpr RelayExprNode::shape() const {
 TVM_REGISTER_GLOBAL("ir.RelayExprShape").set_body_method<RelayExpr>(&RelayExprNode::shape);
 
 namespace relax {
+using tvm::ReprPrinter;
 using tvm::runtime::Optional;
 
 TVM_REGISTER_NODE_TYPE(ShapeExprNode);
@@ -46,6 +47,19 @@ ShapeExpr::ShapeExpr(Array<PrimExpr> values, Span span) {
 TVM_REGISTER_GLOBAL("relax.ShapeExpr").set_body_typed([](Array<PrimExpr> values, Span span) {
   return ShapeExpr(values, span);
 });
+
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+    .set_dispatch<ShapeExprNode>([](const ObjectRef& ref, ReprPrinter* p) {
+      const ShapeExprNode* node = static_cast<const ShapeExprNode*>(ref.get());
+      p->stream << "ShapeExpr(";
+      for (auto it = node->values.begin(); it != node->values.end(); it++) {
+        if (it != node->values.begin()) {
+          p->stream << ", ";
+        }
+        p->stream << *it;
+      }
+      p->stream << ")";
+    });
 
 TVM_REGISTER_NODE_TYPE(VarNode);
 

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -183,8 +183,8 @@ class ScheduleBuilder : public backend::MemoizedExprTranslator<Array<te::Tensor>
             << "meta_schedule.MetaScheduleContextQueryInsideWithScope is not registered";
         prim_func = (*f_create_func)(tensor_outs);
         Optional<ObjectRef> opt_mod_or_base_func =
-            (*f_meta_schedule)(prim_fn_var->name_hint, IRModule({{prim_fn_var, relay_func}}), target_,
-                               Array<IRModule>{IRModule({{prim_fn_var, prim_func}})});
+            (*f_meta_schedule)(prim_fn_var->name_hint, IRModule({{prim_fn_var, relay_func}}),
+                               target_, Array<IRModule>{IRModule({{prim_fn_var, prim_func}})});
         if (const auto* result = opt_mod_or_base_func.as<tir::PrimFuncNode>()) {
           prim_func = GetRef<tir::PrimFunc>(result);
         } else {


### PR DESCRIPTION
Executing [apps/relax_examples/nn_module.py](https://github.com/tlc-pack/relax/blob/relax/apps/relax_examples/nn_module.py) runs into an error during the shape lowering after we merged this PR https://github.com/tlc-pack/relax/pull/74. 
The cause is that in `PrepareExpr2Slot` in that PR, I simply ignored allocating slots for constant shapes. However, we do need to allocate slots for `IntImm(128)` in the following case in nn_module.py, because we need to construct shapes for example `(n, 128)` later from the shape heap. This PR fixes this bug by checking if the program is static shape only or not during the PrepareExpr2Slot pass.
```python
@relax.function
def main(data: Tensor[(n, 784), "float32"], linear_weight: Tensor[(784, 128), "float32"], linear_bias: Tensor[(128,), "float32"], linear_weight1: Tensor[(128, 32), "float32"], linear_bias1: Tensor[(32,), "float32"], linear_weight2: Tensor[(32, 10), "float32"], linear_bias2: Tensor[(10,), "float32"]) -> Tensor[_, "float32"]:
  # block 0
  gv: Tensor[(n, 128), "float32"] = relax.call_dps((n, 128), matmul, (data, linear_weight))
  gv1: Tensor[(n, 128), "float32"] = relax.call_dps((n, 128), add, (gv, linear_bias))
  gv2: Tensor[(n, 128), "float32"] = relax.call_dps((n, 128), relu, (gv1,))
  gv3: Tensor[(n, 32), "float32"] = relax.call_dps((n, 32), matmul1, (gv2, linear_weight1))
  gv4: Tensor[(n, 32), "float32"] = relax.call_dps((n, 32), add1, (gv3, linear_bias1))
  gv5: Tensor[(n, 32), "float32"] = relax.call_dps((n, 32), relu1, (gv4,))
  gv6: Tensor[(n, 10), "float32"] = relax.call_dps((n, 10), matmul2, (gv5, linear_weight2))
  gv7: Tensor[(n, 10), "float32"] = relax.call_dps((n, 10), add2, (gv6, linear_bias2))
  gv8: Tensor[(n, 10), "float32"] = relax.call_dps((n, 10), log_softmax, (gv7,))
  return gv8
```

Also adds `ShapeExpr` printing support to `ReprPrinter` for the convenience of debugging, so `LOG(INFO) << gv` will print `ShapeExpr(n, 128)`.

cc @ZihengJiang @hypercubestart @yongwww

