### PR TITLE
Change call_tir convention; Unify shape/type deduction rule

### DIFF
--- a/include/tvm/relax/attrs/memory.h
+++ b/include/tvm/relax/attrs/memory.h
@@ -28,14 +28,26 @@
 
 namespace tvm {
 namespace relax {
+
 /*!
- * \brief Attributes for allocating storage.
+ * \brief Attributes for allocating tensor.
  */
-struct AllocStorageAttrs : public tvm::AttrsNode<AllocStorageAttrs> {
+struct AllocTensorAttrs : public tvm::AttrsNode<AllocTensorAttrs> {
+  DataType dtype;
+
+  TVM_DECLARE_ATTRS(AllocTensorAttrs, "relax.attrs.AllocTensorAttrs") {
+    TVM_ATTR_FIELD(dtype).describe("The datatype of the tensor to be allocated.");
+  }
+};
+
+/*!
+ * \brief Attributes for allocating storage on Relax VM.
+ */
+struct VMAllocStorageAttrs : public tvm::AttrsNode<VMAllocStorageAttrs> {
   int device_type;
   DataType dtype;
 
-  TVM_DECLARE_ATTRS(AllocStorageAttrs, "relax.attrs.AllocStorageAttrs") {
+  TVM_DECLARE_ATTRS(VMAllocStorageAttrs, "relax.attrs.VMAllocStorageAttrs") {
     TVM_ATTR_FIELD(device_type).describe("The device type on which to allocate memory.");
     TVM_ATTR_FIELD(dtype)
         .describe("The dtype of the tensor to allocate.")
@@ -44,13 +56,13 @@ struct AllocStorageAttrs : public tvm::AttrsNode<AllocStorageAttrs> {
 };
 
 /*!
- * \brief Attributes for allocating tensors.
+ * \brief Attributes for allocating tensor on Relax VM.
  */
-struct AllocTensorAttrs : public tvm::AttrsNode<AllocTensorAttrs> {
+struct VMAllocTensorAttrs : public tvm::AttrsNode<VMAllocTensorAttrs> {
   int offset;
   DataType dtype;
 
-  TVM_DECLARE_ATTRS(AllocTensorAttrs, "relax.attrs.AllocTensorAttrs") {
+  TVM_DECLARE_ATTRS(VMAllocTensorAttrs, "relax.attrs.VMAllocTensorAttrs") {
     TVM_ATTR_FIELD(offset).describe("Storage offset to allocate the tensor.").set_default(0);
     TVM_ATTR_FIELD(dtype)
         .describe("The dtype of the tensor to allocate.")

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -57,6 +57,7 @@ Type = ty.Type
 ShapeType = ty.ShapeType
 DynTensorType = ty.DynTensorType
 DimType = ty.DimType
+TupleType = ty.TupleType
 
 # VM
 ExecBuilder = exec_builder.ExecBuilder
@@ -65,7 +66,7 @@ load_exec_from_file = vm.load_exec_from_file
 
 # Operator
 from .op.base import call_tir
-from .op.op_attrs import AllocStorageAttrs, AllocTensorAttrs
+from .op.op_attrs import VMAllocStorageAttrs, VMAllocTensorAttrs
 
 # IRBuilder
 BlockBuilder = block_builder.BlockBuilder

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -364,7 +364,7 @@ class BlockBuilder(Object):
                 @R.function
                 def rx_func(x: Tensor[(n, m), "float32"], y: Tensor[(n, m), "float32"]) -> Tensor:
                     # block 0
-                    gv = relax.call_tir((128, 128), "te_func", (x, y), dtype="float32")
+                    gv = relax.call_tir("te_func", (x, y), (128, 128), dtype="float32")
                     return gv
 
         Example
@@ -412,8 +412,7 @@ class BlockBuilder(Object):
                 def rx_func(x: Tensor[(n,), "float32"], y: Tensor[((n + 1),), "float32"])
                     -> Tensor[_, "float32"]:
                     # block 0
-                    gv: Tensor[((n + 1),), "float32"]
-                    = relax.call_tir(((n + 1),), te_func, (y,), (n,), dtype="float32")
+                    gv = relax.call_tir(te_func, (y,), ((n + 1),), (n,), dtype="float32")
                     return gv
         """
         primfunc_name_hint = kwargs.pop("primfunc_name_hint", None)
@@ -448,18 +447,21 @@ class BlockBuilder(Object):
             if isinstance(te_out, tvm.te.tensor.Tensor)
             else Tuple([ShapeExpr(x.shape) for x in outs])
         )
-        output_type = (
-            rx.DynTensorType(len(output_shape), te_out.dtype)
-            if isinstance(te_out, tvm.te.tensor.Tensor)
-            else TupleType([rx.DynTensorType(len(x.shape), x.dtype) for x in outs])
+        # output_type = (
+        #     rx.DynTensorType(len(output_shape), te_out.dtype)
+        #     if isinstance(te_out, tvm.te.tensor.Tensor)
+        #     else TupleType([rx.DynTensorType(len(x.shape), x.dtype) for x in outs])
+        # )
+        output_dtype = (
+            te_out.dtype if isinstance(te_out, tvm.te.tensor.Tensor) else [x.dtype for x in outs]
         )
         # add arguments for extra parameters from unbound var
         if len(unbound_tir_vars) > 0:
             call = call_tir(
-                gvar, call_args, output_shape, output_type, tir_vars=ShapeExpr(unbound_tir_vars)
+                gvar, call_args, output_shape, output_dtype, tir_vars=ShapeExpr(unbound_tir_vars)
             )
         else:
-            call = call_tir(gvar, call_args, output_shape, output_type)
+            call = call_tir(gvar, call_args, output_shape, output_dtype)
         return self.emit(call)
 
     def match_shape(self, value: Expr, pattern: List[PrimExpr]) -> Var:

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -456,10 +456,10 @@ class BlockBuilder(Object):
         # add arguments for extra parameters from unbound var
         if len(unbound_tir_vars) > 0:
             call = call_tir(
-                output_shape, output_type, gvar, call_args, tir_vars=ShapeExpr(unbound_tir_vars)
+                gvar, call_args, output_shape, output_type, tir_vars=ShapeExpr(unbound_tir_vars)
             )
         else:
-            call = call_tir(output_shape, output_type, gvar, call_args)
+            call = call_tir(gvar, call_args, output_shape, output_type)
         return self.emit(call)
 
     def match_shape(self, value: Expr, pattern: List[PrimExpr]) -> Var:

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -33,7 +33,6 @@ from .expr import (
     Tuple,
     BaseFunc,
 )
-from .ty import TupleType
 from .op.base import call_tir
 from . import _ffi_api
 
@@ -442,19 +441,17 @@ class BlockBuilder(Object):
             gvar = self.add_func(tir_func, func.__name__)
 
         call_args = [x.op.value for x in te_args]
+
         output_shape = (
             outs[0].shape
             if isinstance(te_out, tvm.te.tensor.Tensor)
             else Tuple([ShapeExpr(x.shape) for x in outs])
         )
-        # output_type = (
-        #     rx.DynTensorType(len(output_shape), te_out.dtype)
-        #     if isinstance(te_out, tvm.te.tensor.Tensor)
-        #     else TupleType([rx.DynTensorType(len(x.shape), x.dtype) for x in outs])
-        # )
+
         output_dtype = (
             te_out.dtype if isinstance(te_out, tvm.te.tensor.Tensor) else [x.dtype for x in outs]
         )
+
         # add arguments for extra parameters from unbound var
         if len(unbound_tir_vars) > 0:
             call = call_tir(

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 """The base Relax operators."""
-from typing import Union, List
+from typing import Union, List, Optional
 
 from . import _ffi_api
 from ..expr import Expr, ShapeExpr, Tuple, Call
@@ -23,31 +23,31 @@ from ...ir import Array
 
 
 def call_tir(
-    output_shape: Union[Tuple, ShapeExpr, List[int]],
-    output_type: Union[TupleType, DynTensorType],
     func: Expr,
     args: Union[Tuple, List[Expr]],
-    tir_vars: ShapeExpr = None,
+    output_shape: Union[Tuple, ShapeExpr, List[int]],
+    output_type: Union[TupleType, DynTensorType],
+    tir_vars: Optional[ShapeExpr] = None,
 ) -> Call:
     """
     Call a destination-passing-style function and return the output.
 
     Parameters
     ----------
-    output_shape: Tuple[ShapeExpr] or ShapeExpr
+    func : Expr
+        The destination-passing-style function, can be ExternFunc or PrimFunc.
+
+    args : Union[Tuple, List[Expr]]
+        The input arguments.
+
+    output_shape: Union[Tuple, ShapeExpr, List[int]]
         The output shape. Tuple[ShapeExpr] if multiple outputs, ShapeExpr if single output.
 
-    output_type: TupleType[DynTensorType] or DynTensorType
+    output_type: Union[TupleType, DynTensorType]
         The output type. TupleType[DynTensorType] if multiple outputs, DynTensorType
         if single output.
 
-    func : ExternFunc or PrimFunc
-        The destination-passing-style function.
-
-    args : Tuple[Expr]
-        The input arguments.
-
-    tir_vars : ShapeExpr
+    tir_vars : ShapeExpr, optional
         ShapeExpr representing a tuple of integers to unpack when calling func. Is null if not used
 
     Returns
@@ -59,4 +59,4 @@ def call_tir(
         output_shape = ShapeExpr(output_shape)
     if isinstance(args, (list, tuple)):
         args = Tuple(args)
-    return _ffi_api.call_tir(output_shape, output_type, func, args, tir_vars)
+    return _ffi_api.call_tir(func, args, output_shape, output_type, tir_vars)

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -15,13 +15,16 @@
 # specific language governing permissions and limitations
 """The base Relax operators."""
 from typing import Union, List
+
 from . import _ffi_api
 from ..expr import Expr, ShapeExpr, Tuple, Call
+from ..ty import DynTensorType, TupleType
 from ...ir import Array
 
 
 def call_tir(
-    shape: Union[Tuple, ShapeExpr, List[int]],
+    output_shape: Union[Tuple, ShapeExpr, List[int]],
+    output_type: Union[TupleType, DynTensorType],
     func: Expr,
     args: Union[Tuple, List[Expr]],
     tir_vars: ShapeExpr = None,
@@ -31,8 +34,12 @@ def call_tir(
 
     Parameters
     ----------
-    shape: Tuple[ShapeExpr] or ShapeExpr
-        The output shape. Tuple[ShapeExpr] if multiple outputs, ShapeExpr is single output.
+    output_shape: Tuple[ShapeExpr] or ShapeExpr
+        The output shape. Tuple[ShapeExpr] if multiple outputs, ShapeExpr if single output.
+
+    output_type: TupleType[DynTensorType] or DynTensorType
+        The output type. TupleType[DynTensorType] if multiple outputs, DynTensorType
+        if single output.
 
     func : ExternFunc or PrimFunc
         The destination-passing-style function.
@@ -48,8 +55,8 @@ def call_tir(
     ret: Call
         A call node for the call_tir operator.
     """
-    if isinstance(shape, (list, tuple, Array)):
-        shape = ShapeExpr(shape)
+    if isinstance(output_shape, (list, tuple, Array)):
+        output_shape = ShapeExpr(output_shape)
     if isinstance(args, (list, tuple)):
         args = Tuple(args)
-    return _ffi_api.call_tir(shape, func, args, tir_vars)
+    return _ffi_api.call_tir(output_shape, output_type, func, args, tir_vars)

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -19,11 +19,16 @@ from tvm.ir import Attrs
 import tvm._ffi
 
 
-@tvm._ffi.register_object("relax.attrs.AllocStorageAttrs")
-class AllocStorageAttrs(Attrs):
-    """Attributes used in alloc_storage operators"""
-
-
 @tvm._ffi.register_object("relax.attrs.AllocTensorAttrs")
 class AllocTensorAttrs(Attrs):
     """Attributes used in alloc_tensor operators"""
+
+
+@tvm._ffi.register_object("relax.attrs.VMAllocStorageAttrs")
+class VMAllocStorageAttrs(Attrs):
+    """Attributes used in VM alloc_storage operators"""
+
+
+@tvm._ffi.register_object("relax.attrs.VMAllocTensorAttrs")
+class VMAllocTensorAttrs(Attrs):
+    """Attributes used in VM alloc_tensor operators"""

--- a/python/tvm/relax/ty.py
+++ b/python/tvm/relax/ty.py
@@ -17,7 +17,7 @@
 # pylint: disable=invalid-name, unused-import
 """The type nodes of the Relax language."""
 import tvm._ffi
-from tvm.ir import Type, TensorType, Span
+from tvm.ir import Type, TensorType, TupleType, Span
 
 from . import _ffi_api
 

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -1034,7 +1034,7 @@ class RelaxTransformer(Transformer):
                         val = self.transform_expr(val)
                         # single output case
                         if isinstance(val, str):
-                            if not isinstance(args[0], relax.ShapeExpr):
+                            if not isinstance(args[2], relax.ShapeExpr):
                                 self.report_error(
                                     (
                                         f"The number of output_shape and output_dtype of "
@@ -1042,10 +1042,10 @@ class RelaxTransformer(Transformer):
                                     ),
                                     expr.span,
                                 )
-                            type_args = [relax.DynTensorType(rank=len(args[0].values), dtype=val)]
+                            type_args = [relax.DynTensorType(rank=len(args[2].values), dtype=val)]
                         elif isinstance(val, Tuple):
                             # multiple outputs case
-                            if not isinstance(args[0], Tuple) and len(args[0]) != len(val):
+                            if not isinstance(args[2], Tuple) and len(args[2]) != len(val):
                                 self.report_error(
                                     (
                                         f"The number of output_shape and output_dtype of "
@@ -1054,9 +1054,9 @@ class RelaxTransformer(Transformer):
                                     expr.span,
                                 )
                             types = []
-                            for i in range(len(args[0])):
+                            for i in range(len(args[2])):
                                 types.append(
-                                    relax.DynTensorType(rank=len(args[0][i].values), dtype=val[i])
+                                    relax.DynTensorType(rank=len(args[2][i].values), dtype=val[i])
                                 )
                             type_args = [relax.TupleType(types)]
                         else:
@@ -1077,9 +1077,10 @@ class RelaxTransformer(Transformer):
                 self.report_error(
                     f"{op.name} expects {op.num_inputs} arguments but got {len(args)}", expr.span
                 )
-            if op.name == "relax.call_tir" and isinstance(args[1], str):
+
+            if op.name == "relax.call_tir" and isinstance(args[0], str):
                 # extern function call case: rewrite identifier to an ExternFunc
-                args[1] = relax.ExternFunc(args[1], self.to_tvm_span(expr.params[1].span))
+                args[0] = relax.ExternFunc(args[0], self.to_tvm_span(expr.params[1].span))
 
         elif isinstance(op, relay.Expr):
             args = [self.transform_expr(arg) for arg in expr.params]

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name, no-else-return
+# pylint: disable=invalid-name, no-else-return, too-many-nested-blocks
 # pylint: disable=inconsistent-return-statements, ungrouped-imports
 """TVM Script Parser For Relax"""
 from __future__ import annotations
@@ -973,6 +973,7 @@ class RelaxTransformer(Transformer):
                 return self.transform_Subscript(expr)
 
         op = self.transform_expr(expr.func_name)
+        type_args = None
 
         if op == SpecialOp.CALL_PACKED:
             extern_func = expr.params[0]
@@ -1020,6 +1021,58 @@ class RelaxTransformer(Transformer):
                         f"{op.name} expects {op.num_inputs} arguments but got {len(args)}",
                         expr.span,
                     )
+
+                if len(expr.keyword_params) != 1:
+                    self.report_error(
+                        f"""{op.name} expects exact one keyword argument with dtype as the key but
+                        got {len(expr.keyword_params)} keyword arguements""",
+                        expr.span,
+                    )
+                for key, val in expr.keyword_params.items():
+                    assert isinstance(key, ast.Constant) and isinstance(key.value, str)
+                    if key.value == "dtype":
+                        val = self.transform_expr(val)
+                        # single output case
+                        if isinstance(val, str):
+                            if not isinstance(args[0], relax.ShapeExpr):
+                                self.report_error(
+                                    (
+                                        f"The number of output_shape and output_dtype of "
+                                        f"call_tir mismatch"
+                                    ),
+                                    expr.span,
+                                )
+                            type_args = [relax.DynTensorType(rank=len(args[0].values), dtype=val)]
+                        elif isinstance(val, Tuple):
+                            # multiple outputs case
+                            if not isinstance(args[0], Tuple) and len(args[0]) != len(val):
+                                self.report_error(
+                                    (
+                                        f"The number of output_shape and output_dtype of "
+                                        f"call_tir mismatch"
+                                    ),
+                                    expr.span,
+                                )
+                            types = []
+                            for i in range(len(args[0])):
+                                types.append(
+                                    relax.DynTensorType(rank=len(args[0][i].values), dtype=val[i])
+                                )
+                            type_args = [relax.TupleType(types)]
+                        else:
+                            self.report_error(
+                                f"call_tir expects the output_dtype to be a string or a tuple",
+                                expr.span,
+                            )
+                    else:
+                        self.report_error(
+                            (
+                                f"{op.name} expects one keyword argument with dtype as the key but "
+                                f"got {len(key.value)} as the key"
+                            ),
+                            expr.span,
+                        )
+
             elif op.num_inputs != -1 and len(args) != op.num_inputs:
                 self.report_error(
                     f"{op.name} expects {op.num_inputs} arguments but got {len(args)}", expr.span
@@ -1054,7 +1107,13 @@ class RelaxTransformer(Transformer):
         attrs = None
         if kwargs or not is_default:
             attrs = tvm.ir.attrs.make_node(attrs_type_key, **kwargs)
-        return relay.Call(op, args, attrs=attrs, span=self.to_tvm_span(expr.span))
+
+        if type_args:
+            return relay.Call(
+                op, args, attrs=attrs, type_args=type_args, span=self.to_tvm_span(expr.span)
+            )
+        else:
+            return relay.Call(op, args, attrs=attrs, span=self.to_tvm_span(expr.span))
 
     # Exprs:
     # - ArrayLiteral
@@ -1089,6 +1148,9 @@ class RelaxTransformer(Transformer):
 
         elif isinstance(expr, ast.Tuple):
             fields = [self.transform_expr(field) for field in expr.values]
+
+            if all([isinstance(f, str) for f in fields]):
+                return tuple(fields)
 
             # TODO(@altanh): this check might be too weak; we really only accept integral PrimExprs
             #                (e.g. int constants, dim vars, and integer operations on these)

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -1018,7 +1018,8 @@ class RelaxTransformer(Transformer):
                 # call_tir is special case because last argument is optional
                 if len(args) != op.num_inputs and len(args) != op.num_inputs - 1:
                     self.report_error(
-                        f"{op.name} expects {op.num_inputs} or {op.num_inputs - 1} arguments but got {len(args)}",
+                        f"""{op.name} expects {op.num_inputs} or {op.num_inputs - 1}
+                        arguments but got {len(args)}""",
                         expr.span,
                     )
 

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -1025,7 +1025,7 @@ class RelaxTransformer(Transformer):
                 if len(expr.keyword_params) != 1:
                     self.report_error(
                         f"""{op.name} expects exact one keyword argument with dtype as the key but
-                        got {len(expr.keyword_params)} keyword arguements""",
+                        got {len(expr.keyword_params)} keyword arguments""",
                         expr.span,
                     )
                 for key, val in expr.keyword_params.items():

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -252,7 +252,17 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::VarBindingNode* op) {
     return PrintPrimFunc(op->var->name_hint(), GetRef<tir::PrimFunc>(prim_func));
   } else {
     Doc doc;
-    doc << Print(op->var) << PrintVarAnnotation(op->var);
+    bool print_annotation = true;
+    static const Op& call_tir_op = Op::Get("relax.call_tir");
+    if (const CallNode* value = op->value.as<CallNode>()) {
+      if (value->op == call_tir_op) {
+        print_annotation = false;
+      }
+    }
+    doc << Print(op->var);
+    if (print_annotation) {
+      doc << PrintVarAnnotation(op->var);
+    }
     doc << " = " << Print(op->value);
     return doc;
   }

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -539,7 +539,7 @@ Doc RelaxScriptPrinter::PrintTupleAnnotation(const TupleType& ty,
   std::vector<Doc> fields;
   for (size_t i = 0; i < ty->fields.size(); i++) {
     if (shape) {
-      if (const relay::TupleNode* shape_tuple = shape.value().as<relay::TupleNode>()) {
+      if (const TupleNode* shape_tuple = shape.value().as<TupleNode>()) {
         if (const DynTensorTypeNode* type_field = ty->fields[i].as<DynTensorTypeNode>()) {
           fields.push_back(
               PrintTensorAnnotation(GetRef<DynTensorType>(type_field), shape_tuple->fields[i]));

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -301,6 +301,7 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
 
   Doc PrintVarAnnotation(const relax::Var& var);
   Doc PrintTensorAnnotation(const relax::DynTensorType& ty, const Optional<ObjectRef>& shape);
+  Doc PrintTupleAnnotation(const TupleType& ty, const Optional<ObjectRef>& shape);
 
   Doc VisitType_(const relax::ShapeTypeNode* node) override;
   Doc VisitType_(const relax::DynTensorTypeNode* node) override;

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -232,8 +232,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     }
 
     // Handle attrs of the call
-    auto alloc_attrs = call_node->attrs.as<AllocStorageAttrs>();
-    ICHECK(alloc_attrs != nullptr) << "must be AllocStorageAttrs";
+    auto alloc_attrs = call_node->attrs.as<VMAllocStorageAttrs>();
+    ICHECK(alloc_attrs != nullptr) << "must be VMAllocStorageAttrs";
     int device_type = alloc_attrs->device_type;
     args.push_back(Instruction::Arg(Instruction::kImmediate, device_type));
     DataType dtype = alloc_attrs->dtype;
@@ -254,8 +254,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     // Handle `self`
     args.push_back(ConvertArg(call_node->args[0]));
     // Handle `offset`
-    auto alloc_attrs = call_node->attrs.as<AllocTensorAttrs>();
-    ICHECK(alloc_attrs != nullptr) << "must be AllocTensorAttrs";
+    auto alloc_attrs = call_node->attrs.as<VMAllocTensorAttrs>();
+    ICHECK(alloc_attrs != nullptr) << "must be VMAllocTensorAttrs";
     int offset = alloc_attrs->offset;
     args.push_back(Instruction::Arg(Instruction::kImmediate, offset));
     // Handle `shape`

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -299,10 +299,6 @@ BindingBlock BlockBuilderNode::EndBlock() {
 }
 
 Optional<Expr> InferShape(const Call& call, DiagnosticContext diag_ctx) {
-  // if the call node's shape_ is filled, return the shape directly.
-  if (call->shape_) {
-    return Downcast<Expr>(call->shape_.value());
-  }
   auto op_map = Op::GetAttrMap<FInferShape>("FInferShape");
   if (call->op.as<OpNode>()) {
     Op op = Downcast<Op>(call->op);
@@ -314,10 +310,6 @@ Optional<Expr> InferShape(const Call& call, DiagnosticContext diag_ctx) {
 }
 
 Type InferType(const Call& call, DiagnosticContext diag_ctx) {
-  // if the call node's checked_type_ is filled, return the type directly.
-  if (call->checked_type_.defined()) {
-    return call->checked_type_;
-  }
   auto op_map = Op::GetAttrMap<FInferType>("FInferType");
   if (call->op.as<OpNode>()) {
     Op op = Downcast<Op>(call->op);

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -89,6 +89,9 @@ DataflowVar::DataflowVar(Id vid, Optional<Expr> shape_annotation, Optional<Type>
   n->vid = std::move(vid);
   n->shape_ = std::move(shape_annotation);
   n->type_annotation = std::move(type_annotation);
+  if (n->type_annotation) {
+    n->checked_type_ = n->type_annotation.value();
+  }
   n->span = std::move(span);
   data_ = std::move(n);
 }

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -221,24 +221,7 @@ TVM_REGISTER_GLOBAL("relax.analysis.post_order_visit").set_body_typed([](Expr ex
 // ==================
 // ExprMutator
 
-Expr ExprMutator::VisitExpr_(const ConstantNode* op) {
-  Expr new_shape;
-  bool unchanged = true;
-  if (op->shape_) {
-    new_shape = this->VisitExpr(Downcast<Expr>(op->shape_.value()));
-    if (!new_shape.same_as(op->shape_)) {
-      unchanged = false;
-    }
-  }
-
-  if (unchanged) {
-    return GetRef<Expr>(op);
-  } else {
-    Expr new_constant = Constant(op->data, op->span);
-    new_constant->shape_ = new_shape;
-    return new_constant;
-  }
-}
+Expr ExprMutator::VisitExpr_(const ConstantNode* op) { return GetRef<Expr>(op); }
 
 Expr ExprMutator::VisitExpr_(const GlobalVarNode* op) { return GetRef<Expr>(op); }
 
@@ -251,17 +234,10 @@ Expr ExprMutator::VisitExpr_(const TupleNode* op) {
     unchanged &= new_field.same_as(field);
   }
 
-  Expr new_shape;
-  if (op->shape_) {
-    new_shape = this->VisitExpr(Downcast<Expr>(op->shape_.value()));
-    unchanged &= new_shape.same_as(op->shape_);
-  }
-
   if (unchanged) {
     return GetRef<Expr>(op);
   } else {
     Expr new_tuple = Tuple(fields, op->span);
-    new_tuple->shape_ = new_shape;
     return new_tuple;
   }
 }
@@ -325,17 +301,10 @@ Expr ExprMutator::VisitExpr_(const CallNode* call_node) {
     unchanged &= new_arg.same_as(arg);
   }
 
-  Expr new_shape;
-  if (call_node->shape_) {
-    new_shape = this->VisitExpr(Downcast<Expr>(call_node->shape_.value()));
-    unchanged &= new_shape.same_as(call_node->shape_);
-  }
-
   if (unchanged) {
     return GetRef<Expr>(call_node);
   } else {
     Expr new_call = Call(new_op, call_args, call_node->attrs, ty_args, call_node->span);
-    new_call->shape_ = new_shape;
     return new_call;
   }
 }

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -54,7 +54,7 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs) {
 // call_tir
 
 Optional<Expr> InferShapeCallTIR(const Call& call, DiagnosticContext diag_ctx) {
-  Expr output_shape = call->args[0];
+  Expr output_shape = call->args[2];
   return output_shape;
 }
 
@@ -69,24 +69,24 @@ Type InferTypeCallTIR(const Call& call, DiagnosticContext diag_ctx) {
 
 RELAY_REGISTER_OP("relax.call_tir")
     .set_num_inputs(4)
-    .add_argument("output_shape", "Expr", "The output shape.")
     .add_argument("func", "Expr", "The destination-passing-style function.")
     .add_argument("args", "Tuple", "The input arguments.")
+    .add_argument("output_shape", "Expr", "The output shape.")
     .add_argument("packed_ints", "Expr",
                   "ShapeExpr representing a tuple of ints to unpack during runtime. Omitted from "
                   "args if unused")
     .set_attr<FInferShape>("FInferShape", InferShapeCallTIR)
     .set_attr<FInferType>("FInferType", InferTypeCallTIR);
 
-Expr MakeCallTIR(Expr output_shape, Type output_type, Expr func, Tuple args,
+Expr MakeCallTIR(Expr func, Tuple args, Expr output_shape, Type output_type,
                  Optional<Expr> packed_ints) {
   static const Op& op = Op::Get("relax.call_tir");
   Call call;
   if (!packed_ints) {
     // don't use additional optional argument
-    call = Call(op, {output_shape, func, args}, {}, {output_type});
+    call = Call(op, {func, args, output_shape}, {}, {output_type});
   } else {
-    call = Call(op, {output_shape, func, args, packed_ints.value()}, {}, {output_type});
+    call = Call(op, {func, args, output_shape, packed_ints.value()}, {}, {output_type});
   }
   return call;
 }

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -26,8 +26,9 @@
 namespace tvm {
 namespace relax {
 
-TVM_REGISTER_NODE_TYPE(AllocStorageAttrs);
 TVM_REGISTER_NODE_TYPE(AllocTensorAttrs);
+TVM_REGISTER_NODE_TYPE(VMAllocStorageAttrs);
+TVM_REGISTER_NODE_TYPE(VMAllocTensorAttrs);
 TVM_REGISTER_NODE_TYPE(ShapeHeapAttrs);
 
 bool EqualConstInt(const PrimExpr& lhs, int64_t value) {
@@ -52,36 +53,40 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs) {
 
 // call_tir
 
+Optional<Expr> InferShapeCallTIR(const Call& call, DiagnosticContext diag_ctx) {
+  Expr output_shape = call->args[0];
+  return output_shape;
+}
+
+Type InferTypeCallTIR(const Call& call, DiagnosticContext diag_ctx) {
+  if (call->type_args.size() != 1) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "type_args of call_tir should have exact 1 output type.");
+  }
+  Type output_type = call->type_args[0];
+  return output_type;
+}
+
 RELAY_REGISTER_OP("relax.call_tir")
     .set_num_inputs(4)
-    .add_argument("shape", "Expr", "The output shape.")
+    .add_argument("output_shape", "Expr", "The output shape.")
     .add_argument("func", "Expr", "The destination-passing-style function.")
     .add_argument("args", "Tuple", "The input arguments.")
     .add_argument("packed_ints", "Expr",
                   "ShapeExpr representing a tuple of ints to unpack during runtime. Omitted from "
-                  "args if unused");
+                  "args if unused")
+    .set_attr<FInferShape>("FInferShape", InferShapeCallTIR)
+    .set_attr<FInferType>("FInferType", InferTypeCallTIR);
 
-Expr MakeCallTIR(Expr shape, Expr func, Tuple args, Optional<Expr> packed_ints) {
+Expr MakeCallTIR(Expr output_shape, Type output_type, Expr func, Tuple args,
+                 Optional<Expr> packed_ints) {
   static const Op& op = Op::Get("relax.call_tir");
   Call call;
   if (!packed_ints) {
     // don't use additional optional argument
-    call = Call(op, {shape, func, args}, {}, {});
+    call = Call(op, {output_shape, func, args}, {}, {output_type});
   } else {
-    call = Call(op, {shape, func, args, packed_ints.value()}, {}, {});
-  }
-  call->shape_ = shape;
-  if (shape->IsInstance<TupleNode>()) {
-    // multiple output tensors
-    Array<Type> types;
-    for (size_t i = 0; i < Downcast<Tuple>(shape)->fields.size(); i++) {
-      // TODO(@yuchen): fix checked_type_ inference
-      types.push_back(args->fields[0]->checked_type_);
-    }
-    call->checked_type_ = TupleType(types);
-  } else {
-    // TODO(@yuchen): fix checked_type_ inference
-    call->checked_type_ = args->fields[0]->checked_type_;
+    call = Call(op, {output_shape, func, args, packed_ints.value()}, {}, {output_type});
   }
   return call;
 }
@@ -104,6 +109,7 @@ TVM_REGISTER_GLOBAL("relax.op.shape_of").set_body_typed(MakeShapeOf);
 // alloc_tensor
 
 RELAY_REGISTER_OP("relax.builtin.alloc_tensor")
+    .set_attrs_type<AllocTensorAttrs>()
     .set_num_inputs(1)
     .add_argument("shape", "Expr", "The shape of the tensor to allocate.");
 
@@ -117,7 +123,7 @@ TVM_REGISTER_GLOBAL("relax.op.builtin.alloc_tensor").set_body_typed(MakeAllocTen
 // vm alloc_storage
 
 RELAY_REGISTER_OP("relax.vm.builtin.alloc_storage")
-    .set_attrs_type<AllocStorageAttrs>()
+    .set_attrs_type<VMAllocStorageAttrs>()
     .set_num_inputs(1)
     .add_argument("size", "Expr", "The size of the storage to allocate.");
 
@@ -131,7 +137,7 @@ TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_storage").set_body_typed(MakeVMAl
 // vm alloc_tensor
 
 RELAY_REGISTER_OP("relax.vm.builtin.alloc_tensor")
-    .set_attrs_type<AllocTensorAttrs>()
+    .set_attrs_type<VMAllocTensorAttrs>()
     .set_num_inputs(1)
     .add_argument("shape", "Expr", "The shape of the tensor to allocate.");
 

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -53,21 +53,50 @@ class CallTIRMutator : public ExprMutator {
 
     if (call->op == call_tir_op) {
       Array<Expr> outs;
-      if (call->args[0]->IsInstance<ShapeExprNode>()) {
-        // single output case
-        ShapeExpr output_shape = Downcast<ShapeExpr>(call->args[0]);
-        outs.push_back(builder_->Emit(Call(alloc_tensor_op, {output_shape}), "alloc"));
-      } else {
-        // multiple output case
-        CHECK(call->args[0]->IsInstance<TupleNode>())
-            << "call_tir expects ShapeExpr or Tuple as first argument, got " << call->args[0];
-        Tuple output_shapes = Downcast<Tuple>(call->args[0]);
-        for (const auto& shape : output_shapes->fields) {
-          CHECK(shape->IsInstance<ShapeExprNode>())
-              << "call_tir exoects Tuple of ShapeExprs, got " << shape << " as an element of tuple";
-          outs.push_back(
-              builder_->Emit(Call(alloc_tensor_op, {Downcast<ShapeExpr>(shape)}), "alloc"));
+      if (call->shape_) {
+        if (call->shape_.value()->IsInstance<ShapeExprNode>()) {
+          // single output case
+          ShapeExpr output_shape = Downcast<ShapeExpr>(call->shape_.value());
+          auto alloc_tensor_attr = make_object<AllocTensorAttrs>();
+
+          if (call->checked_type_.defined()) {
+            auto output_type = Downcast<DynTensorType>(call->checked_type_);
+            alloc_tensor_attr->dtype = output_type->dtype;
+            outs.push_back(builder_->Emit(
+                Call(alloc_tensor_op, {output_shape}, Attrs(alloc_tensor_attr)), "alloc"));
+          } else {
+            LOG(FATAL) << "ValueError: the checked_type_ of call_tir is not populated.";
+          }
+        } else {
+          // multiple output case
+          ICHECK(call->shape_.value()->IsInstance<TupleNode>())
+              << "call_tir expects ShapeExpr or Tuple as its shape, but got " << call->shape_;
+          ICHECK(call->checked_type_->IsInstance<TupleTypeNode>())
+              << "call_tir expects DynTensorType or TupleType as its checked type, but got "
+              << call->checked_type_;
+          Tuple output_shapes = Downcast<Tuple>(call->shape_);
+          TupleType output_types = Downcast<TupleType>(call->checked_type_);
+          ICHECK(output_shapes->fields.size() == output_types->fields.size())
+              << "The output of call_tir should have the same amount of fields in its shape_ and "
+                 "checked_type_";
+          for (size_t i = 0; i < output_shapes->fields.size(); ++i) {
+            ICHECK(output_shapes->fields[i]->IsInstance<ShapeExprNode>())
+                << "call_tir expects Tuple of ShapeExprs, but got " << output_shapes->fields[i]
+                << " as an element of tuple";
+            ICHECK(output_types->fields[i]->IsInstance<DynTensorTypeNode>())
+                << "call_tir expects TupleType of DynTensorType, but got "
+                << output_types->fields[i] << " as an element of TupleType";
+            auto output_type = Downcast<DynTensorType>(output_types->fields[i]);
+            auto alloc_tensor_attr = make_object<AllocTensorAttrs>();
+            alloc_tensor_attr->dtype = output_type->dtype;
+            outs.push_back(builder_->Emit(
+                Call(alloc_tensor_op, {Downcast<ShapeExpr>(output_shapes->fields[i])},
+                     Attrs(alloc_tensor_attr)),
+                "alloc"));
+          }
         }
+      } else {
+        LOG(FATAL) << "ValueError: the shape of call_tir has not populated.";
       }
 
       Array<Expr> args;

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -71,8 +71,8 @@ class InputModule:
             x0 = relax.match_shape(sh, (m, n))
             sh1 = relax.call_packed("vm.builtin.shape_of", w)
             x1 = relax.match_shape(sh1, (n, k))
-            lv0 = R.call_tir((m,k), tir_matmul, (x,w))
-            lv1 = R.call_tir((m,k), tir_relu, (lv0))
+            lv0 = R.call_tir((m,k), tir_matmul, (x,w), dtype="float32")
+            lv1 = R.call_tir((m,k), tir_relu, (lv0), dtype="float32)
             relax.output(lv1)
         return lv1
 """
@@ -152,8 +152,8 @@ def test_class_irmodule(dev: str):
         @R.function
         def main(x: Tensor[(32, 32), "float32"], w: Tensor[(32, 32), "float32"]) -> Tensor:
             with R.dataflow():
-                lv0 = R.call_tir((32, 32), tir_matmul, (x, w))
-                lv1 = R.call_tir((32, 32), tir_relu, (lv0))
+                lv0 = R.call_tir((32, 32), tir_matmul, (x, w), dtype="float32")
+                lv1 = R.call_tir((32, 32), tir_relu, (lv0), dtype="float32")
                 relax.output(lv1)
             return lv1
 
@@ -212,4 +212,4 @@ def test_class_irmodule(dev: str):
 
 
 if __name__ == "__main__":
-    test_class_irmodule(dev="cpu")
+    pytest.main([__file__])

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -71,8 +71,8 @@ class InputModule:
             x0 = relax.match_shape(sh, (m, n))
             sh1 = relax.call_packed("vm.builtin.shape_of", w)
             x1 = relax.match_shape(sh1, (n, k))
-            lv0 = R.call_tir((m,k), tir_matmul, (x,w), dtype="float32")
-            lv1 = R.call_tir((m,k), tir_relu, (lv0), dtype="float32)
+            lv0 = R.call_tir(tir_matmul, (x, w), (m, k), dtype="float32")
+            lv1 = R.call_tir(tir_relu, (lv0), (m, k), dtype="float32)
             relax.output(lv1)
         return lv1
 """
@@ -152,8 +152,8 @@ def test_class_irmodule(dev: str):
         @R.function
         def main(x: Tensor[(32, 32), "float32"], w: Tensor[(32, 32), "float32"]) -> Tensor:
             with R.dataflow():
-                lv0 = R.call_tir((32, 32), tir_matmul, (x, w), dtype="float32")
-                lv1 = R.call_tir((32, 32), tir_relu, (lv0), dtype="float32")
+                lv0 = R.call_tir(tir_matmul, (x, w), (32, 32), dtype="float32")
+                lv1 = R.call_tir(tir_relu, (lv0), (32, 32), dtype="float32")
                 relax.output(lv1)
             return lv1
 

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -315,13 +315,15 @@ def test_emit_te():
     assert rx_func.body.body == out
     assert len(rx_func.body.blocks) == 1
     assert len(rx_func.body.blocks[0].bindings) == 1
-    assert isinstance(rx_func.body.blocks[0].bindings[0].value, rx.Call)
-    assert rx_func.body.blocks[0].bindings[0].value.op == relay.op.get("relax.call_tir")
-    assert len(rx_func.body.blocks[0].bindings[0].value.args) == 3
-    assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "te_func"
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][0] == x
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][1] == y
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][2] == z
+
+    call_node = rx_func.body.blocks[0].bindings[0].value
+    assert isinstance(call_node, rx.Call)
+    assert call_node.op == relay.op.get("relax.call_tir")
+    assert len(call_node.args) == 3
+    assert call_node.args[0].name_hint == "te_func"
+    assert call_node.args[1][0] == x
+    assert call_node.args[1][1] == y
+    assert call_node.args[1][2] == z
 
 
 def test_emit_te_multiple():
@@ -352,9 +354,9 @@ def test_emit_te_multiple():
 
     # only two PrimFuncs were generated since two of them are equal so got deduped
     assert len(prim_func) == 2
-    assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "te_func"
-    assert rx_func.body.blocks[0].bindings[1].value.args[1].name_hint == "te_func"
-    assert rx_func.body.blocks[0].bindings[2].value.args[1].name_hint == "te_func1"
+    assert rx_func.body.blocks[0].bindings[0].value.args[0].name_hint == "te_func"
+    assert rx_func.body.blocks[0].bindings[1].value.args[0].name_hint == "te_func"
+    assert rx_func.body.blocks[0].bindings[2].value.args[0].name_hint == "te_func1"
 
 
 def test_emit_te_multiple_output():
@@ -377,12 +379,13 @@ def test_emit_te_multiple_output():
     # check call tir output shape is a Tuple of ShapeExpr
     assert rx_func.params[0] == x
     assert rx_func.name.name_hint == "rx_func"
-    assert rx_func.body.blocks[0].bindings[0].value.op == relay.op.get("relax.call_tir")
-    assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "te_func"
-    assert isinstance(rx_func.body.blocks[0].bindings[0].value.args[0], rx.Tuple)
-    assert len(rx_func.body.blocks[0].bindings[0].value.args[0]) == 2
-    assert isinstance(rx_func.body.blocks[0].bindings[0].value.args[0][0], rx.ShapeExpr)
-    assert isinstance(rx_func.body.blocks[0].bindings[0].value.args[0][1], rx.ShapeExpr)
+    call_node = rx_func.body.blocks[0].bindings[0].value
+    assert call_node.op == relay.op.get("relax.call_tir")
+    assert call_node.args[0].name_hint == "te_func"
+    assert isinstance(call_node.args[2], rx.Tuple)
+    assert len(call_node.args[2]) == 2
+    assert isinstance(call_node.args[2][0], rx.ShapeExpr)
+    assert isinstance(call_node.args[2][1], rx.ShapeExpr)
 
 
 def test_emit_te_extern():
@@ -403,12 +406,15 @@ def test_emit_te_extern():
     assert rx_func.params[0] == x
     assert rx_func.params[1] == y
     assert len(rx_func.body.blocks) == 1
-    assert isinstance(rx_func.body.blocks[0].bindings[0].value, rx.Call)
-    assert rx_func.body.blocks[0].bindings[0].value.op == relay.op.get("relax.call_tir")
-    assert len(rx_func.body.blocks[0].bindings[0].value.args) == 3
-    assert rx_func.body.blocks[0].bindings[0].value.args[1].name_hint == "matmul"
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][0] == x
-    assert rx_func.body.blocks[0].bindings[0].value.args[2][1] == y
+    call_node = rx_func.body.blocks[0].bindings[0].value
+    assert isinstance(call_node, rx.Call)
+    assert call_node.op == relay.op.get("relax.call_tir")
+    assert len(call_node.args) == 3
+    assert call_node.args[0].name_hint == "matmul"
+    assert call_node.args[1][0] == x
+    assert call_node.args[1][1] == y
+    assert call_node.args[2][0] == n
+    assert call_node.args[2][1] == n
 
 
 def test_emit_tuple_get_item():

--- a/tests/python/relax/test_op.py
+++ b/tests/python/relax/test_op.py
@@ -41,8 +41,8 @@ def test_call_tir() -> None:
     shape_anno = [54, 96]
     type_anno = rx.DynTensorType(2, "float32")
     v0 = rx.Var("v0", shape_anno, type_anno)
-    v1 = rx.call_tir([54, 96], type_anno, rx.extern("test.op.identity"), [v0])
-    v1 = rx.call_tir([54, 96], type_anno, identity_tir, [v0])
+    v1 = rx.call_tir(rx.extern("test.op.identity"), [v0], [54, 96], type_anno)
+    v1 = rx.call_tir(identity_tir, [v0], [54, 96], type_anno)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_op.py
+++ b/tests/python/relax/test_op.py
@@ -41,8 +41,8 @@ def test_call_tir() -> None:
     shape_anno = [54, 96]
     type_anno = rx.DynTensorType(2, "float32")
     v0 = rx.Var("v0", shape_anno, type_anno)
-    v1 = rx.call_tir(rx.extern("test.op.identity"), [v0], [54, 96], type_anno)
-    v1 = rx.call_tir(identity_tir, [v0], [54, 96], type_anno)
+    v1 = rx.call_tir(rx.extern("test.op.identity"), [v0], [54, 96], "float32")
+    v1 = rx.call_tir(identity_tir, [v0], [54, 96], "float32")
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_op.py
+++ b/tests/python/relax/test_op.py
@@ -41,8 +41,8 @@ def test_call_tir() -> None:
     shape_anno = [54, 96]
     type_anno = rx.DynTensorType(2, "float32")
     v0 = rx.Var("v0", shape_anno, type_anno)
-    v1 = rx.call_tir([54, 96], rx.extern("test.op.identity"), [v0])
-    v1 = rx.call_tir([54, 96], identity_tir, [v0])
+    v1 = rx.call_tir([54, 96], type_anno, rx.extern("test.op.identity"), [v0])
+    v1 = rx.call_tir([54, 96], type_anno, identity_tir, [v0])
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -468,7 +468,7 @@ def test_inline_tir():
                         C[vi, vj] = 0.0
                     C[vi, vj] += A[vi, vk] * B[vj, vk]
 
-        z = relax.call_tir((B, 128), my_matmul, (x, y), dtype="float32")
+        z = relax.call_tir(my_matmul, (x, y), (B, 128), dtype="float32")
         return z
 
     x, y = f.params
@@ -481,7 +481,7 @@ def test_inline_tir():
     check_call(
         z_bind.value,
         "relax.call_tir",
-        [relax.ShapeExpr([B, tir.IntImm("int64", 128)]), mm_bind.var, relax.Tuple([x, y])],
+        [mm_bind.var, relax.Tuple([x, y]), relax.ShapeExpr([B, tir.IntImm("int64", 128)])],
     )
 
 
@@ -547,7 +547,7 @@ def test_primexpr_arithmetic():
 def test_call_tir_extern():
     @R.function
     def f(x: Tensor):
-        z = relax.call_tir((10,), "my_extern", (x,), dtype="float32")
+        z = relax.call_tir("my_extern", (x,), (10,), dtype="float32")
         return z
 
     x = f.params[0]
@@ -557,9 +557,9 @@ def test_call_tir_extern():
         z_bind.value,
         "relax.call_tir",
         [
-            relax.ShapeExpr([tir.IntImm("int64", 10)]),
             relax.ExternFunc("my_extern"),
             relax.Tuple([x]),
+            relax.ShapeExpr([tir.IntImm("int64", 10)]),
         ],
     )
 
@@ -586,12 +586,12 @@ def test_class_irmodule():
 
         @R.function
         def g(y: Tensor[(n, n), _]) -> Tensor:
-            return relax.call_tir((n, n), my_matmul, (y, y), dtype="float32")
+            return relax.call_tir(my_matmul, (y, y), (n, n), dtype="float32")
 
         @R.function
         def j(y: Tensor[(n, n), _]) -> Tensor:
             with relax.dataflow():
-                gv = relax.call_tir((n, n), my_matmul, (y, y), dtype="float32")
+                gv = relax.call_tir(my_matmul, (y, y), (n, n), dtype="float32")
                 relax.output(gv)
             return gv
 
@@ -612,7 +612,7 @@ def test_class_irmodule():
     j = my_module[var_j]
 
     assert f.body.body.op == var_g
-    assert g.body.body.args[1] == var_my_matmul
+    assert g.body.body.args[0] == var_my_matmul
 
     gv_bind = j.body.blocks[0].bindings[0]
     assert gv_bind.value.checked_type.rank == 2

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -465,7 +465,7 @@ def test_inline_tir():
                         C[vi, vj] = 0.0
                     C[vi, vj] += A[vi, vk] * B[vj, vk]
 
-        z = relax.call_tir((B, 128), my_matmul, (x, y))
+        z = relax.call_tir((B, 128), my_matmul, (x, y), dtype="float32")
         return z
 
     x, y = f.params
@@ -544,7 +544,7 @@ def test_primexpr_arithmetic():
 def test_call_tir_extern():
     @R.function
     def f(x: Tensor):
-        z = relax.call_tir((10,), "my_extern", (x,))
+        z = relax.call_tir((10,), "my_extern", (x,), dtype="float32")
         return z
 
     x = f.params[0]
@@ -583,7 +583,7 @@ def test_class_irmodule():
 
         @R.function
         def g(y: Tensor[(n, n), _]) -> Tensor:
-            return relax.call_tir((n, n), my_matmul, (y, y))
+            return relax.call_tir((n, n), my_matmul, (y, y), dtype="float32")
 
         @R.function
         def h(x, y, z):

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -159,7 +159,7 @@ def test_inline_tir():
                         C[vi, vj] = 0.0
                     C[vi, vj] += A[vi, vk] * B[vj, vk]
 
-        z = relax.call_tir((B, 128), my_matmul, (x, y))
+        z = relax.call_tir((B, 128), my_matmul, (x, y), dtype="float32")
         return z
 
     check_roundtrip(foo)
@@ -191,7 +191,7 @@ def test_primexpr_arithmetic():
 def test_call_tir_extern():
     @R.function
     def foo(x: Tensor):
-        z = relax.call_tir((10,), "my_extern", (x,))
+        z = relax.call_tir((10,), "my_extern", (x,), dtype="float32")
         return z
 
     check_roundtrip(foo)
@@ -293,7 +293,7 @@ def test_class_irmodule():
 
         @R.function
         def g(y: Tensor[(n, n), _]) -> Tensor:
-            return relax.call_tir((n, n), my_matmul, (y, y))
+            return relax.call_tir((n, n), my_matmul, (y, y), dtype="float32")
 
         @R.function
         def h(x, y, z):

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -159,7 +159,7 @@ def test_inline_tir():
                         C[vi, vj] = 0.0
                     C[vi, vj] += A[vi, vk] * B[vj, vk]
 
-        z = relax.call_tir((B, 128), my_matmul, (x, y), dtype="float32")
+        z = relax.call_tir(my_matmul, (x, y), (B, 128), dtype="float32")
         return z
 
     check_roundtrip(foo)
@@ -191,7 +191,7 @@ def test_primexpr_arithmetic():
 def test_call_tir_extern():
     @R.function
     def foo(x: Tensor):
-        z = relax.call_tir((10,), "my_extern", (x,), dtype="float32")
+        z = relax.call_tir("my_extern", (x,), (10,), dtype="float32")
         return z
 
     check_roundtrip(foo)
@@ -293,7 +293,7 @@ def test_class_irmodule():
 
         @R.function
         def g(y: Tensor[(n, n), _]) -> Tensor:
-            return relax.call_tir((n, n), my_matmul, (y, y), dtype="float32")
+            return relax.call_tir(my_matmul, (y, y), (n, n), dtype="float32")
 
         @R.function
         def h(x, y, z):

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -102,8 +102,8 @@ def test_to_non_dataflow():
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
             with relax.dataflow():
-                lv0 = relax.call_tir((m, n), "test.op.identity", (x,), dtype="float32")
-                gv0 = relax.call_tir((m, n), "test.op.identity", (lv0,), dtype="float32")
+                lv0 = relax.call_tir("test.op.identity", (x,), (m, n), dtype="float32")
+                gv0 = relax.call_tir("test.op.identity", (lv0,), (m, n), dtype="float32")
                 relax.output(gv0)
             return gv0
 
@@ -145,7 +145,7 @@ def test_call_tir_rewrite():
     class TestCallTIRRewrite:
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
-            gv0 = relax.call_tir((m, n), "test.op.identity", (x,), dtype="float32")
+            gv0 = relax.call_tir("test.op.identity", (x,), (m, n), dtype="float32")
             return gv0
 
     mod = TestCallTIRRewrite
@@ -167,7 +167,7 @@ def test_call_tir_rewrite():
     assert isinstance(s1, tvm.relay.Call)
     assert s1.op.name == "relax.builtin.alloc_tensor"
     assert isinstance(s1.args[0], relax.ShapeExpr)
-    assert structural_equal(s1.args[0], s0.args[0])
+    assert structural_equal(s1.args[0], s0.args[2])
     s2 = block.bindings[1].value
     assert s2.op.global_symbol == "test.op.identity"
 
@@ -245,7 +245,7 @@ def test_vm_static_shape_lowering():
         @R.function
         def foo(x: Tensor[(2, 3), "float32"]) -> Tensor:
             with relax.dataflow():
-                y = R.call_tir((2, 6), "test.vm.tile", (x), dtype="float32")
+                y = R.call_tir("test.vm.tile", (x), (2, 6), dtype="float32")
                 relax.output(y)
             return y
 
@@ -281,7 +281,7 @@ def test_vm_shape_lowering_func_param_with_shape():
 
         @R.function
         def foo(x: Tensor[(m, n), "float32"], w: Tensor[(n, k), "float32"]) -> Tensor:
-            gv0 = R.call_tir((m, k), tir_matmul, (x, w), dtype="float32")
+            gv0 = R.call_tir(tir_matmul, (x, w), (m, k), dtype="float32")
             return gv0
 
     mod = InputModule
@@ -348,8 +348,8 @@ def test_to_anf_no_op():
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
             with relax.dataflow():
-                lv0 = relax.call_tir((m, n), "test.op.identity", (x,), dtype="float32")
-                gv0 = relax.call_tir((m, n), "test.op.identity", (lv0,), dtype="float32")
+                lv0 = relax.call_tir("test.op.identity", (x,), (m, n), dtype="float32")
+                gv0 = relax.call_tir("test.op.identity", (lv0,), (m, n), dtype="float32")
                 relax.output(gv0)
             return gv0
 

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -102,8 +102,8 @@ def test_to_non_dataflow():
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
             with relax.dataflow():
-                lv0 = relax.call_tir((m, n), "test.op.identity", (x,))
-                gv0 = relax.call_tir((m, n), "test.op.identity", (lv0,))
+                lv0 = relax.call_tir((m, n), "test.op.identity", (x,), dtype="float32")
+                gv0 = relax.call_tir((m, n), "test.op.identity", (lv0,), dtype="float32")
                 relax.output(gv0)
             return gv0
 
@@ -145,7 +145,7 @@ def test_call_tir_rewrite():
     class TestCallTIRRewrite:
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
-            gv0 = relax.call_tir((m, n), "test.op.identity", (x,))
+            gv0 = relax.call_tir((m, n), "test.op.identity", (x,), dtype="float32")
             return gv0
 
     mod = TestCallTIRRewrite
@@ -177,7 +177,7 @@ def test_vm_memory_lower():
     class TestVMMemoryLower:
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
-            alloc = relax.builtin.alloc_tensor((m, n))
+            alloc = relax.builtin.alloc_tensor((m, n), dtype="float32")
             _ = relax.call_packed("test.op.identity", (x,), alloc)
             gv0 = alloc
             return gv0
@@ -245,7 +245,7 @@ def test_vm_static_shape_lowering():
         @R.function
         def foo(x: Tensor[(2, 3), "float32"]) -> Tensor:
             with relax.dataflow():
-                y = R.call_tir((2, 6), "test.vm.tile", (x))
+                y = R.call_tir((2, 6), "test.vm.tile", (x), dtype="float32")
                 relax.output(y)
             return y
 
@@ -281,7 +281,7 @@ def test_vm_shape_lowering_func_param_with_shape():
 
         @R.function
         def foo(x: Tensor[(m, n), "float32"], w: Tensor[(n, k), "float32"]) -> Tensor:
-            gv0 = R.call_tir((m, k), tir_matmul, (x, w))
+            gv0 = R.call_tir((m, k), tir_matmul, (x, w), dtype="float32")
             return gv0
 
     mod = InputModule
@@ -348,8 +348,8 @@ def test_to_anf_no_op():
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
             with relax.dataflow():
-                lv0 = relax.call_tir((m, n), "test.op.identity", (x,))
-                gv0 = relax.call_tir((m, n), "test.op.identity", (lv0,))
+                lv0 = relax.call_tir((m, n), "test.op.identity", (x,), dtype="float32")
+                gv0 = relax.call_tir((m, n), "test.op.identity", (lv0,), dtype="float32")
                 relax.output(gv0)
             return gv0
 

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -411,7 +411,7 @@ def test_vm_compile_stage3():
         @R.function
         def foo(x: Tensor[(32, 16), "float32"]) -> Tensor:
             with R.dataflow():
-                y = R.call_tir((32, 16), "test.vm.identity", (x), dtype="float32")
+                y = R.call_tir("test.vm.identity", (x), (32, 16), dtype="float32")
                 R.output(y)
             return y
 
@@ -433,7 +433,7 @@ def test_vm_compile_e2e():
         def foo(x: Tensor[_, "float32"]) -> Tensor:
             with R.dataflow():
                 R.match_shape(x, (n, m))
-                y = R.call_tir((n, m * 2), "test.vm.tile", (x), dtype="float32")
+                y = R.call_tir("test.vm.tile", (x), (n, m * 2), dtype="float32")
                 R.output(y)
             return y
 
@@ -471,7 +471,7 @@ def test_vm_compile_e2e_func_param_with_shape():
 
         @R.function
         def func(x: Tensor[(m, n), "float32"], w: Tensor[(n, k), "float32"]) -> Tensor:
-            gv0 = R.call_tir((m, k), tir_matmul, (x, w), dtype="float32")
+            gv0 = R.call_tir(tir_matmul, (x, w), (m, k), dtype="float32")
             return gv0
 
     mod = TestVMCompileE2E2

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -568,6 +568,9 @@ def test_vm_emit_te_dtype_change():
 
     mod = bb.get()
 
+    new_mod = relax.transform.CallTIRRewrite()(mod)
+    assert new_mod["rx_func"].body.blocks[0].bindings[0].value.attrs.dtype == "int16"
+
     target = tvm.target.Target("llvm", host="llvm")
     ex, lib = relax.vm.build(mod, target)
 

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -411,7 +411,7 @@ def test_vm_compile_stage3():
         @R.function
         def foo(x: Tensor[(32, 16), "float32"]) -> Tensor:
             with R.dataflow():
-                y = R.call_tir((32, 16), "test.vm.identity", (x))
+                y = R.call_tir((32, 16), "test.vm.identity", (x), dtype="float32")
                 R.output(y)
             return y
 
@@ -433,7 +433,7 @@ def test_vm_compile_e2e():
         def foo(x: Tensor[_, "float32"]) -> Tensor:
             with R.dataflow():
                 R.match_shape(x, (n, m))
-                y = R.call_tir((n, m * 2), "test.vm.tile", (x))
+                y = R.call_tir((n, m * 2), "test.vm.tile", (x), dtype="float32")
                 R.output(y)
             return y
 
@@ -471,7 +471,7 @@ def test_vm_compile_e2e_func_param_with_shape():
 
         @R.function
         def func(x: Tensor[(m, n), "float32"], w: Tensor[(n, k), "float32"]) -> Tensor:
-            gv0 = R.call_tir((m, k), tir_matmul, (x, w))
+            gv0 = R.call_tir((m, k), tir_matmul, (x, w), dtype="float32")
             return gv0
 
     mod = TestVMCompileE2E2
@@ -549,6 +549,36 @@ def test_vm_emit_te_concat():
     res = vm["rx_func"](inp, inp2)
 
     np.testing.assert_allclose(res.numpy(), np.append(inp.numpy(), inp2.numpy()))
+
+
+def test_vm_emit_te_dtype_change():
+    bb = relax.BlockBuilder()
+    n = tir.Var("n", "int64")
+    type_anno = relax.DynTensorType(1, "float32")
+    x = relax.Var("x", [n], type_anno)
+
+    # convert a tensor with dtype of float32 to int16
+    def te_func(A):
+        B = te.compute((n,), lambda i: A[i].astype("int16"))
+        return B
+
+    with bb.function("rx_func", [x]):
+        y = bb.emit_te(te_func, x)
+        bb.emit_func_output(y)
+
+    mod = bb.get()
+
+    target = tvm.target.Target("llvm", host="llvm")
+    ex, lib = relax.vm.build(mod, target)
+
+    vm = relax.VirtualMachine(ex, tvm.cpu(), mod=lib)
+    inp = tvm.nd.array(
+        np.random.rand(
+            1,
+        ).astype(np.float32)
+    )
+    res = vm["rx_func"](inp)
+    np.testing.assert_allclose(res.numpy(), inp.numpy().astype("int16"))
 
 
 def test_vm_emit_te_floor_symbolic_shape():


### PR DESCRIPTION
As discussed in #88, this pr changes `call_tir` to have its output_shape and output_type specified in its argument and type_args respectively:
`call_tir<out_type>(out_shape, func, [a, b]) -> Expr`.

This changes makes the shape/type deduction rule more principled and simple: the `shape_` and `checked_type_` of a CallNode are always deduced(inferred). During the rewriting, whenever the inputs of a CallNode are changed, the `shape_` and `checked_type_` are always re-deduced.

In TVMScript, one can write the following for call_tir:
```python
# call_tir has a single output
# note that dtype is a keyword argument, indicating it's not a arg of call_tir, but is part of the type_args
y = R.call_tir((32, 16), relu, (x), dtype="float32")

# call_tir has multiple outputs
z = R.call_tir(((1, 3, 224, 224), (3,), (3,)), batch_norm, (data, bn_data_gamma, bn_data_beta, bn_data_moving_mean, bn_data_moving_var), dtype=("float32", "float32", "float32"))
```


Other changes:
- Removes the hardcoded Float32 dtype in the vm memory lowering pass. Adds an attr to `relax.builtin.alloc_tensor` to carry dtype to be used in the vm memory lowering pass. (check out the `test_vm_emit_te_dtype_change` added to test_vm.py)
- Adds printer support for a tensor with `TupleTypeNode` (which is often the return value of a call_tir with multiple outputs), previously we didn't print its shape. The multi-output TVMScript in the above code-snippet prints as:
```python
gv: Tuple[(Tensor[(1, 3, 224, 224), "float32"], Tensor[(3,), "float32"], Tensor[(3,), "float32"])] = relax.call_tir(((1, 3, 224, 224), (3,), (3,)), batch_norm, (data, bn_data_gamma, bn_data_beta, bn_data_moving_mean, bn_data_moving_var), dtype=("float32", "float32", "float32"))
```
We could discuss if we want to print the Tuple with shape info in the lhs of the binding if rhs is a call_tir, which also contains this information. Feedback is welcome!

cc @yongwww @Hzfengsy @hypercubestart  @ZihengJiang 