### PR TITLE
[BlockBuilder] introduce call_te

### DIFF
--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -275,6 +275,38 @@ def test_normalize():
     assert add_call.shape[1] == n
 
 
+def test_call_te():
+    bb = rx.BlockBuilder()
+    dtype = rx.DynTensorType(rank=2, dtype="float32")
+    n, m = tir.Var("n", "int64"), tir.Var("m", "int64")
+    x = rx.Var("x", [n, m], dtype)
+    y = rx.Var("y", [n, m], dtype)
+    z = rx.Var("z", [n, m], dtype)
+
+    def te_func(args, args_dict, msg):
+        A, B = args
+        C = args_dict["C"]
+        D = te.compute((128, 128), lambda i, j: A[i, j] + B[i, j])
+        E = te.compute((128, 128), lambda i, j: D[i, j] - C[i, j])
+        return E
+
+    with bb.function("rx_func", [x, y, z]):
+        with bb.dataflow():
+            out = bb.emit_output(bb.call_te(te_func, [x, y], {"C": z}, msg="hello"))
+        bb.emit_func_output(out)
+
+    mod = bb.get()
+    rx_func = mod["rx_func"]
+
+    assert rx_func.params[0] == x
+    assert rx_func.params[1] == y
+    assert rx_func.params[2] == z
+    assert rx_func.name.name_hint == "rx_func"
+    assert rx_func.body.body == out
+    assert len(rx_func.body.blocks) == 1
+    assert len(rx_func.body.blocks[0].bindings) == 1
+
+
 def test_emit_te():
     bb = rx.BlockBuilder()
     n, m = tir.Var("n", "int64"), tir.Var("m", "int64")


### PR DESCRIPTION
Hi all. BlockBuilder `emit_te` brings a great interface to craft IRModule and unit tests. 

Currently, `emit_te` contains two operators: `call_te`(Create a `call_tir` with TE compute) and `emit`(bind a relax Expr to a var). However, `emit_te` can not directly `emit_output` if inside a dataflow block. i.e., we can not build such a case with block builder:
```python
@relax.function
def fused_add_exp_squeeze(x: Tensor[(10, 20), "float32"]) -> Tensor[_, "float32"]:
    # block 0
    with relax.dataflow():
        lv = relax.call_tir(exp, (x,), (10, 20), dtype="float32")
        gv = relax.call_tir(squeeze, (lv,), (10, 20), dtype="float32")
        relax.output(gv)
    return gv
```
We can only build the function like 
```python
@relax.function
def fused_add_exp_squeeze(x1: Tensor[(10, 20), "float32"]) -> Tensor[_, "float32"]:
    # block 0
    with relax.dataflow():
        lv = relax.call_tir(add, (x1, 1), (10, 20), dtype="float32")
        lv1 = relax.call_tir(exp, (lv,), (10, 20), dtype="float32")
        lv2 = relax.call_tir(squeeze, (lv1,), (10, 20), dtype="float32")
        gv: Tensor[(10, 20), "float32"] = lv2    # <= We must emit_output again from a local var
        relax.output(gv)
    return gv
```

Usually, it does not bring many troubles to users but it may block us to write testing (craft the expected result and assert structural equality)

In this PR, I decouple the `emit_te` logic into two parts `call_te` and `emit`.