### PR TITLE
[VM] Initialize VM devices through a packed function

### DIFF
--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -126,7 +126,7 @@ class VirtualMachine(object):
             init_args.append(device.device_id)
             alloc_type = memory_cfg[device] if device in memory_cfg else default_alloc_type
             init_args.append(alloc_type)
-        _ffi_api.VirtualMachineInit(self.module, *init_args)
+        self.module["vm_initialization"](*init_args)
 
     def __getitem__(self, key: str) -> PackedFunc:
         return self.module[key]


### PR DESCRIPTION
This PR changes the way we initialize Relax virtual machine.

Prior to this PR, we invoke an FFI function to initialize the devices of the VM: https://github.com/tlc-pack/relax/blob/4a05295361303d7ed9ecc545489591032afa3338/src/runtime/relax_vm/vm.cc#L226-L242

This way perfectly works locally. However, once we want to run the module on the remote, the cast on line 229 fails, since `mod` is an instance of RPCModule then, instead of an instance of VirtualMachine. https://github.com/tlc-pack/relax/blob/4a05295361303d7ed9ecc545489591032afa3338/src/runtime/relax_vm/vm.cc#L229

Therefore, we should use a packed function populated by VirtualMachine to do the initialization job, as introduced in this PR.

(BTW I’m now asking Haichen for the reason of setting up devices outside the construction of VM. And I might do some followup refactor if needed.)

cc @ZihengJiang @YuchenJin @yongwww 