### PR TITLE
[Bugfix] Fix call_tir parsing bug

### DIFF
--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -1118,7 +1118,6 @@ class RelaxTransformer(Transformer):
         else:
             attrs = self.parse_call_attr(expr, op)
 
-        # if type_args:
         return relax.Call(
             op, args, attrs=attrs, type_args=type_args, span=self.to_tvm_span(expr.span)
         )

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -452,6 +452,19 @@ def test_func_no_return_fail():
             y = add(x, x)
 
 
+def test_call_tir():
+    @R.function
+    def foo(x: Tensor[(m, n), "float32"]):
+        gv0 = relax.call_tir("test.op.identity", (x,), (m, n), dtype="float32")
+        return gv0
+
+    call_tir_node = foo.body.blocks[0].bindings[0].value
+    assert call_tir_node.attrs is None
+    assert_structural_equal(
+        call_tir_node.type_args[0], relax.DynTensorType(rank=2, dtype="float32")
+    )
+
+
 def test_inline_tir():
     @R.function
     def f(x: Tensor[(B, 128), "float32"], y: Tensor[(128, 128), "float32"]):


### PR DESCRIPTION
Fixing this bug: https://github.com/tlc-pack/relax/issues/108. The root cause is we parsed the `dtype` as both a type_args and a call attribute, but we should remove it from the call attributes.

Lesson: We should always add unit tests and make sure the unit test coverage when raising a PR.
Future work: The parser needs refactoring to register intrinsic handling callbacks and avoid the if-then-else conditions. 

cc: @jinhongyii @yongwww @psrivas2 