### PR TITLE
Make offset type specific to avoid errors on non-linux systems.

### DIFF
--- a/include/tvm/relax/vm/memory_manager.h
+++ b/include/tvm/relax/vm/memory_manager.h
@@ -112,7 +112,7 @@ class StorageObj : public Object {
   Buffer buffer;
 
   /*! \brief Allocate an NDArray from a given piece of storage. */
-  runtime::NDArray AllocNDArray(size_t offset, ShapeTuple shape, DLDataType dtype);
+  runtime::NDArray AllocNDArray(uint64_t offset, ShapeTuple shape, DLDataType dtype);
 
   /*! \brief The deleter for an NDArray when allocated from underlying storage. */
   static void Deleter(Object* ptr);

--- a/src/relax/vm/memory_manager.cc
+++ b/src/relax/vm/memory_manager.cc
@@ -76,7 +76,7 @@ inline size_t GetDataAlignment(const DLTensor& arr) {
   return align;
 }
 
-runtime::NDArray StorageObj::AllocNDArray(size_t offset, ShapeTuple shape, DLDataType dtype) {
+runtime::NDArray StorageObj::AllocNDArray(uint64_t offset, ShapeTuple shape, DLDataType dtype) {
   VerifyDataType(dtype);
 
   // critical zone: allocate header, cannot throw


### PR DESCRIPTION
While trying to build relax on OS X, I encountered an error due to `size_t` being underspecified and unequivalent to `uint64_t` on mac. Using an explicit `uint64_t` instead allows a successful build.