### PR TITLE
[VM] Fix hardcoded device type in memory lowering

### DIFF
--- a/include/tvm/relax/attrs/memory.h
+++ b/include/tvm/relax/attrs/memory.h
@@ -34,9 +34,11 @@ namespace relax {
  */
 struct AllocTensorAttrs : public tvm::AttrsNode<AllocTensorAttrs> {
   DataType dtype;
+  bool is_device;
 
   TVM_DECLARE_ATTRS(AllocTensorAttrs, "relax.attrs.AllocTensorAttrs") {
     TVM_ATTR_FIELD(dtype).describe("The datatype of the tensor to be allocated.");
+    TVM_ATTR_FIELD(is_device).describe("Whether the tensor to be allocated is on device or host.");
   }
 };
 
@@ -44,14 +46,14 @@ struct AllocTensorAttrs : public tvm::AttrsNode<AllocTensorAttrs> {
  * \brief Attributes for allocating storage on Relax VM.
  */
 struct VMAllocStorageAttrs : public tvm::AttrsNode<VMAllocStorageAttrs> {
-  int device_type;
   DataType dtype;
+  bool is_device;
 
   TVM_DECLARE_ATTRS(VMAllocStorageAttrs, "relax.attrs.VMAllocStorageAttrs") {
-    TVM_ATTR_FIELD(device_type).describe("The device type on which to allocate memory.");
     TVM_ATTR_FIELD(dtype)
         .describe("The dtype of the tensor to allocate.")
         .set_default(DataType::Float(32, 1));
+    TVM_ATTR_FIELD(is_device).describe("Whether the tensor to be allocated is on device or host.");
   }
 };
 

--- a/include/tvm/relax/attrs/memory.h
+++ b/include/tvm/relax/attrs/memory.h
@@ -34,11 +34,15 @@ namespace relax {
  */
 struct AllocTensorAttrs : public tvm::AttrsNode<AllocTensorAttrs> {
   DataType dtype;
-  bool is_device;
+  int64_t runtime_device_index;
 
   TVM_DECLARE_ATTRS(AllocTensorAttrs, "relax.attrs.AllocTensorAttrs") {
     TVM_ATTR_FIELD(dtype).describe("The datatype of the tensor to be allocated.");
-    TVM_ATTR_FIELD(is_device).describe("Whether the tensor to be allocated is on device or host.");
+    TVM_ATTR_FIELD(runtime_device_index)
+        .describe(
+            "The device index indicating on which device the tensor is to be allocated at runtime. "
+            "Index -1 is reserved for the host device.")
+        .set_default(-1);
   }
 };
 
@@ -47,13 +51,17 @@ struct AllocTensorAttrs : public tvm::AttrsNode<AllocTensorAttrs> {
  */
 struct VMAllocStorageAttrs : public tvm::AttrsNode<VMAllocStorageAttrs> {
   DataType dtype;
-  bool is_device;
+  int64_t runtime_device_index;
 
   TVM_DECLARE_ATTRS(VMAllocStorageAttrs, "relax.attrs.VMAllocStorageAttrs") {
     TVM_ATTR_FIELD(dtype)
         .describe("The dtype of the tensor to allocate.")
         .set_default(DataType::Float(32, 1));
-    TVM_ATTR_FIELD(is_device).describe("Whether the tensor to be allocated is on device or host.");
+    TVM_ATTR_FIELD(runtime_device_index)
+        .describe(
+            "The device index indicating on which device the tensor is to be allocated at runtime. "
+            "Index -1 is reserved for the host device.")
+        .set_default(-1);
   }
 };
 

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -75,6 +75,10 @@ struct VMState {
   std::vector<Allocator*> allocators;
   /*! \brief The kernel library. */
   Optional<runtime::Module> lib;
+  /*! \brief The devices. */
+  std::vector<Device> devices;
+  /*! \brief Phsical device type. */
+  int device_type = kDLCPU;
 };
 
 /*!
@@ -193,8 +197,6 @@ class VirtualMachine : public runtime::ModuleNode {
   Index pc_{0};
   /*! \brief The special return register. */
   RegType return_value_;
-  /*! \brief The devices. */
-  std::vector<Device> devices_;
 };
 
 }  // namespace relax_vm

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -75,8 +75,6 @@ struct VMState {
   std::vector<Allocator*> allocators;
   /*! \brief The kernel library. */
   Optional<runtime::Module> lib;
-  /*! \brief The devices. */
-  std::vector<Device> devices;
   /*! \brief Phsical device type. */
   int device_type = -1;
 };
@@ -197,6 +195,8 @@ class VirtualMachine : public runtime::ModuleNode {
   Index pc_{0};
   /*! \brief The special return register. */
   RegType return_value_;
+  /*! \brief The devices. */
+  std::vector<Device> devices_;
 };
 
 }  // namespace relax_vm

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -75,8 +75,8 @@ struct VMState {
   std::vector<Allocator*> allocators;
   /*! \brief The kernel library. */
   Optional<runtime::Module> lib;
-  /*! \brief Phsical device type. */
-  int device_type = -1;
+  /*! \brief Runtime physical device list. */
+  std::vector<Device> devices;
 };
 
 /*!
@@ -195,8 +195,6 @@ class VirtualMachine : public runtime::ModuleNode {
   Index pc_{0};
   /*! \brief The special return register. */
   RegType return_value_;
-  /*! \brief The devices. */
-  std::vector<Device> devices_;
 };
 
 }  // namespace relax_vm

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -78,7 +78,7 @@ struct VMState {
   /*! \brief The devices. */
   std::vector<Device> devices;
   /*! \brief Phsical device type. */
-  int device_type = kDLCPU;
+  int device_type = -1;
 };
 
 /*!

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -103,8 +103,13 @@ class VirtualMachine(object):
                 )
             devs = [dev]
 
+        if any(dev.device_type % RPC_SESS_MASK == tvm.cpu().device_type for dev in devs[:-1]):
+            raise RuntimeError(
+                "CPU host is required to be the last element of the device list if provided."
+            )
+
         # CPU is required for executing shape functions
-        if not any(c.device_type % RPC_SESS_MASK == tvm.cpu().device_type for c in devs):
+        if devs[-1].device_type % RPC_SESS_MASK != tvm.cpu().device_type:
             devs.append(tvm.cpu())
 
         default_alloc_type = VirtualMachine.POOLED_ALLOCATOR

--- a/src/relax/backend/vm/builtin.cc
+++ b/src/relax/backend/vm/builtin.cc
@@ -67,24 +67,26 @@ TVM_REGISTER_GLOBAL("vm.builtin.load_shape").set_body_typed([](NDArray heap, Sha
 });
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
-    .set_body_typed([](void* vm_state_ptr, ShapeTuple buffer_size, Index is_device,
+    .set_body_typed([](void* vm_state_ptr, ShapeTuple buffer_size, Index device_index,
                        DLDataType dtype_hint) {
-      int alignment = runtime::kAllocAlignment;
       ICHECK_EQ(buffer_size.size(), 1);
+      int alignment = runtime::kAllocAlignment;
       VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
+      ICHECK_LT(device_index, vm_state->devices.size())
+          << "The device index is out of VM physical devices list";
+
+      if (device_index == -1) {
+        // Allocate on host. Host is always the last element of vm_state->devices.
+        device_index = vm_state->devices.size() - 1;
+      }
+
       int64_t size_imm = buffer_size[0];
       DLOG(INFO) << "AllocStorage: allocation_size=" << size_imm << ", alignment=" << alignment
                  << ", dtype_hint=" << runtime::DLDataType2String(dtype_hint)
-                 << ", is_device=" << is_device;
+                 << ", device_index=" << device_index;
 
       auto storage_obj = runtime::SimpleObjAllocator().make_object<StorageObj>();
-      int device_type;
-      if (is_device) {
-        device_type = vm_state->device_type;
-      } else {
-        device_type = kDLCPU;
-      }
-      auto* alloc = vm_state->allocators[device_type];
+      auto* alloc = vm_state->allocators[device_index];
       ICHECK(alloc) << "Did you forget to init the VirtualMachine with devices?";
       storage_obj->buffer = alloc->Alloc(size_imm, alignment, dtype_hint);
       Storage storage(storage_obj);

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -234,8 +234,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     // Handle attrs of the call
     auto alloc_attrs = call_node->attrs.as<VMAllocStorageAttrs>();
     ICHECK(alloc_attrs != nullptr) << "must be VMAllocStorageAttrs";
-    int device_type = alloc_attrs->device_type;
-    args.push_back(Instruction::Arg(Instruction::kImmediate, device_type));
+    bool is_device = alloc_attrs->is_device;
+    args.push_back(Instruction::Arg(Instruction::kImmediate, is_device));
     DataType dtype = alloc_attrs->dtype;
     TVMRetValue data_type;
     data_type = dtype;

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -234,8 +234,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     // Handle attrs of the call
     auto alloc_attrs = call_node->attrs.as<VMAllocStorageAttrs>();
     ICHECK(alloc_attrs != nullptr) << "must be VMAllocStorageAttrs";
-    bool is_device = alloc_attrs->is_device;
-    args.push_back(Instruction::Arg(Instruction::kImmediate, is_device));
+    Index runtime_device_index = alloc_attrs->runtime_device_index;
+    args.push_back(Instruction::Arg(Instruction::kImmediate, runtime_device_index));
     DataType dtype = alloc_attrs->dtype;
     TVMRetValue data_type;
     data_type = dtype;

--- a/src/relax/backend/vm/vm_memory_lower.cc
+++ b/src/relax/backend/vm/vm_memory_lower.cc
@@ -35,7 +35,7 @@ namespace relax {
 // MemLowerMutator
 // Lower the relax.builtin.alloc_tensor op to VM builtin functions.
 // Example:
-// x = relax.builtin.alloc_tensor((m, n))
+// x = relax.builtin.alloc_tensor((m, n), relax.attrs.AllocTensorAttrs)
 // -->
 // gv0 = relax.call_packed("relax.vm.builtin.alloc_storage", (m * n),
 // relax.attrs.VMAllocStorageAttrs)
@@ -84,7 +84,7 @@ class VMMemLowerMutator : public ExprMutator {
       Expr storage_size = ComputeStorageSize(output_shape, dtype);
       auto storage_attr = make_object<VMAllocStorageAttrs>();
       storage_attr->dtype = dtype;
-      storage_attr->is_device = alloc_attrs->is_device;
+      storage_attr->runtime_device_index = alloc_attrs->runtime_device_index;
 
       Var storage =
           builder_->Emit(Call(vm_alloc_storage_op, {storage_size}, Attrs(storage_attr)), "storage");

--- a/src/relax/backend/vm/vm_memory_lower.cc
+++ b/src/relax/backend/vm/vm_memory_lower.cc
@@ -84,7 +84,7 @@ class VMMemLowerMutator : public ExprMutator {
       Expr storage_size = ComputeStorageSize(output_shape, dtype);
       auto storage_attr = make_object<VMAllocStorageAttrs>();
       storage_attr->dtype = dtype;
-      storage_attr->device_type = 1;
+      storage_attr->is_device = alloc_attrs->is_device;
 
       Var storage =
           builder_->Emit(Call(vm_alloc_storage_op, {storage_size}, Attrs(storage_attr)), "storage");

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -62,6 +62,7 @@ class CallTIRMutator : public ExprMutator {
           if (call->checked_type_.defined()) {
             auto output_type = Downcast<DynTensorType>(call->checked_type_);
             alloc_tensor_attr->dtype = output_type->dtype;
+            alloc_tensor_attr->is_device = true;
             outs.push_back(builder_->Emit(
                 Call(alloc_tensor_op, {output_shape}, Attrs(alloc_tensor_attr)), "alloc"));
           } else {
@@ -89,6 +90,7 @@ class CallTIRMutator : public ExprMutator {
             auto output_type = Downcast<DynTensorType>(output_types->fields[i]);
             auto alloc_tensor_attr = make_object<AllocTensorAttrs>();
             alloc_tensor_attr->dtype = output_type->dtype;
+            alloc_tensor_attr->is_device = true;
             outs.push_back(builder_->Emit(
                 Call(alloc_tensor_op, {Downcast<ShapeExpr>(output_shapes->fields[i])},
                      Attrs(alloc_tensor_attr)),

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -62,7 +62,7 @@ class CallTIRMutator : public ExprMutator {
           if (call->checked_type_.defined()) {
             auto output_type = Downcast<DynTensorType>(call->checked_type_);
             alloc_tensor_attr->dtype = output_type->dtype;
-            alloc_tensor_attr->is_device = true;
+            alloc_tensor_attr->runtime_device_index = 0;
             outs.push_back(builder_->Emit(
                 Call(alloc_tensor_op, {output_shape}, Attrs(alloc_tensor_attr)), "alloc"));
           } else {
@@ -90,7 +90,7 @@ class CallTIRMutator : public ExprMutator {
             auto output_type = Downcast<DynTensorType>(output_types->fields[i]);
             auto alloc_tensor_attr = make_object<AllocTensorAttrs>();
             alloc_tensor_attr->dtype = output_type->dtype;
-            alloc_tensor_attr->is_device = true;
+            alloc_tensor_attr->runtime_device_index = 0;
             outs.push_back(builder_->Emit(
                 Call(alloc_tensor_op, {Downcast<ShapeExpr>(output_shapes->fields[i])},
                      Attrs(alloc_tensor_attr)),

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -88,15 +88,24 @@ RegType VirtualMachine::Invoke(Index gf_idx, const std::vector<RegType>& args) {
 
 void VirtualMachine::Init(const std::vector<Device>& devices,
                           const std::vector<AllocatorType>& alloc_types) {
+  // TODO(@yuchen): support heterogeneous execution
+  ICHECK_LT(devices.size(), 3)
+      << "Currently relax vm only supports at most 2 devices (host + device)";
   ICHECK_EQ(devices.size(), alloc_types.size());
+
+  state.devices.reserve(devices.size());
+  state.allocators.reserve(alloc_types.size());
   for (size_t i = 0; i < devices.size(); i++) {
     auto dev_type = static_cast<size_t>(devices[i].device_type);
+    if (dev_type >= state.device_type) {
+      state.device_type = dev_type;
+    }
     auto alloc = MemoryManager::GetOrCreateAllocator(devices[i], alloc_types[i]);
-    if (devices_.size() <= dev_type) {
-      devices_.resize(dev_type + 1);
+    if (state.devices.size() <= dev_type) {
+      state.devices.resize(dev_type + 1);
       state.allocators.resize(dev_type + 1);
     }
-    devices_[dev_type] = devices[i];
+    state.devices[dev_type] = devices[i];
     state.allocators[dev_type] = alloc;
   }
 }

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -96,7 +96,9 @@ void VirtualMachine::Init(const std::vector<Device>& devices,
   state.devices.reserve(devices.size());
   state.allocators.reserve(alloc_types.size());
   for (size_t i = 0; i < devices.size(); i++) {
-    auto dev_type = static_cast<size_t>(devices[i].device_type);
+    auto dev_type = static_cast<int>(devices[i].device_type);
+    // kDLCPU is the smallest among all device types, so state.device_type will be the device type
+    // (instead of host) if there is any, otherwise it will be kDLCPU
     if (dev_type >= state.device_type) {
       state.device_type = dev_type;
     }

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -93,7 +93,7 @@ void VirtualMachine::Init(const std::vector<Device>& devices,
       << "Currently relax vm only supports at most 2 devices (host + device)";
   ICHECK_EQ(devices.size(), alloc_types.size());
 
-  state.devices.reserve(devices.size());
+  devices_.reserve(devices.size());
   state.allocators.reserve(alloc_types.size());
   for (size_t i = 0; i < devices.size(); i++) {
     auto dev_type = static_cast<int>(devices[i].device_type);
@@ -103,11 +103,11 @@ void VirtualMachine::Init(const std::vector<Device>& devices,
       state.device_type = dev_type;
     }
     auto alloc = MemoryManager::GetOrCreateAllocator(devices[i], alloc_types[i]);
-    if (state.devices.size() <= dev_type) {
-      state.devices.resize(dev_type + 1);
+    if (devices_.size() <= static_cast<size_t>(dev_type)) {
+      devices_.resize(dev_type + 1);
       state.allocators.resize(dev_type + 1);
     }
-    state.devices[dev_type] = devices[i];
+    devices_[dev_type] = devices[i];
     state.allocators[dev_type] = alloc;
   }
 }

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -88,27 +88,17 @@ RegType VirtualMachine::Invoke(Index gf_idx, const std::vector<RegType>& args) {
 
 void VirtualMachine::Init(const std::vector<Device>& devices,
                           const std::vector<AllocatorType>& alloc_types) {
-  // TODO(@yuchen): support heterogeneous execution
+  // TODO(@yuchen): support multi-device heterogeneous execution
   ICHECK_LT(devices.size(), 3)
       << "Currently relax vm only supports at most 2 devices (host + device)";
   ICHECK_EQ(devices.size(), alloc_types.size());
 
-  devices_.reserve(devices.size());
+  state.devices.reserve(devices.size());
   state.allocators.reserve(alloc_types.size());
   for (size_t i = 0; i < devices.size(); i++) {
-    auto dev_type = static_cast<int>(devices[i].device_type);
-    // kDLCPU is the smallest among all device types, so state.device_type will be the device type
-    // (instead of host) if there is any, otherwise it will be kDLCPU
-    if (dev_type >= state.device_type) {
-      state.device_type = dev_type;
-    }
     auto alloc = MemoryManager::GetOrCreateAllocator(devices[i], alloc_types[i]);
-    if (devices_.size() <= static_cast<size_t>(dev_type)) {
-      devices_.resize(dev_type + 1);
-      state.allocators.resize(dev_type + 1);
-    }
-    devices_[dev_type] = devices[i];
-    state.allocators[dev_type] = alloc;
+    state.devices.push_back(devices[i]);
+    state.allocators.push_back(alloc);
   }
 }
 

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -177,7 +177,7 @@ def test_vm_memory_lower():
     class TestVMMemoryLower:
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
-            alloc = relax.builtin.alloc_tensor((m, n), is_device=False, dtype="float32")
+            alloc = relax.builtin.alloc_tensor((m, n), runtime_device_index=0, dtype="float32")
             _ = relax.call_packed("test.op.identity", (x,), alloc)
             gv0 = alloc
             return gv0

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -177,7 +177,7 @@ def test_vm_memory_lower():
     class TestVMMemoryLower:
         @R.function
         def foo(x: Tensor[(m, n), "float32"]):
-            alloc = relax.builtin.alloc_tensor((m, n), dtype="float32")
+            alloc = relax.builtin.alloc_tensor((m, n), is_device=False, dtype="float32")
             _ = relax.call_packed("test.op.identity", (x,), alloc)
             gv0 = alloc
             return gv0

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -150,7 +150,7 @@ def test_vm_constant_serialize():
     ib = relax.ExecBuilder()
     with ib.function("main", num_inputs=1):
         ib.emit_call(
-            "vm.builtin.alloc_storage", args=[ib.vm_state(), (24,), ib.imm(1), dtype], dst=ib.r(1)
+            "vm.builtin.alloc_storage", args=[ib.vm_state(), (24,), ib.imm(0), dtype], dst=ib.r(1)
         )
         ib.emit_call(
             "vm.builtin.alloc_tensor", args=[ib.r(1), ib.imm(0), shape, dtype], dst=ib.r(2)
@@ -242,7 +242,7 @@ def test_vm_storage():
     ib = relax.ExecBuilder()
     with ib.function("main", num_inputs=0):
         ib.emit_call(
-            "vm.builtin.alloc_storage", args=[ib.vm_state(), (24,), ib.imm(1), dtype], dst=ib.r(1)
+            "vm.builtin.alloc_storage", args=[ib.vm_state(), (24,), ib.imm(0), dtype], dst=ib.r(1)
         )
         ib.emit_call(
             "vm.builtin.alloc_tensor", args=[ib.r(1), ib.imm(0), shape, dtype], dst=ib.r(2)


### PR DESCRIPTION
Introduces a `runtime_device_index` field in the attribute of `AllocTensor` to decide the device id on which the tensor to be allocated during runtime. This solves our current need to run VM on one host with one device, multi-device heterogeneous need more thoughts and defer to future.

Tested on local machine by tuning a network with AutoTIR on cuda, build and run on VM, it works. I don't add new test case in this PR because our CI can only run cpu jobs for now. If we want to include gpu tests, we will need to build our own gpu docker with Python3.7 which Relax requires or wait for the tvm docker image to be updated with Python3.7.

cc @MasterJH5574 @ZihengJiang @yongwww 