### PR TITLE
[VM] Refactor and improve vm.

### DIFF
--- a/include/tvm/relax/vm/vm.h
+++ b/include/tvm/relax/vm/vm.h
@@ -172,7 +172,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param curr_frame The current frame.
    * \param inst The call instruction.
    */
-  inline void RunInstCall(VMFrame* curr_frame, Instruction inst);
+  inline void RunInstrCall(VMFrame* curr_frame, Instruction inst);
 
  private:
   /*! \brief The loaded executable. */
@@ -180,7 +180,7 @@ class VirtualMachine : public runtime::ModuleNode {
   /*!
    * \brief Internal function table cache to speedup execution.
    * \note This is used to cache functions so we do not need
-   *       to loop up by name every time.
+   *       to look up by name every time.
    *       It does mean that the definition of the function
    *       cannot change when the vm get loaded.
    */

--- a/include/tvm/relax/vm/vm.h
+++ b/include/tvm/relax/vm/vm.h
@@ -24,6 +24,7 @@
 #ifndef TVM_RELAX_VM_VM_H_
 #define TVM_RELAX_VM_VM_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -54,6 +55,13 @@ struct VMFrame {
   std::vector<RegType> register_file;
   /*! \brief Register in caller's frame to put return value */
   RegName caller_return_register;
+  // The following fields are used for PackedFunc call within
+  // a single function scope. The space is reused across multiple
+  // packed func calls to increase cache locality and avoid re-allocation
+  /*! \brief Temporary argument value stack for packed func call. */
+  std::vector<TVMValue> call_arg_values;
+  /*! \brief Temporary argument tcode stack for packed func call. */
+  std::vector<int> call_arg_tcodes;
 
   VMFrame(Index pc, Index register_file_size)
       : return_pc(pc), register_file(register_file_size), caller_return_register(0) {}
@@ -133,16 +141,23 @@ class VirtualMachine : public runtime::ModuleNode {
   void PopFrame();
   /*!
    * \brief Write to a VM register.
+   * \param frame current vm frame.
    * \param reg The register to write to.
    * \param obj The object to write to.
    */
-  inline void WriteRegister(RegName reg, const RegType& obj);
+  inline void WriteRegister(VMFrame* frame, RegName reg, const RegType& obj);
   /*!
    * \brief Read a VM register.
+   * \param frame current vm frame.
    * \param reg The register to read from.
    * \return The value of the register.
    */
-  inline RegType ReadRegister(RegName reg) const;
+  inline RegType ReadRegister(VMFrame* frame, RegName reg) const;
+  /*!
+   * \brief Prepare function table so that func_table_[func_index] is populated.
+   * \param func_index The function index.
+   */
+  inline void PrepareFuncTable(Index func_index);
   /*!
    * \brief Invoke a VM function.
    * \param fidx The function index.
@@ -152,12 +167,29 @@ class VirtualMachine : public runtime::ModuleNode {
   RegType Invoke(Index fidx, const std::vector<RegType>& args);
   /*! \brief Run VM dispatch loop. */
   void RunLoop();
+  /*!
+   * \brief Run call instruction.
+   * \param curr_frame The current frame.
+   * \param inst The call instruction.
+   */
+  inline void RunInstCall(VMFrame* curr_frame, Instruction inst);
 
  private:
   /*! \brief The loaded executable. */
   ObjectPtr<Executable> exec_;
-  /*! \brief The current stack of call frames. */
-  std::vector<VMFrame> frames_;
+  /*!
+   * \brief Internal function table cache to speedup execution.
+   * \note This is used to cache functions so we do not need
+   *       to loop up by name every time.
+   *       It does mean that the definition of the function
+   *       cannot change when the vm get loaded.
+   */
+  std::vector<PackedFunc> func_table_;
+  /*!
+   * \brief The current stack of call frames.
+   * \note: Use unique ptr to avoid re-allocation and copy when frames_ get resized.
+   */
+  std::vector<std::unique_ptr<VMFrame>> frames_;
   /*! \brief The virtual machine PC. */
   Index pc_{0};
   /*! \brief The special return register. */

--- a/src/relax/vm/vm.cc
+++ b/src/relax/vm/vm.cc
@@ -105,7 +105,7 @@ void VirtualMachine::PrepareFuncTable(Index func_index) {
   func_table_[func_index] = func;
 }
 
-void VirtualMachine::RunInstCall(VMFrame* curr_frame, Instruction instr) {
+void VirtualMachine::RunInstrCall(VMFrame* curr_frame, Instruction instr) {
   DLOG(INFO) << "\n  pc = " << pc_ << ", execute: " << exec_->func_names[instr.func_idx];
 
   // Use the call arg stack from the current frame to increase reuse
@@ -164,7 +164,7 @@ void VirtualMachine::RunLoop() {
     Instruction instr = exec_->GetInstruction(pc_);
     switch (instr.op) {
       case Opcode::Call: {
-        this->RunInstCall(curr_frame, instr);
+        this->RunInstrCall(curr_frame, instr);
         break;
       }
       case Opcode::Ret: {

--- a/src/relax/vm/vm.cc
+++ b/src/relax/vm/vm.cc
@@ -58,7 +58,7 @@ RegType VirtualMachine::Invoke(Index gf_idx, const std::vector<RegType>& args) {
   // load arguments to the register file
   ICHECK(static_cast<size_t>(gfunc.num_args) == args.size());
   for (size_t i = 0; i < args.size(); ++i) {
-    WriteRegister(i, args[i]);
+    WriteRegister(frames_.back().get(), i, args[i]);
   }
   // set program counter
   pc_ = gfunc.start_instr;
@@ -81,77 +81,108 @@ void VirtualMachine::Init(const std::vector<Device>& devices,
   }
 }
 
+void VirtualMachine::PrepareFuncTable(Index func_index) {
+  // fast path, function already in cache;
+
+  if (static_cast<Index>(func_table_.size()) > func_index && func_table_[func_index] != nullptr)
+    return;
+
+  if (static_cast<Index>(func_table_.size()) <= func_index) {
+    func_table_.resize(func_index + 1, nullptr);
+  }
+
+  const std::string& func_name = exec_->func_names[func_index];
+  // lookup function and populate
+  PackedFunc func{nullptr};
+  if (state.lib.defined()) {
+    func = state.lib.value()->GetFunction(func_name, true);
+  }
+  if (!func.defined()) {
+    const PackedFunc* p_func = Registry::Get(func_name);
+    CHECK(p_func != nullptr);
+    func = *(p_func);
+  }
+  func_table_[func_index] = func;
+}
+
+void VirtualMachine::RunInstCall(VMFrame* curr_frame, Instruction instr) {
+  DLOG(INFO) << "\n  pc = " << pc_ << ", execute: " << exec_->func_names[instr.func_idx];
+
+  // Use the call arg stack from the current frame to increase reuse
+  // and avoid re-allocation
+  curr_frame->call_arg_values.resize(instr.num_args);
+  curr_frame->call_arg_tcodes.resize(instr.num_args);
+
+  // NOTE: no changes and resize to those vector ref(otherwise can leads to segfault)
+  //       in the remainder part of the function.
+  std::vector<TVMValue>& values = curr_frame->call_arg_values;
+  std::vector<int>& tcodes = curr_frame->call_arg_tcodes;
+
+  runtime::TVMArgsSetter setter(values.data(), tcodes.data());
+  for (Index i = 0; i < instr.num_args; ++i) {
+    Instruction::Arg arg = instr.args[i];
+    switch (arg.kind()) {
+      case Instruction::kRegister: {
+        if (arg.value() == Instruction::kVMStateRegister) {
+          setter(i, &(this->state));
+        } else {
+          setter(i, ReadRegister(curr_frame, arg.value()));
+        }
+        break;
+      }
+      case Instruction::kImmediate: {
+        setter(i, arg.value());
+        break;
+      }
+      case Instruction::kConstIdx: {
+        setter(i, this->exec_->constants[arg.value()]);
+        break;
+      }
+      default: {
+        LOG(FATAL) << "";
+      }
+    }
+  }
+  TVMArgs args(values.data(), tcodes.data(), values.size());
+  TVMRetValue ret;
+  // prepare and invoke
+  this->PrepareFuncTable(instr.func_idx);
+  func_table_[instr.func_idx].CallPacked(args, &ret);
+
+  if (instr.dst != Instruction::kVoidArg) {
+    WriteRegister(curr_frame, instr.dst, ret);
+  }
+  pc_++;
+}
+
 void VirtualMachine::RunLoop() {
   size_t start_frame = frames_.size();
+  VMFrame* curr_frame = frames_.back().get();
+
   while (true) {
-    if (static_cast<size_t>(pc_) >= exec_->instr_offset.size()) {
-      LOG(FATAL) << "run into invalide section";
-    }
+    ICHECK_LT(static_cast<size_t>(pc_), exec_->instr_offset.size()) << "run into invalide section";
     Instruction instr = exec_->GetInstruction(pc_);
     switch (instr.op) {
       case Opcode::Call: {
-        std::string func_name = exec_->func_names[instr.func_idx];
-        DLOG(INFO) << "\n  pc = " << pc_ << ", execute: " << func_name;
-
-        PackedFunc func{nullptr};
-        if (state.lib.defined()) {
-          func = state.lib.value()->GetFunction(func_name, true);
-        }
-        if (!func.defined()) {
-          const PackedFunc* p_func = Registry::Get(func_name);
-          CHECK(p_func != nullptr);
-          func = *(p_func);
-        }
-
-        std::vector<TVMValue> values(instr.num_args);
-        std::vector<int> tcodes(instr.num_args);
-        runtime::TVMArgsSetter setter(values.data(), tcodes.data());
-        for (Index i = 0; i < instr.num_args; ++i) {
-          Instruction::Arg arg = instr.args[i];
-          switch (arg.kind()) {
-            case Instruction::kRegister: {
-              if (arg.value() == Instruction::kVMStateRegister) {
-                setter(i, &(this->state));
-              } else {
-                setter(i, ReadRegister(arg.value()));
-              }
-              break;
-            }
-            case Instruction::kImmediate: {
-              setter(i, arg.value());
-              break;
-            }
-            case Instruction::kConstIdx: {
-              setter(i, this->exec_->constants[arg.value()]);
-              break;
-            }
-            default: {
-              LOG(FATAL) << "";
-            }
-          }
-        }
-        TVMArgs args(values.data(), tcodes.data(), values.size());
-        TVMRetValue ret;
-        func.CallPacked(args, &ret);
-        if (instr.dst != Instruction::kVoidArg) {
-          WriteRegister(instr.dst, ret);
-        }
-        pc_++;
+        this->RunInstCall(curr_frame, instr);
         break;
       }
       case Opcode::Ret: {
         // If we have hit the point from which we started
         // running, we should return to the caller breaking
         // the dispatch loop.
-        return_value_ = ReadRegister(instr.result);
-        auto caller_return_register = frames_.back().caller_return_register;
+        return_value_ = ReadRegister(curr_frame, instr.result);
+        RegName caller_return_register = curr_frame->caller_return_register;
         PopFrame();
         if (frames_.size() < start_frame) {
           ICHECK(frames_.size() == start_frame - 1);
           return;
+        } else {
+          // Update the current frame to be the parent frame.
+          curr_frame = frames_.back().get();
+          // Otherwise we are just returning from a local call.
+          WriteRegister(curr_frame, caller_return_register, return_value_);
         }
-        // Otherwise we are just returning from a local call.
-        WriteRegister(caller_return_register, return_value_);
         break;
       }
       case Opcode::Goto: {
@@ -159,7 +190,7 @@ void VirtualMachine::RunLoop() {
         break;
       }
       case Opcode::If: {
-        int64_t cond_val = ReadRegister(instr.cond);
+        int64_t cond_val = ReadRegister(curr_frame, instr.cond);
         if (cond_val != 0) {
           pc_++;
         } else {
@@ -173,23 +204,21 @@ void VirtualMachine::RunLoop() {
 }
 
 void VirtualMachine::PushFrame(Index ret_pc, const VMFunction& vm_func) {
-  auto frame = VMFrame(ret_pc, vm_func.register_file_size);
-  frames_.push_back(frame);
+  frames_.emplace_back(std::make_unique<VMFrame>(ret_pc, vm_func.register_file_size));
 }
 
 void VirtualMachine::PopFrame() {
   ICHECK_GT(frames_.size(), 0);
-  const VMFrame& fr = frames_.back();
-  pc_ = fr.return_pc;
+  pc_ = frames_.back()->return_pc;
   frames_.pop_back();
 }
 
-inline void VirtualMachine::WriteRegister(Index r, const RegType& val) {
-  frames_.back().register_file[r] = val;
+inline void VirtualMachine::WriteRegister(VMFrame* frame, Index r, const RegType& val) {
+  frame->register_file[r] = val;
 }
 
-inline RegType VirtualMachine::ReadRegister(Index r) const {
-  return frames_.back().register_file[r];
+inline RegType VirtualMachine::ReadRegister(VMFrame* frame, Index r) const {
+  return frame->register_file[r];
 }
 
 // initialize the VirtualMachine, takes variable-length arguments

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -529,7 +529,7 @@ def test_vm_emit_te_extern():
     weight = tvm.nd.array(np.random.rand(32, 16).astype(np.float32))
     res = vm["rx_cblas_matmul"](data, weight)
     expected = np.dot(data.numpy(), weight.numpy())
-    tvm.testing.assert_allclose(res.numpy(), expected, rtol=1e-7, atol=1e-7)
+    tvm.testing.assert_allclose(res.numpy(), expected, rtol=1e-6, atol=1e-6)
 
 
 def test_vm_emit_te_concat():


### PR DESCRIPTION
- Have a separate function for RunInstCall.
- Cache func_index lookup by table to avoid repeative lookup by str.
- Move PackedFunc call arg stack to Frame to increase locality and avoid re-allocation in repeative calls.
- Make frame stack of unique_ptr to avoid frame re-allocation and copy during frame.resize.
- Pass curr_frame as arguments into sub-functions to make it explicit.
- Reduce rtol to avoid flaky test
