### PR TITLE
[CI] Enable GPU tests; Add AutoTIR cuda test.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,14 +45,14 @@
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = "tlcpack/ci-lint:v0.67"
-ci_gpu = "tlcpack/ci-gpu:v0.82"
-ci_cpu = "tlcpack/ci-cpu:v0.82"
-ci_wasm = "tlcpack/ci-wasm:v0.71"
-ci_i386 = "tlcpack/ci-i386:v0.74"
-ci_qemu = "tlcpack/ci-qemu:v0.10"
-ci_arm = "tlcpack/ci-arm:v0.07"
-ci_hexagon = "tlcpack/ci-hexagon:v0.01"
+ci_lint = 'tlcpack/ci-lint:v0.69'
+ci_gpu = 'tlcpack/ci-gpu:v0.82'
+ci_cpu = 'tlcpack/ci-cpu:v0.82'
+ci_wasm = 'tlcpack/ci-wasm:v0.72'
+ci_i386 = 'tlcpack/ci-i386:v0.75'
+ci_qemu = 'tlcpack/ci-qemu:v0.11'
+ci_arm = 'tlcpack/ci-arm:v0.08'
+ci_hexagon = 'tlcpack/ci-hexagon:v0.02'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images
@@ -278,9 +278,10 @@ stage('Build and Test') {
       node('GPU') {
         ws(per_exec_ws('tvm/build-gpu')) {
           init_git()
-          sh "${docker_run} --no-gpu ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh build"
-          make("${ci_gpu} --no-gpu", 'build', '-j2')
-          sh "${docker_run} --no-gpu ${ci_gpu} ./tests/scripts/task_python_integration_gpuonly.sh"
+          sh "${docker_run} ${ci_gpu} nvidia-smi"
+          sh "${docker_run}  ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh build"
+          make("${ci_gpu}", 'build', '-j2')
+          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_integration_gpuonly.sh"
         }
       }
     },

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -167,8 +167,8 @@ def test_autotir(dev: str):
     if dev == "cpu":
         target = Target("llvm --num-cores=16")
         dev = tvm.cpu()
-    else:
-        target = Target("nvidia/geforce-rtx-3070")
+    elif dev == "cuda":
+        target = Target("nvidia/nvidia-t4")
         dev = tvm.cuda()
 
     database = DummyDatabase()
@@ -187,32 +187,37 @@ def test_autotir(dev: str):
                 database=database,
             )
 
-    with transform.PassContext(opt_level=3):
-        ex0 = relax.vm.build(mod, target)
+    if dev == "cpu":
+        with transform.PassContext(opt_level=3):
+            ex0 = relax.vm.build(mod, target)
+            vm0 = relax.VirtualMachine(ex0, dev)
+
+        # Measure the performance w/o tuning log
+        tic = time.time()
+        vm0["main"](data, weight)
+        toc = time.time()
+        e0 = toc - tic
+        print(f"w/o tuning: {e0}")
 
     with transform.PassContext(opt_level=3):
         mod = relax.transform.MetaScheduleApplyHistoryBest(database, target)(mod)
         ex1 = relax.vm.build(mod, target)
 
-    vm0 = relax.VirtualMachine(ex0, dev)
     vm1 = relax.VirtualMachine(ex1, dev)
     data = tvm.nd.array(np.random.rand(32, 32).astype(np.float32), dev)
     weight = tvm.nd.array(np.random.rand(32, 32).astype(np.float32), dev)
-
-    # Measure the performance w/o tuning log
-    tic = time.time()
-    vm0["main"](data, weight)
-    toc = time.time()
-    e0 = toc - tic
 
     # Measure the performance w/ tuning log
     tic = time.time()
     vm1["main"](data, weight)
     toc = time.time()
     e1 = toc - tic
-
-    print(f"w/o tuning: {e0}")
     print(f"w/  tuning: {e1}")
+
+
+@tvm.testing.requires_gpu
+def test_autotir_gpu():
+    test_autotir("cuda")
 
 
 if __name__ == "__main__":

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -27,7 +27,7 @@ export TVM_BIND_THREADS=0
 export TVM_NUM_THREADS=2
 
 # Run Relax tests
-TVM_TEST_TARGETS="llvm" pytest tests/python/relax
+TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" pytest tests/python/relax
 
 # NOTE: also set by task_python_integration_gpuonly.sh.
 # if [ -z "${TVM_INTEGRATION_TESTSUITE_NAME:-}" ]; then

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -27,7 +27,10 @@ export TVM_BIND_THREADS=0
 export TVM_NUM_THREADS=2
 
 # Run Relax tests
-TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" pytest tests/python/relax
+TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm}" pytest tests/python/relax
+
+# Run Relax examples
+ls ./apps/relax_examples/*.py | xargs python3
 
 # NOTE: also set by task_python_integration_gpuonly.sh.
 # if [ -z "${TVM_INTEGRATION_TESTSUITE_NAME:-}" ]; then

--- a/tests/scripts/task_python_integration_gpuonly.sh
+++ b/tests/scripts/task_python_integration_gpuonly.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-export TVM_TEST_TARGETS="cuda;opencl;metal;rocm;nvptx;opencl -device=mali,aocl_sw_emu"
+export TVM_TEST_TARGETS="llvm;cuda"
 export PYTEST_ADDOPTS="-m gpu $PYTEST_ADDOPTS"
 export TVM_RELAY_TEST_TARGETS="cuda"
 export TVM_INTEGRATION_TESTSUITE_NAME=python-integration-gpu


### PR DESCRIPTION
The TVM official docker images were upgraded to have Python3.7 installed recently, so we are able to use them for both CPU and GPU in CI.

Enables the AutoTIR cuda test, note that the default TIR primfunc emitted by EmitTE do not have thread binding construct, so we need to run MetaSchedule which applies split and bind to threads.