### PR TITLE
[Bugfix] Fix bug in relax.vm.build to pass target argument.

### DIFF
--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -186,7 +186,7 @@ def build(mod: tvm.IRModule, target: tvm.target.Target) -> Tuple[Executable, Mod
 
     # split primfunc and relax function
     rx_mod, tir_mod = _split_tir_relax(new_mod)
-    lib = tvm.build(tir_mod, target)
+    lib = tvm.build(tir_mod, target=target)
     ex = _ffi_api.VMCodeGen(rx_mod)
     return ex, lib
 

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -29,6 +29,7 @@ from tvm.meta_schedule.database import PyDatabase, Workload, TuningRecord
 from tvm.meta_schedule.integration import extract_task_from_relax
 from tvm import transform
 import time
+import pytest
 
 # Test case with dynamic shape.
 # Tuning with dynamic shape is not supported yet.
@@ -115,6 +116,7 @@ class DummyDatabase(PyDatabase):
         print("\n".join([str(r) for r in self.records]))
 
 
+@pytest.mark.parametrize("dev", ["cpu"])
 def test_class_irmodule(dev: str):
     @tvm.script.ir_module
     class InputModule:


### PR DESCRIPTION
tvm.build has the "target" as third argument. Previously, target was passed in the wrong position. This change passes target as named argument.

3 tests were failing as part of this change because cuda as target is not supported well. We restrict "dev" to be "cpu" for these tests for now.  