### PR TITLE
[PASS] Fold constant & Bind Params

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -119,8 +119,9 @@ class BlockBuilderNode : public Object {
    * \brief Lookup a var in the binding table \p binding_table_.
    * \param var The input var.
    * \return The Expr bound to the input \p var.
+   * \note For function parameters, this function returns NullOpt.
    */
-  Expr LookupBinding(const Var& var);
+  Optional<Expr> LookupBinding(const Var& var);
 
   /*!
    * \brief Check if two shape expressions can be proven equal at compile time.

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -275,8 +275,9 @@ class ExprMutator : public ExprFunctor<Expr(const Expr&)> {
    * \brief Look up the value bound to a variable.
    * \param var The var to be looked up.
    * \return The value bound to the input \p var.
+   * \note For function parameters, this function returns NullOpt.
    */
-  Expr LookupBinding(const Var& var);
+  Optional<Expr> LookupBinding(const Var& var);
 
   /*!
    * \brief Post-order rewrite a node and normalize.

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -87,6 +87,24 @@ TVM_DLL Pass ToANF();
 TVM_DLL Pass MetaScheduleApplyHistoryBest(const tvm::meta_schedule::Database& database,
                                           Target target);
 
+/*!
+ * \brief Bind params of function of the module to constant tensors.
+ *
+ * \param func_name The name of the function to bind parameters.
+ * \param params The parameters to bind.
+ *
+ * \return The Pass.
+ */
+TVM_DLL Pass BindParams(String name, Map<String, runtime::NDArray> params);
+
+/*!
+ * \brief Fold constant expressions.
+ *
+ * \return The Pass.
+ */
+TVM_DLL Pass FoldConstant();
+
+
 }  // namespace transform
 }  // namespace relax
 }  // namespace tvm

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -104,7 +104,6 @@ TVM_DLL Pass BindParams(String name, Map<String, runtime::NDArray> params);
  */
 TVM_DLL Pass FoldConstant();
 
