### PR TITLE
[FIX] Fix structure equal hash for MatchShape

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -224,13 +224,15 @@ class MatchShapeNode : public BindingNode {
   }
 
   bool SEqualReduce(const MatchShapeNode* other, SEqualReducer equal) const {
-    return equal(value, other->value) && equal(pattern, other->pattern) &&
+    // NOTE: pattern can contain ShapeExpr which defines the vars
+    return equal(value, other->value) && equal.DefEqual(pattern, other->pattern) &&
            equal.DefEqual(var, other->var);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
+    // NOTE: pattern can contain ShapeExpr which defines the vars
     hash_reduce(value);
-    hash_reduce(pattern);
+    hash_reduce.DefHash(pattern);
     hash_reduce.DefHash(var);
   }
 

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -356,6 +356,9 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
     RelaxScriptPrinter* parent_;
   };
 };
+
+String AsRelaxScript(const ObjectRef& mod, bool show_meta_data);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -1821,6 +1821,14 @@ Doc TVMScriptPrinterWithDiagnostic::PrintLoop(const For& loop) {
 }
 
 String AsTVMScript(const ObjectRef& mod, const String& tir_prefix, bool show_meta) {
+  // Temporary redirect possibly relax related printing to relax script
+  // TODO(tvm-team): make relax script printer handle all possible cases and
+  // make that as a default of TVMScript printer
+  if (mod->IsInstance<IRModuleNode>() || mod->IsInstance<relax::FunctionNode>()) {
+    // TODO(tvm-team) support tir_prefix in relax printer
+    return relax::AsRelaxScript(mod, show_meta);
+  }
+
   ICHECK(mod->IsInstance<PrimFuncNode>() || mod->IsInstance<IRModuleNode>());
   Doc doc;
   doc << TVMScriptPrinter::PrintHeader(tir_prefix)


### PR DESCRIPTION
The pattern field of the match shape can define variables,
as a result, we need to add DefEqual and Hash here.

Added a regression testcase.

Lesson: we would benefit from more testcases
with check_save_roundtrip checks(like this one) for more relax example.

Additional change:
- Redirected some printer to be able to print relax fragements useful for debugging.
