### PR TITLE
Improve printer for DynTensorType and ShapeExpr

### DIFF
--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -776,6 +776,12 @@ Doc RelayTextPrinter::VisitType_(const TypeDataNode* node) {
   return doc;
 }
 
+Doc RelayTextPrinter::VisitType_(const relax::DynTensorTypeNode* node) {
+  Doc doc;
+  doc << "Tensor[rank=" << node->rank << ", dtype=\"" << PrintDType(node->dtype) << "\"]";
+  return doc;
+}
+
 //------------------------------------
 // Overload of Attr printing functions
 //------------------------------------

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -194,6 +194,7 @@ class RelayTextPrinter : public ExprFunctor<Doc(const Expr&)>,
   Doc VisitType_(const FuncTypeNode* node) final;
   Doc VisitType_(const RelayRefTypeNode* node) final;
   Doc VisitType_(const TypeDataNode* node) final;
+  Doc VisitType_(const relax::DynTensorTypeNode* node) final;
   //------------------------------------
   // Overload of Attr printing functions
   //------------------------------------
@@ -580,7 +581,8 @@ class TextPrinter {
                (node->IsInstance<tir::PrimFuncNode>() || node->IsInstance<PrimExprNode>() ||
                 node->IsInstance<tir::StmtNode>())) {
       doc << tir_text_printer_.Print(node);
-    } else if (node.defined() && node->IsInstance<relax::FunctionNode>()) {
+    } else if (node.defined() && (node->IsInstance<relax::FunctionNode>() ||
+                                  node->IsInstance<relax::ShapeExprNode>())) {
       doc << relax_text_printer_.Print(node);
     } else {
       doc << relay_text_printer_.PrintFinal(node);

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -304,5 +304,15 @@ def test_class_irmodule():
     check_roundtrip(my_module)
 
 
+def test_dyntensortype():
+    x = relax.DynTensorType(rank=3, dtype="float32")
+    assert x.__str__() == 'Tensor[rank=3, dtype="float32"]'
+
+
+def test_shapeexpr():
+    x = relax.ShapeExpr([tir.IntImm("int64", 10), tir.IntImm("int64", 5)])
+    assert x.__str__() == "(10, 5)"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Examples:

- DynTensorType
```
Tensor[rank=4, dtype="float32"]
```
- ShapeExpr([tir.IntImm("int64", 10), tir.IntImm("int64", 5)])
```
output: (10, 5)
```

@YuchenJin @yongwww 