### PR TITLE
[VM][Refactor] Move VM files to TVM runtime directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ list(APPEND COMPILER_SRCS "src/target/datatype/myfloat/myfloat.cc")
 tvm_file_glob(GLOB RUNTIME_SRCS
   src/runtime/*.cc
   src/runtime/vm/*.cc
+  src/runtime/relax_vm/*.cc
 )
 
 if(BUILD_FOR_HEXAGON)

--- a/include/tvm/relax/exec_builder.h
+++ b/include/tvm/relax/exec_builder.h
@@ -18,22 +18,21 @@
  */
 
 /*!
- * \file tvm/relax/vm/exec_builder.h
+ * \file tvm/relax/exec_builder.h
  */
-#ifndef TVM_RELAX_VM_EXEC_BUILDER_H_
-#define TVM_RELAX_VM_EXEC_BUILDER_H_
+#ifndef TVM_RELAX_EXEC_BUILDER_H_
+#define TVM_RELAX_EXEC_BUILDER_H_
 
 #include <tvm/ir/expr.h>
 #include <tvm/node/reflection.h>
 #include <tvm/node/repr_printer.h>
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/registry.h>
+#include <tvm/runtime/relax_vm/bytecode.h>
+#include <tvm/runtime/relax_vm/executable.h>
 
 #include <string>
 #include <vector>
-
-#include "./bytecode.h"
-#include "./executable.h"
 
 namespace tvm {
 namespace relax {
@@ -121,4 +120,4 @@ class ExecBuilder : public ObjectRef {
 }  // namespace relax
 }  // namespace tvm
 
-#endif  // TVM_RELAX_VM_EXEC_BUILDER_H_
+#endif  // TVM_RELAX_EXEC_BUILDER_H_

--- a/include/tvm/runtime/relax_vm/bytecode.h
+++ b/include/tvm/runtime/relax_vm/bytecode.h
@@ -18,11 +18,11 @@
  */
 
 /*!
- * \file tvm/relax/vm/bytecode.h
+ * \file tvm/runtime/relax_vm/bytecode.h
  * \brief The bytecode for the virtual machine.
  */
-#ifndef TVM_RELAX_VM_BYTECODE_H_
-#define TVM_RELAX_VM_BYTECODE_H_
+#ifndef TVM_RUNTIME_RELAX_VM_BYTECODE_H_
+#define TVM_RUNTIME_RELAX_VM_BYTECODE_H_
 
 #include <tvm/runtime/data_type.h>
 #include <tvm/runtime/logging.h>
@@ -177,4 +177,4 @@ struct Instruction {
 }  // namespace runtime
 }  // namespace tvm
 
-#endif  // TVM_RELAX_VM_BYTECODE_H_
+#endif  // TVM_RUNTIME_RELAX_VM_BYTECODE_H_

--- a/include/tvm/runtime/relax_vm/executable.h
+++ b/include/tvm/runtime/relax_vm/executable.h
@@ -18,11 +18,10 @@
  */
 
 /*!
- * \file tvm/relax/vm/executable.h
- * \brief
+ * \file tvm/runtime/relax_vm/executable.h
  */
-#ifndef TVM_RELAX_VM_EXECUTABLE_H_
-#define TVM_RELAX_VM_EXECUTABLE_H_
+#ifndef TVM_RUNTIME_RELAX_VM_EXECUTABLE_H_
+#define TVM_RUNTIME_RELAX_VM_EXECUTABLE_H_
 
 #include <tvm/ir/expr.h>
 #include <tvm/runtime/object.h>
@@ -192,4 +191,4 @@ class Executable : public runtime::ModuleNode {
 }  // namespace runtime
 }  // namespace tvm
 
-#endif  // TVM_RELAX_VM_EXECUTABLE_H_
+#endif  // TVM_RUNTIME_RELAX_VM_EXECUTABLE_H_

--- a/include/tvm/runtime/relax_vm/memory_manager.h
+++ b/include/tvm/runtime/relax_vm/memory_manager.h
@@ -18,11 +18,11 @@
  */
 
 /*!
- * \file tvm/relax/vm/memory_manager.h
+ * \file tvm/runtime/relax_vm/memory_manager.h
  * \brief Abstract device memory management API
  */
