### PR TITLE
call_tir convention change

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -175,6 +175,16 @@ class RelayExprNode : public BaseExprNode {
   RelayExpr shape() const;
 
   /*!
+   * \brief Set the shape_ of a RelayExpr.
+   */
+  void set_shape(ObjectRef shape) const;
+
+  /*!
+   * \brief Set the checked_type_ of a RelayExpr.
+   */
+  void set_type(Type type) const;
+
+  /*!
    * \brief Check if the inferred(checked) type of the Expr
    *  is backed by a TTypeNode and return it.
    *

--- a/include/tvm/relax/attrs/memory.h
+++ b/include/tvm/relax/attrs/memory.h
@@ -31,11 +31,11 @@ namespace relax {
 /*!
  * \brief Attributes for allocating storage.
  */
-struct AllocStorageAttrs : public tvm::AttrsNode<AllocStorageAttrs> {
+struct VMAllocStorageAttrs : public tvm::AttrsNode<VMAllocStorageAttrs> {
   int device_type;
   DataType dtype;
 
-  TVM_DECLARE_ATTRS(AllocStorageAttrs, "relax.attrs.AllocStorageAttrs") {
+  TVM_DECLARE_ATTRS(VMAllocStorageAttrs, "relax.attrs.VMAllocStorageAttrs") {
     TVM_ATTR_FIELD(device_type).describe("The device type on which to allocate memory.");
     TVM_ATTR_FIELD(dtype)
         .describe("The dtype of the tensor to allocate.")
@@ -46,11 +46,11 @@ struct AllocStorageAttrs : public tvm::AttrsNode<AllocStorageAttrs> {
 /*!
  * \brief Attributes for allocating tensors.
  */
-struct AllocTensorAttrs : public tvm::AttrsNode<AllocTensorAttrs> {
+struct VMAllocTensorAttrs : public tvm::AttrsNode<VMAllocTensorAttrs> {
   int offset;
   DataType dtype;
 
-  TVM_DECLARE_ATTRS(AllocTensorAttrs, "relax.attrs.AllocTensorAttrs") {
+  TVM_DECLARE_ATTRS(VMAllocTensorAttrs, "relax.attrs.VMAllocTensorAttrs") {
     TVM_ATTR_FIELD(offset).describe("Storage offset to allocate the tensor.").set_default(0);
     TVM_ATTR_FIELD(dtype)
         .describe("The dtype of the tensor to allocate.")

--- a/include/tvm/relax/attrs/tensor.h
+++ b/include/tvm/relax/attrs/tensor.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/relax/attrs/tensor.h
+ * \brief Attributes for tensor allocation operators.
+ */
+#ifndef TVM_RELAX_ATTRS_TENSOR_H_
+#define TVM_RELAX_ATTRS_TENSOR_H_
+
+#include <tvm/ir/attrs.h>
+
+namespace tvm {
+namespace relax {
+/*!
+ * \brief Attributes for allocating tensors.
+ */
+struct AllocTensorAttrs : public tvm::AttrsNode<AllocTensorAttrs> {
+  DataType dtype;
+
+  TVM_DECLARE_ATTRS(AllocTensorAttrs, "relax.attrs.AllocTensorAttrs") {
+    TVM_ATTR_FIELD(dtype).describe("The datatype of the tensor to be allocated.");
+  }
+};
+
+}  // namespace relax
+}  // namespace tvm
+#endif  // TVM_RELAX_ATTRS_TENSOR_H_

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -327,6 +327,7 @@ class CallNode : public ExprNode {
     v->Visit("virtual_device_", &virtual_device_);
     v->Visit("span", &span);
     v->Visit("_checked_type_", &checked_type_);
+    v->Visit("shape_", &shape_);
   }
 
   bool SEqualReduce(const CallNode* other, SEqualReducer equal) const {

--- a/python/tvm/ir/expr.py
+++ b/python/tvm/ir/expr.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=redefined-builtin
 """Common expressions data structures in the IR."""
 import tvm._ffi
 

--- a/python/tvm/ir/expr.py
+++ b/python/tvm/ir/expr.py
@@ -61,6 +61,14 @@ class RelayExpr(BaseExpr):
         """
         return _ffi_api.RelayExprShape(self)
 
+    def _set_shape(self, shape):
+        """Set the shape of tvm.relay.Expr."""
+        _ffi_api.RelayExprSetShape(self, shape)
+
+    def _set_type(self, type):
+        """Set the checked type of tvm.relay.Expr."""
+        _ffi_api.RelayExprSetType(self, type)
+
 
 @tvm._ffi.register_object("GlobalVar")
 class GlobalVar(RelayExpr):

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -66,7 +66,7 @@ load_exec_from_file = vm.load_exec_from_file
 
 # Operator
 from .op.base import call_tir
-from .op.op_attrs import AllocStorageAttrs, AllocTensorAttrs
+from .op.op_attrs import VMAllocStorageAttrs, VMAllocTensorAttrs
 
 # IRBuilder
 BlockBuilder = block_builder.BlockBuilder

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -57,6 +57,7 @@ Type = ty.Type
 ShapeType = ty.ShapeType
 DynTensorType = ty.DynTensorType
 DimType = ty.DimType
+TupleType = ty.TupleType
 
 # VM
 ExecBuilder = exec_builder.ExecBuilder

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -20,7 +20,7 @@ from typing import List, Optional
 import tvm._ffi
 from ..ir import Node, Span, SourceName, BaseFunc
 from ..runtime import String
-from ..relay import Id, Tuple, TupleGetItem
+from ..relay import Id, Tuple, TupleGetItem, TupleType
 from ..tir import PrimExpr
 from . import _ffi_api
 from .. import relay

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -21,7 +21,6 @@ from ...ir import Array
 
 
 def call_tir(
-    shape: Union[Tuple, ShapeExpr, List[int]],
     func: Expr,
     args: Union[Tuple, List[Expr]],
     tir_vars: ShapeExpr = None,
@@ -31,9 +30,6 @@ def call_tir(
 
     Parameters
     ----------
-    shape: Tuple[ShapeExpr] or ShapeExpr
-        The output shape. Tuple[ShapeExpr] if multiple outputs, ShapeExpr is single output.
-
     func : ExternFunc or PrimFunc
         The destination-passing-style function.
 
@@ -48,8 +44,6 @@ def call_tir(
     ret: Call
         A call node for the call_tir operator.
     """
-    if isinstance(shape, (list, tuple, Array)):
-        shape = ShapeExpr(shape)
     if isinstance(args, (list, tuple)):
         args = Tuple(args)
-    return _ffi_api.call_tir(shape, func, args, tir_vars)
+    return _ffi_api.call_tir(func, args, tir_vars)

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -17,7 +17,6 @@
 from typing import Union, List
 from . import _ffi_api
 from ..expr import Expr, ShapeExpr, Tuple, Call
-from ...ir import Array
 
 
 def call_tir(

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -19,11 +19,16 @@ from tvm.ir import Attrs
 import tvm._ffi
 
 
-@tvm._ffi.register_object("relax.attrs.AllocStorageAttrs")
-class AllocStorageAttrs(Attrs):
-    """Attributes used in alloc_storage operators"""
-
-
 @tvm._ffi.register_object("relax.attrs.AllocTensorAttrs")
 class AllocTensorAttrs(Attrs):
     """Attributes used in alloc_tensor operators"""
+
+
+@tvm._ffi.register_object("relax.attrs.VMAllocStorageAttrs")
+class VMAllocStorageAttrs(Attrs):
+    """Attributes used in VM alloc_storage operators"""
+
+
+@tvm._ffi.register_object("relax.attrs.VMAllocTensorAttrs")
+class VMAllocTensorAttrs(Attrs):
+    """Attributes used in VM alloc_tensor operators"""

--- a/python/tvm/relax/ty.py
+++ b/python/tvm/relax/ty.py
@@ -17,7 +17,7 @@
 # pylint: disable=invalid-name, unused-import
 """The type nodes of the Relax language."""
 import tvm._ffi
-from tvm.ir import Type, TensorType, Span
+from tvm.ir import Type, TensorType, TupleType, Span
 
 from . import _ffi_api
 

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -232,8 +232,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     }
 
     // Handle attrs of the call
-    auto alloc_attrs = call_node->attrs.as<AllocStorageAttrs>();
-    ICHECK(alloc_attrs != nullptr) << "must be AllocStorageAttrs";
+    auto alloc_attrs = call_node->attrs.as<VMAllocStorageAttrs>();
+    ICHECK(alloc_attrs != nullptr) << "must be VMAllocStorageAttrs";
     int device_type = alloc_attrs->device_type;
     args.push_back(Instruction::Arg(Instruction::kImmediate, device_type));
     DataType dtype = alloc_attrs->dtype;
@@ -254,8 +254,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     // Handle `self`
     args.push_back(ConvertArg(call_node->args[0]));
     // Handle `offset`
-    auto alloc_attrs = call_node->attrs.as<AllocTensorAttrs>();
-    ICHECK(alloc_attrs != nullptr) << "must be AllocTensorAttrs";
+    auto alloc_attrs = call_node->attrs.as<VMAllocTensorAttrs>();
+    ICHECK(alloc_attrs != nullptr) << "must be VMAllocTensorAttrs";
     int offset = alloc_attrs->offset;
     args.push_back(Instruction::Arg(Instruction::kImmediate, offset));
     // Handle `shape`

--- a/src/relax/backend/vm/vm_memory_lower.cc
+++ b/src/relax/backend/vm/vm_memory_lower.cc
@@ -21,6 +21,7 @@
  * \brief Perform memory lowering. Lowers the relax.builtin.alloc_tensor intrinsic to VM intrinsics.
  */
 #include <tvm/relax/attrs/memory.h>
+#include <tvm/relax/attrs/tensor.h>
 #include <tvm/relax/backend.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/type.h>
@@ -37,14 +38,13 @@ namespace relax {
 // Example:
 // x = relax.builtin.alloc_tensor((m, n))
 // -->
-// gv0 = relax.call_packed("relax.vm.builtin.alloc_storage", (m * n), relax.attrs.AllocStorageAttrs)
+// gv0 = relax.call_packed("relax.vm.builtin.alloc_storage", (m * n),
+// relax.attrs.VMAllocStorageAttrs)
 // gv1 = relax.call_packed("relax.vm.builtin.alloc_tensor", gv0, (m, n),
-// relax.attrs.AllocTensorAttrs)
+// relax.attrs.VMAllocTensorAttrs)
 
 class VMMemLowerMutator : public ExprMutator {
-  Expr ComputeStorageSize(const Expr& shape, const Type& type) const {
-    DynTensorType tensor_type = Downcast<DynTensorType>(type);
-    DataType dtype = DataType(tensor_type->dtype);
+  Expr ComputeStorageSize(const Expr& shape, const DataType& dtype) const {
     // Question: what if the dtype of tensor_type is unknown?
     // Symbolic/static shape case
     if (auto* shape_expr = shape.as<ShapeExprNode>()) {
@@ -79,19 +79,19 @@ class VMMemLowerMutator : public ExprMutator {
     // TODO(@yuchen): memory planning
     if (call->op == alloc_tensor_op) {
       ShapeExpr output_shape = Downcast<ShapeExpr>(call->args[0]);
-
-      // TODO(@yuchen): Get the type of input x, options: add an attr to relax.builtin.alloc_tensor
-      Type tensor_type = DynTensorType(output_shape->values.size(), DataType::Float(32));
-      Expr storage_size = ComputeStorageSize(output_shape, tensor_type);
-      auto storage_attr = make_object<AllocStorageAttrs>();
-      storage_attr->dtype = DataType::Float(32);
+      auto alloc_attrs = call->attrs.as<AllocTensorAttrs>();
+      ICHECK(alloc_attrs != nullptr) << "must be AllocTensorAttrs";
+      DataType dtype = alloc_attrs->dtype;
+      Expr storage_size = ComputeStorageSize(output_shape, dtype);
+      auto storage_attr = make_object<VMAllocStorageAttrs>();
+      storage_attr->dtype = dtype;
       storage_attr->device_type = 1;
 
       Var storage =
           builder_->Emit(Call(vm_alloc_storage_op, {storage_size}, Attrs(storage_attr)), "storage");
-      auto tensor_attr = make_object<AllocTensorAttrs>();
+      auto tensor_attr = make_object<VMAllocTensorAttrs>();
       tensor_attr->offset = 0;
-      tensor_attr->dtype = DataType::Float(32);
+      tensor_attr->dtype = dtype;
       Expr shape = call->args[0];
       Var tensor =
           builder_->Emit(Call(vm_alloc_tensor_op, {storage, shape}, Attrs(tensor_attr)), "tensor");

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -21,7 +21,7 @@
 namespace tvm {
 
 RelayExpr RelayExprNode::shape() const {
-  if (this->shape_.defined()) {
+  if (this->shape_) {
     return Downcast<RelayExpr>(this->shape_);
   }
   static const Op& op = Op::Get("relax.shape_of");
@@ -29,7 +29,13 @@ RelayExpr RelayExprNode::shape() const {
   return relay::Call(op, {self}, {}, {});
 }
 
+void RelayExprNode::set_shape(ObjectRef shape) const { this->shape_ = shape; }
+
+void RelayExprNode::set_type(Type type) const { this->checked_type_ = type; }
+
 TVM_REGISTER_GLOBAL("ir.RelayExprShape").set_body_method<RelayExpr>(&RelayExprNode::shape);
+TVM_REGISTER_GLOBAL("ir.RelayExprSetShape").set_body_method<RelayExpr>(&RelayExprNode::set_shape);
+TVM_REGISTER_GLOBAL("ir.RelayExprSetType").set_body_method<RelayExpr>(&RelayExprNode::set_type);
 
 namespace relax {
 using tvm::ReprPrinter;

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -335,8 +335,15 @@ Expr ExprMutator::VisitExpr_(const CallNode* call_node) {
     return GetRef<Expr>(call_node);
   } else {
     Expr new_call = Call(new_op, call_args, call_node->attrs, ty_args, call_node->span);
-    new_call->shape_ = new_shape;
-    new_call->checked_type_ = call_node->checked_type_;
+
+    // preserve the shape and checked type for call_tir
+    // for other ops, they should be deduced
+    static const Op& call_tir_op = Op::Get("relax.call_tir");
+    if (call_node->op == call_tir_op) {
+      new_call->shape_ = new_shape;
+      new_call->checked_type_ = call_node->checked_type_;
+    }
+
     return new_call;
   }
 }

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -336,6 +336,7 @@ Expr ExprMutator::VisitExpr_(const CallNode* call_node) {
   } else {
     Expr new_call = Call(new_op, call_args, call_node->attrs, ty_args, call_node->span);
     new_call->shape_ = new_shape;
+    new_call->checked_type_ = call_node->checked_type_;
     return new_call;
   }
 }

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -18,6 +18,7 @@
  */
 #include <tvm/relax/attrs/memory.h>
 #include <tvm/relax/attrs/shape.h>
+#include <tvm/relax/attrs/tensor.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relay/op.h>
 
@@ -26,8 +27,9 @@
 namespace tvm {
 namespace relax {
 
-TVM_REGISTER_NODE_TYPE(AllocStorageAttrs);
 TVM_REGISTER_NODE_TYPE(AllocTensorAttrs);
+TVM_REGISTER_NODE_TYPE(VMAllocStorageAttrs);
+TVM_REGISTER_NODE_TYPE(VMAllocTensorAttrs);
 TVM_REGISTER_NODE_TYPE(ShapeHeapAttrs);
 
 bool EqualConstInt(const PrimExpr& lhs, int64_t value) {
@@ -90,6 +92,7 @@ TVM_REGISTER_GLOBAL("relax.op.shape_of").set_body_typed(MakeShapeOf);
 // alloc_tensor
 
 RELAY_REGISTER_OP("relax.builtin.alloc_tensor")
+    .set_attrs_type<AllocTensorAttrs>()
     .set_num_inputs(1)
     .add_argument("shape", "Expr", "The shape of the tensor to allocate.");
 
@@ -103,7 +106,7 @@ TVM_REGISTER_GLOBAL("relax.op.builtin.alloc_tensor").set_body_typed(MakeAllocTen
 // vm alloc_storage
 
 RELAY_REGISTER_OP("relax.vm.builtin.alloc_storage")
-    .set_attrs_type<AllocStorageAttrs>()
+    .set_attrs_type<VMAllocStorageAttrs>()
     .set_num_inputs(1)
     .add_argument("size", "Expr", "The size of the storage to allocate.");
 
@@ -117,7 +120,7 @@ TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_storage").set_body_typed(MakeVMAl
 // vm alloc_tensor
 
 RELAY_REGISTER_OP("relax.vm.builtin.alloc_tensor")
-    .set_attrs_type<AllocTensorAttrs>()
+    .set_attrs_type<VMAllocTensorAttrs>()
     .set_num_inputs(1)
     .add_argument("shape", "Expr", "The shape of the tensor to allocate.");
 

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -70,8 +70,8 @@ class InputModule:
             x0 = relax.match_shape(sh, (m, n))
             sh1 = relax.call_packed("vm.builtin.shape_of", w)
             x1 = relax.match_shape(sh1, (n, k))
-            lv0:Tensor[(m,k), "float32"] = R.call_tir(tir_matmul, (x,w))
-            lv1:Tensor[(m,k), "float32"] = R.call_tir(tir_relu, (lv0))
+            lv0:Tensor[(m, k), "float32"] = R.call_tir(tir_matmul, (x,w))
+            lv1:Tensor[(m, k), "float32"] = R.call_tir(tir_relu, (lv0))
             relax.output(lv1)
         return lv1
 """

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -70,8 +70,8 @@ class InputModule:
             x0 = relax.match_shape(sh, (m, n))
             sh1 = relax.call_packed("vm.builtin.shape_of", w)
             x1 = relax.match_shape(sh1, (n, k))
-            lv0 = R.call_tir((m,k), tir_matmul, (x,w))
-            lv1 = R.call_tir((m,k), tir_relu, (lv0))
+            lv0:Tensor[(m,k), "float32"] = R.call_tir(tir_matmul, (x,w))
+            lv1:Tensor[(m,k), "float32"] = R.call_tir(tir_relu, (lv0))
             relax.output(lv1)
         return lv1
 """
@@ -150,8 +150,8 @@ def test_class_irmodule(dev: str):
         @R.function
         def main(x: Tensor[(32, 32), "float32"], w: Tensor[(32, 32), "float32"]) -> Tensor:
             with R.dataflow():
-                lv0 = R.call_tir((32, 32), tir_matmul, (x, w))
-                lv1 = R.call_tir((32, 32), tir_relu, (lv0))
+                lv0: Tensor[(32, 32), "float32"] = R.call_tir(tir_matmul, (x, w))
+                lv1: Tensor[(32, 32), "float32"] = R.call_tir(tir_relu, (lv0))
                 relax.output(lv1)
             return lv1
 

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -315,11 +315,11 @@ def test_emit_te():
     assert len(rx_func.body.blocks[0].bindings) == 1
     assert isinstance(rx_func.body.blocks[0].bindings[0].value, rx.Call)
     assert rx_func.body.blocks[0].bindings[0].value.op == relay.op.get("relax.call_tir")
-    assert len(rx_func.body.blocks[0].bindings[0].value.args) == 3
-    assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "te_func"
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][0] == x
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][1] == y
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][2] == z
+    assert len(rx_func.body.blocks[0].bindings[0].value.args) == 2
+    assert rx_func.body.blocks[0].bindings[0].value.args[0].name_hint == "te_func"
+    assert rx_func.body.blocks[0].bindings[0].value.args[1][0] == x
+    assert rx_func.body.blocks[0].bindings[0].value.args[1][1] == y
+    assert rx_func.body.blocks[0].bindings[0].value.args[1][2] == z
 
 
 def test_emit_te_multiple():
@@ -350,9 +350,9 @@ def test_emit_te_multiple():
 
     # only two PrimFuncs were generated since two of them are equal so got deduped
     assert len(prim_func) == 2
-    assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "te_func"
-    assert rx_func.body.blocks[0].bindings[1].value.args[1].name_hint == "te_func"
-    assert rx_func.body.blocks[0].bindings[2].value.args[1].name_hint == "te_func1"
+    assert rx_func.body.blocks[0].bindings[0].value.args[0].name_hint == "te_func"
+    assert rx_func.body.blocks[0].bindings[1].value.args[0].name_hint == "te_func"
+    assert rx_func.body.blocks[0].bindings[2].value.args[0].name_hint == "te_func1"
 
 
 def test_emit_te_multiple_output():
@@ -376,11 +376,17 @@ def test_emit_te_multiple_output():
     assert rx_func.params[0] == x
     assert rx_func.name.name_hint == "rx_func"
     assert rx_func.body.blocks[0].bindings[0].value.op == relay.op.get("relax.call_tir")
-    assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "te_func"
-    assert isinstance(rx_func.body.blocks[0].bindings[0].value.args[0], rx.Tuple)
-    assert len(rx_func.body.blocks[0].bindings[0].value.args[0]) == 2
-    assert isinstance(rx_func.body.blocks[0].bindings[0].value.args[0][0], rx.ShapeExpr)
-    assert isinstance(rx_func.body.blocks[0].bindings[0].value.args[0][1], rx.ShapeExpr)
+    assert rx_func.body.blocks[0].bindings[0].value.args[0].name_hint == "te_func"
+    assert isinstance(rx_func.body.blocks[0].bindings[0].value.shape, rx.Tuple)
+    assert len(rx_func.body.blocks[0].bindings[0].value.shape) == 2
+    assert isinstance(rx_func.body.blocks[0].bindings[0].value.shape[0], rx.ShapeExpr)
+    assert isinstance(rx_func.body.blocks[0].bindings[0].value.shape[1], rx.ShapeExpr)
+    assert isinstance(rx_func.body.blocks[0].bindings[0].value.checked_type, rx.TupleType)
+    assert len(rx_func.body.blocks[0].bindings[0].value.checked_type.fields) == 2
+    assert rx_func.body.blocks[0].bindings[0].value.checked_type.fields[0].rank == 2
+    assert rx_func.body.blocks[0].bindings[0].value.checked_type.fields[0].dtype == "float32"
+    assert rx_func.body.blocks[0].bindings[0].value.checked_type.fields[1].rank == 2
+    assert rx_func.body.blocks[0].bindings[0].value.checked_type.fields[1].dtype == "float32"
 
 
 def test_emit_te_extern():
@@ -403,10 +409,10 @@ def test_emit_te_extern():
     assert len(rx_func.body.blocks) == 1
     assert isinstance(rx_func.body.blocks[0].bindings[0].value, rx.Call)
     assert rx_func.body.blocks[0].bindings[0].value.op == relay.op.get("relax.call_tir")
-    assert len(rx_func.body.blocks[0].bindings[0].value.args) == 3
-    assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "matmul"
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][0] == x
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][1] == y
+    assert len(rx_func.body.blocks[0].bindings[0].value.args) == 2
+    assert rx_func.body.blocks[0].bindings[0].value.args[0].name_hint == "matmul"
+    assert rx_func.body.blocks[0].bindings[0].value.args[1][0] == x
+    assert rx_func.body.blocks[0].bindings[0].value.args[1][1] == y
 
 
 def test_emit_tuple_get_item():

--- a/tests/python/relax/test_op.py
+++ b/tests/python/relax/test_op.py
@@ -41,8 +41,8 @@ def test_call_tir() -> None:
     shape_anno = [54, 96]
     type_anno = rx.DynTensorType(2, "float32")
     v0 = rx.Var("v0", shape_anno, type_anno)
-    v1 = rx.call_tir([54, 96], rx.extern("test.op.identity"), [v0])
-    v1 = rx.call_tir([54, 96], identity_tir, [v0])
+    v1 = rx.call_tir(rx.extern("test.op.identity"), [v0])
+    v1 = rx.call_tir(identity_tir, [v0])
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -523,7 +523,7 @@ def test_primexpr_arithmetic():
 def test_call_tir_extern():
     @R.function
     def f(x: Tensor):
-        z = relax.call_tir((10,), "my_extern", (x,))
+        z: Tensor[(10,), "float32"] = relax.call_tir("my_extern", (x,))
         return z
 
     x = f.params[0]
@@ -533,7 +533,6 @@ def test_call_tir_extern():
         z_bind.value,
         "relax.call_tir",
         [
-            relax.ShapeExpr([tir.IntImm("int64", 10)]),
             relax.ExternFunc("my_extern"),
             relax.Tuple([x]),
         ],

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -188,7 +188,7 @@ def test_primexpr_arithmetic():
 def test_call_tir_extern():
     @R.function
     def foo(x: Tensor):
-        z = relax.call_tir((10,), "my_extern", (x,))
+        z: Tensor[(10,), "float32"] = relax.call_tir("my_extern", (x,))
         return z
 
     check_roundtrip(foo)

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -102,8 +102,8 @@ def test_to_non_dataflow():
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
             with relax.dataflow():
-                lv0 = relax.call_tir((m, n), "test.op.identity", (x,))
-                gv0 = relax.call_tir((m, n), "test.op.identity", (lv0,))
+                lv0: Tensor[(m, n), "float32"] = relax.call_tir("test.op.identity", (x,))
+                gv0: Tensor[(m, n), "float32"] = relax.call_tir("test.op.identity", (lv0,))
                 relax.output(gv0)
             return gv0
 
@@ -145,7 +145,7 @@ def test_call_tir_rewrite():
     class TestCallTIRRewrite:
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
-            gv0 = relax.call_tir((m, n), "test.op.identity", (x,))
+            gv0: Tensor[(m, n), "float32"] = relax.call_tir("test.op.identity", (x,))
             return gv0
 
     mod = TestCallTIRRewrite
@@ -167,7 +167,7 @@ def test_call_tir_rewrite():
     assert isinstance(s1, tvm.relay.Call)
     assert s1.op.name == "relax.builtin.alloc_tensor"
     assert isinstance(s1.args[0], relax.ShapeExpr)
-    assert structural_equal(s1.args[0], s0.args[0])
+    assert structural_equal(s1.args[0], s0.shape)
     s2 = block.bindings[1].value
     assert s2.op.global_symbol == "test.op.identity"
 
@@ -245,7 +245,7 @@ def test_vm_static_shape_lowering():
         @R.function
         def foo(x: Tensor[(2, 3), "float32"]) -> Tensor:
             with relax.dataflow():
-                y = R.call_tir((2, 6), "test.vm.tile", (x))
+                y: Tensor[(2, 6), "float32"] = R.call_tir("test.vm.tile", (x))
                 relax.output(y)
             return y
 
@@ -348,8 +348,8 @@ def test_to_anf_no_op():
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
             with relax.dataflow():
-                lv0 = relax.call_tir((m, n), "test.op.identity", (x,))
-                gv0 = relax.call_tir((m, n), "test.op.identity", (lv0,))
+                lv0: Tensor[(m, n), "float32"] = relax.call_tir("test.op.identity", (x,))
+                gv0: Tensor[(m, n), "float32"] = relax.call_tir("test.op.identity", (lv0,))
                 relax.output(gv0)
             return gv0
 

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -177,7 +177,7 @@ def test_vm_memory_lower():
     class TestVMMemoryLower:
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
-            alloc = relax.builtin.alloc_tensor((m, n))
+            alloc = relax.builtin.alloc_tensor((m, n), dtype="float32")
             _ = relax.call_packed("test.op.identity", (x,), alloc)
             gv0 = alloc
             return gv0

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -411,11 +411,12 @@ def test_vm_compile_stage3():
         @R.function
         def foo(x: Tensor[(32, 16), "float32"]) -> Tensor:
             with R.dataflow():
-                y = R.call_tir((32, 16), "test.vm.identity", (x))
+                y: Tensor[(32, 16), "float32"] = R.call_tir("test.vm.identity", (x))
                 R.output(y)
             return y
 
     mod = TestVMCompileStage3
+
     target = tvm.target.Target("llvm", host="llvm")
     ex, lib = relax.vm.build(mod, target)
     vm = relax.VirtualMachine(ex, tvm.cpu(), mod=lib)
@@ -433,7 +434,7 @@ def test_vm_compile_e2e():
         def foo(x: Tensor[_, "float32"]) -> Tensor:
             with R.dataflow():
                 R.match_shape(x, (n, m))
-                y = R.call_tir((n, m * 2), "test.vm.tile", (x))
+                y: Tensor[(n, m * 2), "float32"] = R.call_tir("test.vm.tile", (x))
                 R.output(y)
             return y
 
@@ -471,7 +472,7 @@ def test_vm_compile_e2e_func_param_with_shape():
 
         @R.function
         def func(x: Tensor[(m, n), "float32"], w: Tensor[(n, k), "float32"]) -> Tensor:
-            gv0 = R.call_tir((m, k), tir_matmul, (x, w))
+            gv0: Tensor[(m, k), "float32"] = R.call_tir(tir_matmul, (x, w))
             return gv0
 
     mod = TestVMCompileE2E2


### PR DESCRIPTION
Currently, `call_tir` has the following signature: 
`call_tir(output_shape: Expr, low_level_func: Expr, inputs: Tuple[Expr]) -> Expr`

It has `output_shape` as the first argument, however, the same information is carried in `call.shape_`. Likewise, the output dtype info is contained in `call.checked_type_`.

This PR removes the `output_shape` field in `call_tir`:
1. In the TVMScript frontend, `x: Tensor(shape, dtype) = call_tir(shape, low_level_func, [a, b])` changes to `x: Tensor(shape, dtype) = call_tir(low_level_func, [a, b])`. The rhs call node has the shape and checked type assigned in the parser based on the lhs `shape` and `dtype` for the tensor;
2. In EmitTE, because we can directly get the shape and dtype from the output TE tensor, we directly set the shape and checked type to the call node.

Major changes:
- Introduces `set_shape` and `set_type` to set the shape and type to an Expr, used in the parser and BlockBuilder;
- Adds an attr to `relax.builtin.alloc_tensor` to carry dtype;
- Finally fixes the `checked_type_` of `call_tir`, and removes the hardcoded Float32 dtype in the vm memory lowering pass.