-
 }  // namespace transform
 }  // namespace relax
 }  // namespace tvm

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -118,3 +118,32 @@ def MetaScheduleApplyHistoryBest(
 
     """
     return _ffi_api.MetaScheduleApplyHistoryBest(database, target)
+
+
+def BindParams(func_name, params) -> tvm.ir.transform.Pass:
+    """Bind params of main function of the module to constant tensors.
+
+    Parameters
+    ----------
+
+    func_name: str
+        The function name to be bound
+
+    params : dict from str to ndarray
+        The map from param name to constant tensors.
+
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
+    return _ffi_api.BindParams(func_name, params)
+
+
+def FoldConstant() -> tvm.ir.transform.Pass:
+    """Fold constant expressions
+
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
+    return _ffi_api.FoldConstant()

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -19,6 +19,8 @@
 import tvm.ir
 from tvm.target import Target
 from tvm.meta_schedule.database import PyDatabase
+from typing import Dict
+
 from . import _ffi_api
 
 
@@ -120,8 +122,8 @@ def MetaScheduleApplyHistoryBest(
     return _ffi_api.MetaScheduleApplyHistoryBest(database, target)
 
 
-def BindParams(func_name, params) -> tvm.ir.transform.Pass:
-    """Bind params of main function of the module to constant tensors.
+def BindParams(func_name: str, params: Dict[str, tvm.runtime.NDArray]) -> tvm.ir.transform.Pass:
+    """Bind params of function of the module to constant tensors.
 
     Parameters
     ----------

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -16,10 +16,10 @@
 # under the License.
 # pylint: disable=invalid-name
 """Relax transformation passes."""
+from typing import Dict
 import tvm.ir
 from tvm.target import Target
 from tvm.meta_schedule.database import PyDatabase
-from typing import Dict
 
 from . import _ffi_api
 

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -463,12 +463,9 @@ Var BlockBuilderNode::EmitOutput(const VarBinding& binding) {
   return binding->var;
 }
 
-Expr BlockBuilderNode::LookupBinding(const Var& var) {
+Optional<Expr> BlockBuilderNode::LookupBinding(const Var& var) {
   auto it = binding_table_.find(var->vid);
-  if (it == binding_table_.end()) {
-    this->diag_ctx_.EmitFatal(Diagnostic::Error(var->span)
-                              << "The var to be looked up is not in the binding table.");
-  }
+  if (it == binding_table_.end()) return NullOpt;
   return it->second;
 }
 

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -557,7 +557,7 @@ Expr ExprMutator::VisitWithNewScope(const Expr& expr) {
   return ret;
 }
 
-Expr ExprMutator::LookupBinding(const Var& var) { return builder_->LookupBinding(var); }
+Optional<Expr> ExprMutator::LookupBinding(const Var& var) { return builder_->LookupBinding(var); }
 
 Var ExprMutator::WithShapeAndType(Var var, Optional<ObjectRef> shape, Type type) {
   // shape/type changes if it goes from defined -> undefined or the other way, hence xor

--- a/src/relax/transform/bind_params.cc
+++ b/src/relax/transform/bind_params.cc
@@ -49,6 +49,12 @@ class ExprBinder : public ExprMutator {
   const tvm::Map<Var, Expr>& args_map_;
 };
 
+/*!
+ * \brief Bind params on expr
+ * \param expr The expr where to bind params
+ * \param args_map The map from param var to the expr it binds to
+ * \return The result expr after bind params
+ */
 Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
   if (const FunctionNode* func = expr.as<FunctionNode>()) {
     Expr new_body = ExprBinder(args_map).VisitExpr(func->body);
@@ -106,6 +112,13 @@ inline Function BindParamsByName(Function func, const Map<String, runtime::NDArr
   return ret;
 }
 
+/*!
+ * \brief Bind params to a specific function in a module
+ * \param m The module
+ * \param func_name The name of the specific function
+ * \param param The param dict
+ * \return The module after binding params.
+ */
 IRModule BindParam(IRModule m, String func_name, Map<String, runtime::NDArray> param) {
   IRModuleNode* new_module = m.CopyOnWrite();
   Map<GlobalVar, BaseFunc> functions = m->functions;

--- a/src/relax/transform/bind_params.cc
+++ b/src/relax/transform/bind_params.cc
@@ -1,0 +1,138 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+#include <tvm/relax/attrs/memory.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+#include <tvm/relax/type.h>
+#include <tvm/relay/interpreter.h>
+#include <tvm/tir/op.h>
+#include <tvm/driver/driver_api.h>
+
+#include <utility>
+
+namespace tvm {
+namespace relax {
+
+// Implement bind.
+class ExprBinder : public ExprMutator {
+ public:
+  explicit ExprBinder(const tvm::Map<Var, Expr>& args_map) : args_map_(args_map) {}
+
+  Expr VisitExpr_(const VarNode* op) final {
+    auto id = GetRef<Var>(op);
+    auto it = args_map_.find(id);
+    if (it != args_map_.end()) {
+      return (*it).second;
+    } else {
+      return ExprMutator::VisitExpr_(op);
+    }
+  }
+
+ private:
+  const tvm::Map<Var, Expr>& args_map_;
+};
+
+Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
+  if (const FunctionNode* func = expr.as<FunctionNode>()) {
+    Expr new_body = ExprBinder(args_map).VisitExpr(func->body);
+    Array<Var> new_params;
+    for (size_t i = 0; i < func->params.size(); ++i) {
+      if (!args_map.count(func->params[i])) {
+        new_params.push_back(func->params[i]);
+      }
+    }
+    if (new_body.same_as(func->body) && new_params.size() == func->params.size()) {
+      return expr;
+    }
+    auto ret = runtime::make_object<FunctionNode>(*func);
+    ret->params = new_params;
+    ret->body = new_body;
+    return std::move(Function(ret));
+  } else {
+    return ExprBinder(args_map).VisitExpr(expr);
+  }
+}
+
+/*!
+ * \brief Bind params to function by using name
+ * \param func Relax function
+ * \param params params dict
+ * \return Function
+ */
+inline Function BindParamsByName(Function func,
+                                 const Map<String, runtime::NDArray>& params) {
+  std::unordered_map<std::string, Var> name_dict;
+  std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> repeat_var;
+  for (auto arg : func->params) {
+    const auto& name = arg->name_hint();
+    if (name_dict.count(name)) {
+      repeat_var.insert(name_dict[name]);
+    } else {
+      name_dict[name] = arg;
+    }
+  }
+
+  std::unordered_map<Var, Expr, ObjectPtrHash, ObjectPtrEqual> bind_dict;
+  for (auto& kv : params) {
+    if (name_dict.count(kv.first) == 0) {
+      continue;
+    }
+    auto arg = name_dict.at(kv.first);
+    if (repeat_var.count(arg)) {
+      LOG(FATAL) << "Multiple args in the function have name " << kv.first;
+    }
+    bind_dict[arg] = Constant(kv.second);
+  }
+  Expr bound_expr = Bind(func, bind_dict);
+  Function ret = Downcast<Function>(bound_expr);
+  ICHECK(ret.defined()) << "The returning type is expected to be a Relax Function."
+                        << "\n";
+  return ret;
+}
+
+IRModule BindParam(IRModule m, String func_name, Map<String, runtime::NDArray> param) {
+  IRModuleNode* new_module = m.CopyOnWrite();
+  Map<GlobalVar, BaseFunc> functions = m->functions;
+  for (const auto& func_pr : functions) {
+    if (const auto* relax_f = func_pr.second.as<FunctionNode>()) {
+      if (relax_f->name.value()->name_hint == func_name) {
+        Function f_after_bind = BindParamsByName(GetRef<Function>(relax_f),
+                                                 param);
+        new_module->Update(func_pr.first, f_after_bind);
+      }
+    }
+  }
+  return GetRef<IRModule>(new_module);
+}
+
+namespace transform {
+
+Pass BindParams(String func_name, Map<String, runtime::NDArray> params) {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =
+      [=](IRModule mod, PassContext pc) { return BindParam(std::move(mod), func_name, params); };
+  return CreateModulePass(pass_func, 0, "BindParams", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.BindParams").set_body_typed(BindParams);
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/transform/bind_params.cc
+++ b/src/relax/transform/bind_params.cc
@@ -30,7 +30,7 @@
 namespace tvm {
 namespace relax {
 
-// Implement bind.
+/*! \brief Helper to implement bind params.*/
 class ExprBinder : public ExprMutator {
  public:
   explicit ExprBinder(const tvm::Map<Var, Expr>& args_map) : args_map_(args_map) {}
@@ -64,7 +64,7 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
     auto ret = runtime::make_object<FunctionNode>(*func);
     ret->params = new_params;
     ret->body = new_body;
-    return std::move(Function(ret));
+    return Function(ret);
   } else {
     return ExprBinder(args_map).VisitExpr(expr);
   }
@@ -95,7 +95,7 @@ inline Function BindParamsByName(Function func, const Map<String, runtime::NDArr
     }
     auto arg = name_dict.at(kv.first);
     if (repeat_var.count(arg)) {
-      LOG(FATAL) << "Multiple args in the function have name " << kv.first;
+      LOG(FATAL) << "ValueError: Multiple args in the function have name " << kv.first;
     }
     bind_dict[arg] = Constant(kv.second);
   }

--- a/src/relax/transform/bind_params.cc
+++ b/src/relax/transform/bind_params.cc
@@ -1,29 +1,29 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
+#include <tvm/driver/driver_api.h>
 #include <tvm/relax/attrs/memory.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/transform.h>
 #include <tvm/relax/type.h>
 #include <tvm/relay/interpreter.h>
 #include <tvm/tir/op.h>
-#include <tvm/driver/driver_api.h>
 
 #include <utility>
 
@@ -76,8 +76,7 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
  * \param params params dict
  * \return Function
  */
-inline Function BindParamsByName(Function func,
-                                 const Map<String, runtime::NDArray>& params) {
+inline Function BindParamsByName(Function func, const Map<String, runtime::NDArray>& params) {
   std::unordered_map<std::string, Var> name_dict;
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> repeat_var;
   for (auto arg : func->params) {
@@ -113,8 +112,7 @@ IRModule BindParam(IRModule m, String func_name, Map<String, runtime::NDArray> p
   for (const auto& func_pr : functions) {
     if (const auto* relax_f = func_pr.second.as<FunctionNode>()) {
       if (relax_f->name.value()->name_hint == func_name) {
-        Function f_after_bind = BindParamsByName(GetRef<Function>(relax_f),
-                                                 param);
+        Function f_after_bind = BindParamsByName(GetRef<Function>(relax_f), param);
         new_module->Update(func_pr.first, f_after_bind);
       }
     }

--- a/src/relax/transform/fma_rewrite.cc
+++ b/src/relax/transform/fma_rewrite.cc
@@ -54,7 +54,7 @@ class EwiseFMARewriter : public ExprMutator {
     if (call->op == add_op) {
       // NOTE: assumes df block is completely SSA
       // FIXME(@altanh, @yuchen): this will crash if args[0] isn't a Var
-      Expr value = LookupBinding(Downcast<Var>(call->args[0]));
+      Optional<Expr> value = LookupBinding(Downcast<Var>(call->args[0]));
       const CallNode* mul = value.as<CallNode>();
       if (mul && mul->op == multiply_op) {
         Call fma_call = Call(ewise_fma_op, {mul->args[0], mul->args[1], call->args[1]}, {}, {});

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -96,6 +96,10 @@ class ConstantFolder : public ExprMutator {
     Optional<PackedFunc> build_func = NullOpt;
 
     try {
+      // Not all the primfunc can be directly built via llvm, for example, if a function is
+      // already scheduled to only work on GPU, we will need to skip this in the const folder for
+      // now
+      // TODO(Hongyi): further check and narrow the scope of foldable function
       runtime::Module rt_module =
           build(LowerPrimFunc(func, "tir_function"), eval_cpu_target, eval_cpu_target);
       build_func = rt_module.GetFunction("tir_function");

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -31,7 +31,7 @@ namespace relax {
 
 class ConstantFolder : public ExprMutator {
  public:
-  ConstantFolder(IRModule ctx_module) : ctx_module_(ctx_module) {}
+  explicit ConstantFolder(IRModule ctx_module) : ctx_module_(ctx_module) {}
 
  private:
   /*!

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -41,7 +41,7 @@ class ConstantFolder : public ExprMutator {
   static Optional<runtime::ShapeTuple> MatchConstShape(const Expr& expr) {
     auto* shape = expr.as<ShapeExprNode>();
     if (!shape) return NullOpt;
-    
+
     std::vector<int64_t> shape_values;
     for (const auto v : shape->values) {
       auto* ptr = v.as<IntImmNode>();

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <tvm/driver/driver_api.h>
+#include <tvm/ir/function.h>
+#include <tvm/relax/attrs/memory.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+#include <tvm/relax/type.h>
+#include <tvm/tir/function.h>
+#include <tvm/tir/op.h>
+
+namespace tvm {
+namespace relax {
+
+class ConstantFolder : public ExprMutator {
+ public:
+  ConstantFolder(IRModule ctx_module) : ctx_module_(ctx_module) {}
+
+ private:
+  /*!
+   * \brief Pattern match expr to a constant shape and get runtime shape tuple from it.
+   * \return The runtime shape tuple, or nullopt if it is not a constant shape.
+   */
+  static Optional<runtime::ShapeTuple> MatchConstShape(const Expr& expr) {
+    if (auto* shape = expr.as<ShapeExprNode>()) {
+      std::vector<int64_t> shape_values;
+      for (const auto v : shape->values) {
+        if (auto* ptr = v.as<IntImmNode>()) {
+          shape_values.push_back(ptr->value);
+        } else {
+          return NullOpt;
+        }
+      }
+      return runtime::ShapeTuple(shape_values.begin(), shape_values.end());
+    } else {
+      return NullOpt;
+    }
+  }
+
+  /*!
+   * \brief Pattern match op to constant array arguments.
+   * \return The constant array arguments, or nullopt if match fails.o
+   */
+  static Optional<Array<runtime::NDArray>> MatchConstArrayArgs(const Array<Expr>& args) {
+    Array<runtime::NDArray> res;
+    for (auto arg : args) {
+      if (auto* ptr = arg.as<relay::ConstantNode>()) {
+        res.push_back(ptr->data);
+      } else {
+        return NullOpt;
+      }
+    }
+    return res;
+  }
+
+  /*!
+   * \brief Pattern match op to a TIR function and look it up.
+   * \return The TIR function, or nullopt if patter match fails.
+   */
+  Optional<tir::PrimFunc> MatchPrimFunc(const Expr& op) {
+    if (auto* ptr = op.as<GlobalVarNode>()) {
+      // NOTE: as check works for nullptr(returns null)
+      Optional<BaseFunc> base_func = ctx_module_->functions.Get(GetRef<GlobalVar>(ptr));
+      if (auto* pfunc = base_func.as<tir::PrimFuncNode>()) {
+        return GetRef<tir::PrimFunc>(pfunc);
+      }
+    }
+    return NullOpt;
+  }
+
+  /*!
+   * \brief Get a cached build version of func
+   * \return The cached func, nullopt if func cannot be built.
+   */
+  Optional<PackedFunc> GetCachedBuild(tir::PrimFunc func) {
+    // TODO(tvm-team): consider another way of bulk extract and build PrimFunc once
+    // would be helpful for future cases where PrimFunc recursively call into each other
+    Target eval_cpu_target{"llvm"};
+
+    auto it = func_build_cache_.find(func);
+    if (it != func_build_cache_.end()) {
+      return it->second;
+    }
+    Optional<PackedFunc> build_func = NullOpt;
+
+    try {
+      runtime::Module rt_module =
+          build(LowerPrimFunc(func, "tir_function"), eval_cpu_target, eval_cpu_target);
+      build_func = rt_module.GetFunction("tir_function");
+    } catch (const tvm::Error& err) {
+      // build failure may happen in which case we skip
+      DLOG(WARNING) << "Build failure for function " << func;
+    }
+    func_build_cache_[func] = build_func;
+    return build_func;
+  }
+
+  // Try constant evaluate the function call
+  // if failed return NullOpt
+  Optional<Expr> ConstEvaluateCallTIR(tir::PrimFunc tir_func, Array<runtime::NDArray> arr_args,
+                                      runtime::ShapeTuple shape) {
+    // obtain function from the cache.
+    Optional<PackedFunc> func = GetCachedBuild(tir_func);
+    if (!func) return NullOpt;
+
+    std::vector<TVMValue> values(arr_args.size() + 1);
+    std::vector<int> type_codes(arr_args.size() + 1);
+
+    DLDevice cpu_dev = {DLDeviceType::kDLCPU, 0};
+    runtime::NDArray ret_tensor = runtime::NDArray::Empty(shape, DataType::Float(32), cpu_dev);
+
+    // avoid set rvalue ref which get de-allocated later, store args in a vector
+    // where temp_args[i] are lvalue ref that is stable
+    std::vector<runtime::NDArray> temp_args(arr_args.begin(), arr_args.end());
+
+    size_t arg_offset = 0;
+    for (; arg_offset < arr_args.size(); ++arg_offset) {
+      runtime::TVMArgsSetter(values.data(), type_codes.data())(arg_offset, temp_args[arg_offset]);
+    }
+    // set return value
+    runtime::TVMArgsSetter(values.data(), type_codes.data())(arg_offset++, ret_tensor);
+
+    TVMRetValue ret;
+    // invoke
+    func.value().CallPacked(TVMArgs(values.data(), type_codes.data(), values.size()), &ret);
+    return Constant(ret_tensor);
+  }
+
+  Expr VisitCallTIR(Call call) {
+    // call_tir needs to have at least three arguments
+    ICHECK_GE(call->args.size(), 3);
+    Optional<tir::PrimFunc> func = MatchPrimFunc(call->args[0]);
+    ICHECK(call->args[1].as<TupleNode>()) << "call_tir.args[1] requires to be Tuple";
+    Optional<Array<runtime::NDArray>> arr_args =
+        MatchConstArrayArgs(call->args[1].as<TupleNode>()->fields);
+    Optional<runtime::ShapeTuple> shape = MatchConstShape(call->args[2]);
+
+    // Pattern 0: call constant function, const argument with const shape.
+    if (func && arr_args && shape) {
+      // value_or will return value if it is not null, otherwise return or
+      return ConstEvaluateCallTIR(func.value(), arr_args.value(), shape.value()).value_or(call);
+    }
+    // TODO(hongyi): support const-fold tuple outputs
+    return std::move(call);
+  }
+
+  Expr VisitExpr_(const CallNode* call) override {
+    // post-order mutation
+    Call post_call = Downcast<Call>(VisitExprPostOrder_(call));
+    static const Op& call_tir_op = Op::Get("relax.call_tir");
+
+    if (call->op.same_as(call_tir_op)) {
+      return VisitCallTIR(post_call);
+    } else {
+      return std::move(post_call);
+    }
+  }
+
+  Expr VisitExpr_(const DataflowVarNode* op) final {
+    Optional<Expr> opt = LookupBinding(GetRef<Var>(op));
+    // NOTE: opt can be nullptr, in which case opt is nullptr
+    // as check checks if opt is not null and is instance of constant
+    if (opt.as<relay::ConstantNode>()) {
+      return opt.value();
+    } else {
+      return ExprMutator::VisitExpr_(op);
+    }
+  }
+
+  Expr VisitExpr_(const VarNode* op) final {
+    Optional<Expr> opt = LookupBinding(GetRef<Var>(op));
+    // NOTE: opt can be nullptr, in which case opt is nullptr
+    // as check checks if opt is not null and is instance of constant
+    if (opt.as<relay::ConstantNode>()) {
+      return opt.value();
+    } else {
+      return ExprMutator::VisitExpr_(op);
+    }
+  }
+
+  // the context module to lookup functions
+  IRModule ctx_module_;
+  // cache for function build, via structural equality
+  std::unordered_map<tir::PrimFunc, Optional<runtime::PackedFunc>, StructuralHash, StructuralEqual>
+      func_build_cache_;
+};
+
+namespace transform {
+
+Pass FoldConstant() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
+      [=](Function f, IRModule m, PassContext pc) {
+        ConstantFolder folder(m);
+        return Downcast<Function>(folder(f));
+      };
+  return CreateFunctionPass(pass_func, 0, "FoldConstant", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.FoldConstant").set_body_typed(FoldConstant);
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/tests/python/relax/test_transform_bind_params.py
+++ b/tests/python/relax/test_transform_bind_params.py
@@ -1,0 +1,52 @@
+from __future__ import annotations  # must import to defer parsing of annotations
+import pytest
+import tvm
+import tvm.testing
+from tvm import relax, relay
+from tvm.ir.base import assert_structural_equal
+import numpy as np
+
+import tvm.script
+from tvm.script import tir as T, relax as R
+
+def test_bind_params():
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
+            T.func_attr({"global_symbol": "tir_matmul"})
+            A = T.match_buffer(x, (16, 16))
+            B = T.match_buffer(y, (16, 16))
+            C = T.match_buffer(z, (16, 16))
+            for i0, j, k0, i1, k1 in T.grid(4, 16, 4, 4, 4):
+                with T.block("matmul"):
+                    vi = T.axis.S(16, i0*4+i1)
+                    vj = T.axis.S(16, j)
+                    vk = T.axis.R(16, k0*4+k1)
+                    with T.init():
+                        C[vi, vj] = T.float32(0)
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+
+        @R.function
+        def main(x: Tensor[(16, 16), "float32"], w: Tensor[(16, 16), "float32"]) -> Tensor[(16, 16), "float32"]:
+            gv0 = R.call_tir(tir_matmul, (x, w), (16, 16), dtype="float32")
+            return gv0
+
+    w_tvm = tvm.nd.array(np.random.rand(16, 16).astype(np.float32))
+    x_tvm = tvm.nd.array(np.random.rand(16, 16).astype(np.float32))
+    mod = relax.transform.BindParams({"x": x_tvm})(InputModule)
+    assert len(mod["main"].params)==1
+
+    target = tvm.target.Target("llvm", host="llvm")
+    ex_after = relax.vm.build(mod, target)
+    vm_after = relax.VirtualMachine(ex_after, tvm.cpu())
+    res_after = vm_after["main"](w_tvm)
+
+    ex_before = relax.vm.build(InputModule, target)
+    vm_before = relax.VirtualMachine(ex_before, tvm.cpu())
+    res_before = vm_before["main"](x_tvm, w_tvm)
+
+    tvm.testing.assert_allclose(res_before.numpy(), res_after.numpy())
+
+if __name__ == "__main__":
+    test_bind_params()

--- a/tests/python/relax/test_transform_bind_params.py
+++ b/tests/python/relax/test_transform_bind_params.py
@@ -1,9 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 from __future__ import annotations  # must import to defer parsing of annotations
-import pytest
 import tvm
 import tvm.testing
 from tvm import relax, relay
-from tvm.ir.base import assert_structural_equal
 import numpy as np
 
 import tvm.script

--- a/tests/python/relax/test_transform_bind_params.py
+++ b/tests/python/relax/test_transform_bind_params.py
@@ -18,7 +18,7 @@
 from __future__ import annotations  # must import to defer parsing of annotations
 import tvm
 import tvm.testing
-from tvm import relax, relay
+from tvm import relax
 import numpy as np
 
 import tvm.script
@@ -68,4 +68,4 @@ def test_bind_params():
 
 
 if __name__ == "__main__":
-    test_bind_params()
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -79,11 +79,11 @@ def test_one_fold_addone():
 
     c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
     c1_np = c0_np + 1
-    input_module = gen_mod(Module, "before", {"c0": c0_np})
-    expected_module = gen_mod(Module, "after", {"c1": c1_np})
+    before = gen_mod(Module, "before", {"c0": c0_np})
+    expected = gen_mod(Module, "expected", {"c1": c1_np})
 
-    output_module = relax.transform.FoldConstant()(input_module)
-    tvm.ir.assert_structural_equal(output_module, expected_module)
+    after = relax.transform.FoldConstant()(before)
+    tvm.ir.assert_structural_equal(after, expected)
 
 
 def test_one_fold_transpose():
@@ -109,11 +109,11 @@ def test_one_fold_transpose():
 
     c0_np = np.arange(2 * 3).astype("float32").reshape(2, 3)
     c1_np = c0_np.T
-    input_module = gen_mod(Module, "before", {"c0": c0_np})
-    expected_module = gen_mod(Module, "after", {"c1": c1_np})
+    before = gen_mod(Module, "before", {"c0": c0_np})
+    expected = gen_mod(Module, "expected", {"c1": c1_np})
 
-    output_module = relax.transform.FoldConstant()(input_module)
-    tvm.ir.assert_structural_equal(output_module, expected_module)
+    after = relax.transform.FoldConstant()(before)
+    tvm.ir.assert_structural_equal(after, expected)
 
 
 def test_two_hop_addone():
@@ -141,11 +141,11 @@ def test_two_hop_addone():
     c0_np = np.arange((2 * 2)).astype("float32").reshape(2, 2)
     c1_np = c0_np + 1
     c2_np = c1_np + 1
-    input_module = gen_mod(Module, "before", {"c0": c0_np})
-    expected_module = gen_mod(Module, "after", {"c1": c1_np, "c2": c2_np})
+    before = gen_mod(Module, "before", {"c0": c0_np})
+    expected = gen_mod(Module, "expected", {"c1": c1_np, "c2": c2_np})
 
-    output_module = relax.transform.FoldConstant()(input_module)
-    tvm.ir.assert_structural_equal(output_module, expected_module)
+    after = relax.transform.FoldConstant()(before)
+    tvm.ir.assert_structural_equal(after, expected)
 
 
 def test_dataflow_fold():
@@ -174,10 +174,10 @@ def test_dataflow_fold():
 
     c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
     c1_np = c0_np
-    input_module = gen_mod(Module, "before", {"c0": c0_np})
-    expected_module = gen_mod(Module, "after", {"c1": c1_np})
-    output_module = relax.transform.FoldConstant()(input_module)
-    tvm.ir.assert_structural_equal(output_module, expected_module)
+    before = gen_mod(Module, "before", {"c0": c0_np})
+    expected = gen_mod(Module, "expected", {"c1": c1_np})
+    after = relax.transform.FoldConstant()(before)
+    tvm.ir.assert_structural_equal(after, expected)
 
 
 def test_fold_mixed_case():
@@ -241,10 +241,10 @@ def test_fold_mixed_case():
     c1_np = c0_np + 1
     c2_np = c0_np - c1_np
 
-    input_module = gen_mod(Module, "before", {"c0": c0_np})
-    expected_module = gen_mod(Module, "after", {"c0": c0_np, "c1": c1_np, "c2": c2_np})
-    output_module = relax.transform.FoldConstant()(input_module)
-    tvm.ir.assert_structural_equal(output_module, expected_module)
+    before = gen_mod(Module, "before", {"c0": c0_np})
+    expected = gen_mod(Module, "expected", {"c0": c0_np, "c1": c1_np, "c2": c2_np})
+    after = relax.transform.FoldConstant()(before)
+    tvm.ir.assert_structural_equal(after, expected)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -19,7 +19,7 @@ import pytest
 import sys
 import tvm
 import tvm.testing
-from tvm import relax, relay
+from tvm import relax
 from tvm.ir.base import assert_structural_equal
 import numpy as np
 
@@ -73,7 +73,7 @@ def test_one_fold_addone():
             return lv0
 
         @R.function
-        def after(c1: Tensor[(16, 16), "float32"]):
+        def expected(c1: Tensor[(16, 16), "float32"]):
             lv0 = c1
             return c1
 
@@ -103,7 +103,7 @@ def test_one_fold_transpose():
             return lv0
 
         @R.function
-        def after(c1: Tensor[(3, 2), "float32"]):
+        def expected(c1: Tensor[(3, 2), "float32"]):
             lv0 = c1
             return c1
 
@@ -133,7 +133,7 @@ def test_two_hop_addone():
             return lv1
 
         @R.function
-        def after(c1: Tensor[(2, 2), "float32"], c2: Tensor[(2, 2), "float32"]):
+        def expected(c1: Tensor[(2, 2), "float32"], c2: Tensor[(2, 2), "float32"]):
             lv0 = c1
             lv1 = c2
             return c2
@@ -166,7 +166,7 @@ def test_dataflow_fold():
             return gv0
 
         @R.function
-        def after(c1: Tensor[(16, 16), "float32"]):
+        def expected(c1: Tensor[(16, 16), "float32"]):
             with R.dataflow():
                 gv0 = c1
                 R.output(gv0)
@@ -220,7 +220,7 @@ def test_fold_mixed_case():
             return lv3
 
         @R.function
-        def after(
+        def expected(
             c0: Tensor[(16, 16), "float32"],
             c1: Tensor[(16, 16), "float32"],
             c2: Tensor[(16, 16), "float32"],

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -25,6 +25,7 @@ import numpy as np
 import tvm.script
 from tvm.script import tir as T, relax as R
 
+
 def gen_mod(mod, name, binding):
     """Select relax function with name, rename to main and and bind constant.
 
@@ -89,7 +90,7 @@ def test_one_fold_transpose():
     @tvm.script.ir_module
     class InputModule:
         @T.prim_func
-        def transpose(A: T.Buffer[(2, 3), "float32"], B: T.Buffer[(3, 2), "float32"]) -> None:
+        def func(A: T.Buffer[(2, 3), "float32"], B: T.Buffer[(3, 2), "float32"]) -> None:
             for i, j in T.grid(3, 2):
                 with T.block("transpose"):
                     vi, vj = T.axis.remap("SS", [i, j])
@@ -97,7 +98,7 @@ def test_one_fold_transpose():
 
         @R.function
         def before(c0: Tensor[(2, 3), "float32"]):
-            lv0 = relax.call_tir(transpose, (c0,), (3, 2), dtype="float32")
+            lv0 = relax.call_tir(func, (c0,), (3, 2), dtype="float32")
             return lv0
 
         @R.function

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -1,0 +1,253 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations  # must import to defer parsing of annotations
+import pytest
+import tvm
+import tvm.testing
+from tvm import relax, relay
+from tvm.ir.base import assert_structural_equal
+import numpy as np
+
+import tvm.script
+from tvm.script import tir as T, relax as R
+
+def gen_mod(mod, name, binding):
+    """Select relax function with name, rename to main and and bind constant.
+
+    Parameters
+    ----------
+    mod: IRModule
+        The input module
+
+    name: str
+        The name of relax function to preserve and rename to main
+
+    binding: Dict[str, array]
+        The const parameter bindings
+    """
+    funcs = {}
+    binding = {k: tvm.nd.array(v) for k, v in binding.items()}
+
+    for k, v in mod.functions.items():
+        if isinstance(v, tvm.relax.Function):
+            if k.name_hint == name:
+                # rename to main
+                gv = tvm.ir.GlobalVar("main")
+                funcs[gv] = tvm.relax.Function(v.params, v.body, v.ret_type, gv)
+        else:
+            funcs[k] = v
+    mod = tvm.IRModule(funcs)
+    return relax.transform.BindParams("main", binding)(mod)
+
+
+def test_one_fold_addone():
+    # put before after in a single module
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def addone(A: T.Buffer[(16, 16), "float32"], B: T.Buffer[(16, 16), "float32"]) -> None:
+            for i, j in T.grid(16, 16):
+                with T.block("addone"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    B[vi, vj] = A[vi, vj] + T.float32(1)
+
+        @R.function
+        def before(c0: Tensor[(16, 16), "float32"]):
+            lv0 = relax.call_tir(addone, (c0,), (16, 16), dtype="float32")
+            return lv0
+
+        @R.function
+        def after(c1: Tensor[(16, 16), "float32"]):
+            lv0 = c1
+            return c1
+
+    c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
+    c1_np = c0_np + 1
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c1": c1_np})
+
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
+
+
+def test_one_fold_transpose():
+    # put before after in a single module
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def transpose(A: T.Buffer[(2, 3), "float32"], B: T.Buffer[(3, 2), "float32"]) -> None:
+            for i, j in T.grid(3, 2):
+                with T.block("transpose"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    B[vi, vj] = A[vj, vi]
+
+        @R.function
+        def before(c0: Tensor[(2, 3), "float32"]):
+            lv0 = relax.call_tir(transpose, (c0,), (3, 2), dtype="float32")
+            return lv0
+
+        @R.function
+        def after(c1: Tensor[(3, 2), "float32"]):
+            lv0 = c1
+            return c1
+
+    c0_np = np.arange(2 * 3).astype("float32").reshape(2, 3)
+    c1_np = c0_np.T
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c1": c1_np})
+
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
+
+
+def test_two_hop_addone():
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def addone(A: T.Buffer[(2, 2), "float32"], B: T.Buffer[(2, 2), "float32"]) -> None:
+            for i, j in T.grid(2, 2):
+                with T.block("addone"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    B[vi, vj] = A[vi, vj] + T.float32(1)
+
+        @R.function
+        def before(c0: Tensor[(2, 2), "float32"]):
+            lv0 = relax.call_tir(addone, (c0,), (2, 2), dtype="float32")
+            lv1 = relax.call_tir(addone, (lv0,), (2, 2), dtype="float32")
+            return lv1
+
+        @R.function
+        def after(c1: Tensor[(2, 2), "float32"], c2: Tensor[(2, 2), "float32"]):
+            lv0 = c1
+            lv1 = c2
+            return c2
+
+    c0_np = np.arange((2 * 2)).astype("float32").reshape(2, 2)
+    c1_np = c0_np + 1
+    c2_np = c1_np + 1
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c1": c1_np, "c2": c2_np})
+
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
+
+
+def test_dataflow_fold():
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def identity(A: T.Buffer[(16, 16), "float32"], B: T.Buffer[(16, 16), "float32"]) -> None:
+            for i, j in T.grid(16, 16):
+                with T.block("identity"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    B[vi, vj] = A[vi, vj]
+
+        @R.function
+        def before(c0: Tensor[(16, 16), "float32"]):
+            with R.dataflow():
+                gv0 = relax.call_tir(identity, (c0,), (16, 16), dtype="float32")
+                R.output(gv0)
+            return gv0
+
+        @R.function
+        def after(c1: Tensor[(16, 16), "float32"]):
+            with R.dataflow():
+                gv0 = c1
+                R.output(gv0)
+            return c1
+
+    c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
+    c1_np = c0_np
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c1": c1_np})
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
+
+
+def test_fold_mixed_case():
+    @tvm.script.ir_module
+    class InputModule:
+        # TIR function can handle different cases.
+        @T.prim_func
+        def addone(a: T.handle, b: T.handle) -> None:
+            n = T.var("int32")
+            m = T.var("int32")
+            A = T.match_buffer(a, (n, m))
+            B = T.match_buffer(b, (n, m))
+            for i, j in T.grid(n, m):
+                with T.block("addone"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    B[vi, vj] = A[vi, vj] + T.float32(1)
+
+        @T.prim_func
+        def sub(
+            A: T.Buffer[(16, 16), "float32"],
+            B: T.Buffer[(16, 16), "float32"],
+            C: T.Buffer[(16, 16), "float32"],
+        ) -> None:
+            for i, j in T.grid(16, 16):
+                with T.block("sub"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    C[vi, vj] = A[vi, vj] - B[vi, vj]
+
+        @R.function
+        def before(c0: Tensor[(16, 16), "float32"], x: Tensor[(_, _), "float32"]):
+            x0 = R.match_shape(x, (n, m))
+            # this line cannot be folded because n is unknown
+            lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
+            # this line can be folded
+            lv1 = relax.call_tir(addone, (c0,), (16, 16), dtype="float32")
+            # this line can be folded because all inputs are const
+            lv2 = relax.call_tir(sub, (c0, lv1), (16, 16), dtype="float32")
+            # this line can not be folded because x's shape is unknown
+            lv3 = relax.call_tir(sub, (lv2, x), (16, 16), dtype="float32")
+            return lv3
+
+        @R.function
+        def after(
+            c0: Tensor[(16, 16), "float32"],
+            c1: Tensor[(16, 16), "float32"],
+            c2: Tensor[(16, 16), "float32"],
+            x: Tensor[(_, _), "float32"],
+        ):
+            x0 = R.match_shape(x, (n, m))
+            # this line cannot be folded because n is unknown
+            lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
+            # this line can be folded
+            lv1 = c1
+            # this line can be folded because all inputs are const
+            lv2 = c2
+            # this line can not be folded because x's shape is unknown
+            lv3 = relax.call_tir(sub, (c2, x), (16, 16), dtype="float32")
+            return lv3
+
+    c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
+    c1_np = c0_np + 1
+    c2_np = c0_np - c1_np
+
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c0": c0_np, "c1": c1_np, "c2": c2_np})
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
+
+
+if __name__ == "__main__":
+    test_one_fold_addone()
+    test_one_fold_transpose()
+    test_two_hop_addone()
+    test_dataflow_fold()
+    test_fold_mixed_case()


### PR DESCRIPTION
This is a PR of the FoldConstant pass and BindParams pass.
FoldConstant folds constant expressions (currently only support constant call_tir) and BindParams binds params of function of the module to constant tensors.

In this PR, one noticeable change of the BlockBuilder api is that we return Optional\<Expr\> for LookupBinding. It returns NullOpt when looking up function params.

cc: @tqchen @Hzfengsy @MasterJH5574 @YuchenJin 