-#ifndef TVM_RELAX_VM_MEMORY_MANAGER_H_
-#define TVM_RELAX_VM_MEMORY_MANAGER_H_
+#ifndef TVM_RUNTIME_RELAX_VM_MEMORY_MANAGER_H_
+#define TVM_RUNTIME_RELAX_VM_MEMORY_MANAGER_H_
 
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/runtime/ndarray.h>
@@ -139,4 +139,4 @@ class Storage : public ObjectRef {
 }  // namespace runtime
 }  // namespace tvm
 
-#endif  // TVM_RELAX_VM_MEMORY_MANAGER_H_
+#endif  // TVM_RUNTIME_RELAX_VM_MEMORY_MANAGER_H_

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -18,11 +18,10 @@
  */
 
 /*!
- * \file tvm/relax/vm/vm.h
- * \brief
+ * \file tvm/runtime/relax_vm/vm.h
  */
-#ifndef TVM_RELAX_VM_VM_H_
-#define TVM_RELAX_VM_VM_H_
+#ifndef TVM_RUNTIME_RELAX_VM_VM_H_
+#define TVM_RUNTIME_RELAX_VM_VM_H_
 
 #include <memory>
 #include <string>
@@ -202,4 +201,4 @@ class VirtualMachine : public runtime::ModuleNode {
 }  // namespace runtime
 }  // namespace tvm
 
-#endif  // TVM_RELAX_VM_VM_H_
+#endif  // TVM_RUNTIME_RELAX_VM_VM_H_

--- a/src/relax/backend/vm/builtin.cc
+++ b/src/relax/backend/vm/builtin.cc
@@ -17,11 +17,8 @@
  * under the License.
  */
 /*!
- * \file src/relax/vm/builtin.cc
+ * \file src/relax/backend/vm/builtin.cc
  */
-#include <tvm/relax/vm/bytecode.h>
-#include <tvm/relax/vm/memory_manager.h>
-#include <tvm/relax/vm/vm.h>
 #include <tvm/runtime/container/adt.h>
 #include <tvm/runtime/data_type.h>
 #include <tvm/runtime/device_api.h>
@@ -30,6 +27,9 @@
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/registry.h>
+#include <tvm/runtime/relax_vm/bytecode.h>
+#include <tvm/runtime/relax_vm/memory_manager.h>
+#include <tvm/runtime/relax_vm/vm.h>
 
 namespace tvm {
 namespace runtime {

--- a/src/relax/backend/vm/codegen_vm.h
+++ b/src/relax/backend/vm/codegen_vm.h
@@ -26,8 +26,8 @@
 #define TVM_RELAX_BACKEND_VM_CODEGEN_VM_H_
 
 #include <tvm/ir/module.h>
-#include <tvm/relax/vm/exec_builder.h>
-#include <tvm/relax/vm/executable.h>
+#include <tvm/relax/exec_builder.h>
+#include <tvm/runtime/relax_vm/executable.h>
 #include <tvm/target/target.h>
 
 #include <string>

--- a/src/relax/backend/vm/exec_builder.cc
+++ b/src/relax/backend/vm/exec_builder.cc
@@ -18,9 +18,9 @@
  */
 
 /*!
- * \file src/relax/vm/exec_builder.cc
+ * \file src/relax/backend/vm/exec_builder.cc
  */
-#include <tvm/relax/vm/exec_builder.h>
+#include <tvm/relax/exec_builder.h>
 
 #include <sstream>
 

--- a/src/runtime/relax_vm/bytecode.cc
+++ b/src/runtime/relax_vm/bytecode.cc
@@ -18,12 +18,12 @@
  */
 
 /*!
- * \file src/relax/vm/bytecode.cc
+ * \file src/runtime/relax_vm/bytecode.cc
  * \brief The bytecode for Relax virtual machine.
  */
 
-#include <tvm/relax/vm/bytecode.h>
 #include <tvm/runtime/logging.h>
+#include <tvm/runtime/relax_vm/bytecode.h>
 
 #include <functional>
 #include <sstream>

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -18,19 +18,18 @@
  */
 
 /*!
- * \file src/relax/vm/executable.cc
- * \brief
+ * \file src/runtime/relax_vm/executable.cc
  */
 
 #include <dmlc/memory_io.h>
-#include <tvm/relax/vm/executable.h>
-#include <tvm/relax/vm/vm.h>
 #include <tvm/runtime/logging.h>
+#include <tvm/runtime/relax_vm/executable.h>
+#include <tvm/runtime/relax_vm/vm.h>
 
 #include <functional>
 #include <sstream>
 
-#include "../../runtime/file_utils.h"
+#include "../file_utils.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/relax_vm/memory_manager.cc
+++ b/src/runtime/relax_vm/memory_manager.cc
@@ -18,10 +18,10 @@
  */
 
 /*!
- * \file tvm/relax/vm/memory_manager.cc
+ * \file tvm/runtime/relax_vm/memory_manager.cc
  * \brief Allocate and manage memory for the Relay VM.
  */
-#include <tvm/relax/vm/memory_manager.h>
+#include <tvm/runtime/relax_vm/memory_manager.h>
 
 #include <memory>
 #include <utility>

--- a/src/runtime/relax_vm/naive_allocator.h
+++ b/src/runtime/relax_vm/naive_allocator.h
@@ -18,13 +18,13 @@
  */
 
 /*!
- * \file tvm/relax/vm/naive_allocator.h
+ * \file tvm/runtime/relax_vm/naive_allocator.h
  */
-#ifndef TVM_RELAX_VM_NAIVE_ALLOCATOR_H_
-#define TVM_RELAX_VM_NAIVE_ALLOCATOR_H_
+#ifndef TVM_RUNTIME_RELAX_VM_NAIVE_ALLOCATOR_H_
+#define TVM_RUNTIME_RELAX_VM_NAIVE_ALLOCATOR_H_
 
-#include <tvm/relax/vm/memory_manager.h>
 #include <tvm/runtime/device_api.h>
+#include <tvm/runtime/relax_vm/memory_manager.h>
 
 #include <atomic>
 
@@ -62,4 +62,4 @@ class NaiveAllocator final : public Allocator {
 }  // namespace runtime
 }  // namespace tvm
 
-#endif  // TVM_RELAX_VM_NAIVE_ALLOCATOR_H_
+#endif  // TVM_RUNTIME_RELAX_VM_NAIVE_ALLOCATOR_H_

--- a/src/runtime/relax_vm/pooled_allocator.h
+++ b/src/runtime/relax_vm/pooled_allocator.h
@@ -18,13 +18,13 @@
  */
 
 /*!
- * \file tvm/relax/vm/pooled_allocator.h
+ * \file tvm/runtime/relax_vm/pooled_allocator.h
  */
-#ifndef TVM_RELAX_VM_POOLED_ALLOCATOR_H_
-#define TVM_RELAX_VM_POOLED_ALLOCATOR_H_
+#ifndef TVM_RUNTIME_RELAX_VM_POOLED_ALLOCATOR_H_
+#define TVM_RUNTIME_RELAX_VM_POOLED_ALLOCATOR_H_
 
-#include <tvm/relax/vm/memory_manager.h>
 #include <tvm/runtime/device_api.h>
+#include <tvm/runtime/relax_vm/memory_manager.h>
 
 #include <atomic>
 #include <mutex>
@@ -108,4 +108,4 @@ class PooledAllocator final : public Allocator {
 }  // namespace runtime
 }  // namespace tvm
 
-#endif  // TVM_RELAX_VM_POOLED_ALLOCATOR_H_
+#endif  // TVM_RUNTIME_RELAX_VM_POOLED_ALLOCATOR_H_

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -18,11 +18,10 @@
  */
 
 /*!
- * \file src/relax/vm/vm.cc
- * \brief
+ * \file src/runtime/relax_vm/vm.cc
  */
 
-#include <tvm/relax/vm/vm.h>
+#include <tvm/runtime/relax_vm/vm.h>
 
 namespace tvm {
 namespace runtime {


### PR DESCRIPTION
This is a refactor PR. It moves some necessary files from `include/tvm/relax/vm/` to `include/tvm/runtime/relax_vm/`, and from `src/relax/vm/` to `src/runtime/relax_vm/`.

In order to run our VM remotely through the RPC mechanism provided by TVM and thereby enabling end-to-end auto-tuning with Meta-Schedule on different backends, we need to make the VM and the Executable part of the TVM runtime. To this end, we have two possible ways:
* moving VM files to `include/tvm/runtime/` and `src/runtime/`, 
* hacking `CMakeLists.txt` to include `src/relax/vm/` as part of runtime sources and exclude the directory from compiler sources.

Per discussion with @tqchen and @YuchenJin, we agreed to move these files now. The refactor doesn't make the Relax VM runtime conflict with Relay VM runtime. Besides, the refactor doesn't seem to impact our future upstreaming. Thus I crafted this PR.

Welcome to review and leave any comment! Would love to hear opinions from the team :-)

cc @YuchenJin @tqchen @yongwww @ZihengJiang @sunggg 