### PR TITLE
[BlockBuilder] Deduce and fill shape/type for Expr in Normalizer.

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -73,6 +73,8 @@ class BlockBuilderNode : public Object {
    * \brief Emits an Expr, and returns the variable it is bound to.
    * \param expr The Expr to be emitted.
    * \param name_hint Name hint for the bound variable.
+   * \note This Emit function normalizes the \p expr, and performs shape and type deductions by
+   * calling Normalize.
    * \return The new variable that \p expr is bound to.
    */
   virtual Var Emit(const Expr& expr, std::string name_hint = "");
@@ -167,6 +169,15 @@ class BlockBuilderNode : public Object {
   TVM_DECLARE_BASE_OBJECT_INFO(BlockBuilderNode, Object);
 
  private:
+  /*!
+   * \brief Emits an Expr, and returns the variable it is bound to.
+   * \param expr The Expr to be emitted.
+   * \param is_dataflow Is the bound variable a DataflowVar or not(i.e. Var).
+   * \param name_hint Name hint for the bound variable.
+   * \note This Emit function normalizes the \p expr, and performs shape and type deductions by
+   * calling Normalize.
+   * \return The new variable that \p expr is bound to.
+   */
   Var Emit(const Expr& expr, bool is_dataflow, std::string name_hint);
 
   /*! \brief The IRModule being built by the BlockBuilder. */

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=invalid-name, wrong-import-position
 """The Relax IR namespace containing the IR, type, operator, and builder."""
+from tvm.relay import FuncType
 from . import exec_builder
 from . import expr
 from . import ty
@@ -58,6 +59,7 @@ ShapeType = ty.ShapeType
 DynTensorType = ty.DynTensorType
 DimType = ty.DimType
 TupleType = ty.TupleType
+FuncType = ty.FuncType
 
 # VM
 ExecBuilder = exec_builder.ExecBuilder

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -288,7 +288,7 @@ class BlockBuilder(Object):
         Returns
         -------
         ret : tvm.relax.Var
-            A newly created variable that gets binded to the input expr.
+            A newly created variable that gets bound to the input expr.
         """
         return _ffi_api.BlockBuilderEmit(self, expr)
 
@@ -385,7 +385,7 @@ class BlockBuilder(Object):
         Returns
         -------
         ret : tvm.relax.Var
-            A newly created variable that gets binded to the call code.
+            A newly created variable that gets bound to the call code.
 
         Example
         -------
@@ -502,7 +502,7 @@ class BlockBuilder(Object):
         Returns
         -------
         ret : tvm.relax.Var
-            A newly created variable that gets binded to the call code.
+            A newly created variable that gets bound to the call code.
         """
         return _ffi_api.BlockBuilderEmitMatchShape(self, value, pattern)
 
@@ -517,7 +517,7 @@ class BlockBuilder(Object):
         Returns
         -------
         ret : tvm.relax.Var
-            The return variable which gets binded to the output.
+            The return variable which gets bound to the output.
         """
         if isinstance(output, (list, tuple)):
             output = Tuple(output)
@@ -542,7 +542,7 @@ class BlockBuilder(Object):
         Returns
         -------
         ret : tvm.relax.Var
-            The return variable which gets binded to the output.
+            The return variable which gets bound to the output.
         """
         if self._is_emit_func_output_called:
             raise RuntimeError("emit_func_output must be called exactly once in a relax function.")

--- a/python/tvm/relax/ty.py
+++ b/python/tvm/relax/ty.py
@@ -17,7 +17,7 @@
 # pylint: disable=invalid-name, unused-import
 """The type nodes of the Relax language."""
 import tvm._ffi
-from tvm.ir import Type, TensorType, TupleType, Span
+from tvm.ir import Type, TensorType, TupleType, FuncType, Span
 
 from . import _ffi_api
 

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -443,6 +443,10 @@ class RelaxTransformer(Transformer):
             for func_name, func in root_func.funcs.items():
                 global_var = self.scope[func_name]
                 self.module[global_var] = self.transform_function(func, is_global=True)
+            # TODO(@yuchen): temporarily make the the parser.from_source api also run
+            # ResolveGlobals pass to populate shape and checked type to be consitent
+            # with the behavior of directly parsing TVMScript
+            self.module = relax.transform.ResolveGlobals()(self.module)
             return self.module
         else:
             self.report_error(f"unsupported input class: {root_func}", root_func.span)

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -117,7 +117,7 @@ class VMShapeLowerMutator : public ExprMutator {
 
     // FIXME(@yuchen): Implement vm.builtin.free_shape_heap.
     // builder_->Emit(Call(ExternFunc("vm.builtin.free_shape_heap"), {shape_heap_}), "gv");
-    new_body = SeqExpr(blocks, new_body);
+    new_body = builder_->Normalize(SeqExpr(blocks, new_body));
 
     return Function(node->name, node->params, new_body, ret_type);
   }

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -32,6 +32,30 @@
 namespace tvm {
 namespace relax {
 
+// Helper function to infer the shape of a Call.
+Optional<Expr> InferShape(const Call& call, DiagnosticContext diag_ctx) {
+  auto op_map = Op::GetAttrMap<FInferShape>("FInferShape");
+  if (call->op.as<OpNode>()) {
+    Op op = Downcast<Op>(call->op);
+    if (op_map.count(op)) {
+      return op_map[op](call, diag_ctx);
+    }
+  }
+  return NullOpt;
+}
+
+// Helper function to infer the type of a Call.
+Type InferType(const Call& call, DiagnosticContext diag_ctx) {
+  auto op_map = Op::GetAttrMap<FInferType>("FInferType");
+  if (call->op.as<OpNode>()) {
+    Op op = Downcast<Op>(call->op);
+    if (op_map.count(op)) {
+      return op_map[op](call, diag_ctx);
+    }
+  }
+  return Type();
+}
+
 // ================================
 // BlockBuilderNode::ExprNormalizer
 
@@ -43,7 +67,6 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
 #define RELAX_EXPR_NORMALIZER_LEAF(OP) \
   Expr VisitExpr_(const OP* op) final { return GetRef<Expr>(op); }
 
-  RELAX_EXPR_NORMALIZER_LEAF(ConstantNode);
   RELAX_EXPR_NORMALIZER_LEAF(VarNode);
   RELAX_EXPR_NORMALIZER_LEAF(DataflowVarNode);
   RELAX_EXPR_NORMALIZER_LEAF(ShapeExprNode);
@@ -70,15 +93,67 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
       new_fields.push_back(new_field);
       unchanged &= new_field.same_as(field);
     }
-    return unchanged ? GetRef<Expr>(op) : Tuple(new_fields);
+    Tuple tuple = unchanged ? GetRef<Tuple>(op) : Tuple(new_fields);
+
+    // only do shape/type inference if the Tuple does not have shape/type
+    if (tuple->shape_ && tuple->checked_type_.defined()) {
+      return tuple;
+    }
+
+    if (!tuple->shape_) {
+      Array<Expr> tuple_shape;
+      for (Expr field : tuple->fields) {
+        if (field->shape_) {
+          tuple_shape.push_back(Downcast<Expr>(field->shape_.value()));
+        } else {
+          break;
+        }
+      }
+      if (tuple_shape.size() == tuple->fields.size()) {
+        tuple->shape_ = Tuple(tuple_shape);
+      }
+    }
+
+    if (!tuple->checked_type_.defined()) {
+      Array<Type> tuple_type;
+      for (Expr field : tuple->fields) {
+        if (field->checked_type_.defined()) {
+          tuple_type.push_back(field->checked_type_);
+        } else {
+          break;
+        }
+      }
+      if (tuple_type.size() == tuple->fields.size()) {
+        tuple->checked_type_ = TupleType(tuple_type);
+      }
+    }
+    return tuple;
   }
 
   Expr VisitExpr_(const FunctionNode* op) final {
     Expr new_body = this->VisitWithNewScope(op->body);
+    Function func;
     if (new_body.same_as(op->body)) {
-      return GetRef<Expr>(op);
+      func = GetRef<Function>(op);
+    } else {
+      func = Function(op->name, op->params, new_body, op->ret_type);
     }
-    return Function(op->name, op->params, new_body, op->ret_type);
+
+    // only do shape/type inference if the Function does not have shape/type
+    if (func->shape_ && func->checked_type_.defined()) {
+      return func;
+    }
+
+    // Note: the shape_ of Function is left as Null for now, to be consitent with
+    // Function->checked_type_, which is a FuncType
+    if (!func->checked_type_.defined() && func->body->checked_type_.defined()) {
+      Array<Type> param_types;
+      for (auto param : func->params) {
+        param_types.push_back(param->checked_type_);
+      }
+      func->checked_type_ = FuncType(param_types, func->body->checked_type_, {}, {});
+    }
+    return func;
   }
 
   Expr VisitExpr_(const CallNode* op) final {
@@ -86,16 +161,40 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     bool unchanged = new_op.same_as(op->op);
 
     Array<Expr> new_args;
-    for (const Expr& arg : op->args) {
-      Expr new_arg = this->Bind(arg);
-      new_args.push_back(new_arg);
-      unchanged &= new_arg.same_as(arg);
+    if (!op->args.empty()) {
+      for (const Expr& arg : op->args) {
+        Expr new_arg = this->Bind(arg);
+        new_args.push_back(new_arg);
+        unchanged &= new_arg.same_as(arg);
+      }
     }
 
+    Call call;
     if (unchanged) {
-      return GetRef<Expr>(op);
+      call = GetRef<Call>(op);
+    } else {
+      call = Call(new_op, new_args, op->attrs, op->type_args);
     }
-    return Call(new_op, new_args, op->attrs, op->type_args);
+
+    // only do shape/type inference if the Call does not have shape/type
+    if (call->shape_ && call->checked_type_.defined()) {
+      return call;
+    }
+
+    if (!call->shape_) {
+      // shape inference
+      auto inferred_shape = InferShape(call, this->builder_->diag_ctx_);
+      if (inferred_shape) {
+        call->shape_ = inferred_shape.value();
+      }
+    }
+
+    if (!call->checked_type_.defined()) {
+      // type inference
+      auto inferred_type = InferType(call, this->builder_->diag_ctx_);
+      call->checked_type_ = inferred_type;
+    }
+    return call;
   }
 
   Expr VisitExpr_(const SeqExprNode* op) final {
@@ -120,10 +219,50 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
       unchanged = false;
     }
 
+    SeqExpr seq_expr;
     if (unchanged) {
-      return GetRef<Expr>(op);
+      seq_expr = GetRef<SeqExpr>(op);
     }
-    return SeqExpr(new_blocks, new_body);
+    seq_expr = SeqExpr(new_blocks, new_body);
+
+    // only do shape/type inference if the SeqExpr does not have shape/type
+    if (seq_expr->shape_ && seq_expr->checked_type_.defined()) {
+      return seq_expr;
+    }
+
+    if (!seq_expr->shape_ && seq_expr->body->shape_) {
+      seq_expr->shape_ = seq_expr->body->shape_;
+    }
+
+    if (!seq_expr->checked_type_.defined() && seq_expr->body->checked_type_.defined()) {
+      seq_expr->checked_type_ = seq_expr->body->checked_type_;
+    }
+    return seq_expr;
+  }
+
+  Expr VisitExpr_(const ConstantNode* op) final {
+    Constant constant = GetRef<Constant>(op);
+
+    // only do shape/type inference if the Constant does not have shape/type
+    if (constant->shape_ && constant->checked_type_.defined()) {
+      return constant;
+    }
+
+    auto shape_tuple = constant->data.Shape();
+    if (!constant->shape_) {
+      Array<PrimExpr> values;
+      for (size_t dim = 0; dim < shape_tuple.size(); dim++) {
+        values.push_back(IntImm(DataType::Int(64), shape_tuple[dim]));
+      }
+      constant->shape_ = relax::ShapeExpr(values);
+    }
+
+    if (!constant->checked_type_.defined()) {
+      DataType dtype = constant->data.DataType();
+      Type type = relax::DynTensorType(shape_tuple.size(), dtype);
+      constant->checked_type_ = type;
+    }
+    return constant;
   }
 
   Expr VisitExpr_(const IfNode* op) final {
@@ -139,10 +278,29 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
 
   Expr VisitExpr_(const TupleGetItemNode* op) final {
     Expr new_tuple = this->VisitExpr(op->tuple);
+    TupleGetItem node;
     if (new_tuple.same_as(op->tuple)) {
-      return GetRef<Expr>(op);
+      node = GetRef<TupleGetItem>(op);
     }
-    return TupleGetItem(new_tuple, op->index);
+    node = TupleGetItem(new_tuple, op->index);
+
+    // only do shape/type inference if the TupleGetItem does not have shape/type
+    if (node->shape_ && node->checked_type_.defined()) {
+      return node;
+    }
+
+    if (!node->shape_ && node->tuple->shape_) {
+      if (const TupleNode* shape = node->tuple->shape_.as<TupleNode>()) {
+        node->shape_ = shape->fields[node->index];
+      }
+    }
+
+    if (!node->checked_type_.defined() && node->tuple->checked_type_.defined()) {
+      if (const TupleTypeNode* type = node->tuple->checked_type_.as<TupleTypeNode>()) {
+        node->checked_type_ = type->fields[node->index];
+      }
+    }
+    return node;
   }
 
   Binding VisitBinding(const Binding& binding) {
@@ -298,90 +456,24 @@ BindingBlock BlockBuilderNode::EndBlock() {
   return ret;
 }
 
-Optional<Expr> InferShape(const Call& call, DiagnosticContext diag_ctx) {
-  auto op_map = Op::GetAttrMap<FInferShape>("FInferShape");
-  if (call->op.as<OpNode>()) {
-    Op op = Downcast<Op>(call->op);
-    if (op_map.count(op)) {
-      return op_map[op](call, diag_ctx);
-    }
-  }
-  return NullOpt;
-}
-
-Type InferType(const Call& call, DiagnosticContext diag_ctx) {
-  auto op_map = Op::GetAttrMap<FInferType>("FInferType");
-  if (call->op.as<OpNode>()) {
-    Op op = Downcast<Op>(call->op);
-    if (op_map.count(op)) {
-      return op_map[op](call, diag_ctx);
-    }
-  }
-  return Type();
-}
-
 Var BlockBuilderNode::Emit(const Expr& expr, std::string name_hint) {
   return Emit(expr, CurrentFrame()->is_dataflow, name_hint);
 }
 
 Var BlockBuilderNode::Emit(const Expr& expr, bool is_dataflow, std::string name_hint) {
   BlockFrame* cur_frame = CurrentFrame();
+  Expr normalized = Normalize(expr);
 
   if (name_hint.empty()) {
     name_hint = is_dataflow ? "lv" : "gv";
   }
   Id vid = Id(name_table_->GetUniqueName(name_hint));
   Var var = is_dataflow ? DataflowVar(vid, NullOpt, NullOpt) : Var(vid, NullOpt, NullOpt);
+  var->checked_type_ = normalized->checked_type_;
+  var->shape_ = normalized->shape_;
 
-  // do eager inference for Calls
-  if (const CallNode* call_node = expr.as<CallNode>()) {
-    // TypeInference::InferCall(...)
-    const Call& call = GetRef<Call>(call_node);
-
-    Optional<Expr> inferred_shape = InferShape(call, this->diag_ctx_);
-    Type inferred_type = InferType(call, this->diag_ctx_);
-
-    var->shape_ = inferred_shape;
-    var->checked_type_ = inferred_type;
-
-    Call new_call = Call(call->op, call->args, call->attrs, call->type_args, call->span);
-    new_call->checked_type_ = inferred_type;
-    new_call->shape_ = inferred_shape;
-
-    cur_frame->bindings.push_back(VarBinding(var, new_call));
-    this->binding_table_[var->vid] = new_call;
-  } else if (const VarNode* var_node = expr.as<VarNode>()) {
-    const Var& lhs_var = GetRef<Var>(var_node);
-    if (lhs_var->shape_.defined()) {
-      var->shape_ = lhs_var->shape_;
-    }
-    if (lhs_var->checked_type_.defined()) {
-      var->checked_type_ = lhs_var->checked_type_;
-    }
-    cur_frame->bindings.push_back(VarBinding(var, lhs_var));
-    this->binding_table_[var->vid] = lhs_var;
-  } else if (const TupleGetItemNode* tuple_get_item_node = expr.as<TupleGetItemNode>()) {
-    if (const VarNode* tuple = tuple_get_item_node->tuple.as<VarNode>()) {
-      if (tuple->shape_.defined()) {
-        if (const TupleNode* shape = tuple->shape_.as<TupleNode>()) {
-          var->shape_ = shape->fields[tuple_get_item_node->index];
-        }
-      }
-      if (tuple->checked_type_.defined()) {
-        if (const TupleTypeNode* type = tuple->checked_type_.as<TupleTypeNode>()) {
-          var->checked_type_ = type->fields[tuple_get_item_node->index];
-        }
-      }
-      cur_frame->bindings.push_back(VarBinding(var, expr));
-      this->binding_table_[var->vid] = expr;
-    } else {
-      LOG(FATAL) << "TypeError: Invalid type as the tuple field of TupleGetItemNode: "
-                 << tuple_get_item_node->tuple->GetTypeKey();
-    }
-  } else {
-    cur_frame->bindings.push_back(VarBinding(var, expr));
-    binding_table_[var->vid] = expr;
-  }
+  cur_frame->bindings.push_back(VarBinding(var, expr));
+  binding_table_[var->vid] = expr;
 
   return var;
 }
@@ -501,141 +593,6 @@ bool BlockBuilderNode::CanProveShapeEqual(const Expr& lhs, const Expr& rhs) {
 Expr BlockBuilderNode::Normalize(const Expr& expr) {
   // TODO(@altanh): fast path
   Expr normalized = normalizer_->VisitExpr(expr);
-  if (normalized.as<CallNode>()) {
-    // FIXME(@altanh): potentially breaks idempotency
-    Call call = Downcast<Call>(normalized);
-
-    // only do shape/type inference if the Call does not have shape/type
-    if (call->shape_ && call->checked_type_.defined()) {
-      return call;
-    }
-
-    if (!call->shape_) {
-      // shape inference
-      auto inferred_shape = InferShape(call, this->diag_ctx_);
-      if (inferred_shape) {
-        call->shape_ = this->Normalize(inferred_shape.value());
-      }
-    }
-
-    if (!call->checked_type_.defined()) {
-      // type inference
-      auto inferred_type = InferType(call, this->diag_ctx_);
-      call->checked_type_ = inferred_type;
-    }
-    return call;
-  } else if (normalized.as<TupleNode>()) {
-    Tuple tuple = Downcast<Tuple>(normalized);
-
-    // only do shape/type inference if the Tuple does not have shape/type
-    if (tuple->shape_ && tuple->checked_type_.defined()) {
-      return tuple;
-    }
-
-    if (!tuple->shape_) {
-      Array<Expr> tuple_shape;
-      for (Expr field : tuple->fields) {
-        if (field->shape_) {
-          tuple_shape.push_back(Downcast<Expr>(field->shape_.value()));
-        } else {
-          break;
-        }
-      }
-      if (tuple_shape.size() == tuple->fields.size()) {
-        tuple->shape_ = Tuple(tuple_shape);
-      }
-    }
-
-    if (!tuple->checked_type_.defined()) {
-      Array<Type> tuple_type;
-      for (Expr field : tuple->fields) {
-        if (field->checked_type_.defined()) {
-          tuple_type.push_back(field->checked_type_);
-        } else {
-          break;
-        }
-      }
-      if (tuple_type.size() == tuple->fields.size()) {
-        tuple->checked_type_ = TupleType(tuple_type);
-      }
-    }
-    return tuple;
-  } else if (normalized.as<TupleGetItemNode>()) {
-    TupleGetItem node = Downcast<TupleGetItem>(normalized);
-
-    // only do shape/type inference if the TupleGetItem does not have shape/type
-    if (node->shape_ && node->checked_type_.defined()) {
-      return node;
-    }
-
-    if (!node->shape_ && node->tuple->shape_) {
-      if (const TupleNode* shape = node->tuple->shape_.as<TupleNode>()) {
-        node->shape_ = shape->fields[node->index];
-      }
-    }
-
-    if (!node->checked_type_.defined() && node->tuple->checked_type_.defined()) {
-      if (const TupleTypeNode* type = node->tuple->checked_type_.as<TupleTypeNode>()) {
-        node->checked_type_ = type->fields[node->index];
-      }
-    }
-    return node;
-  } else if (normalized.as<ConstantNode>()) {
-    Constant constant = Downcast<Constant>(normalized);
-
-    // only do shape/type inference if the Constant does not have shape/type
-    if (constant->shape_ && constant->checked_type_.defined()) {
-      return constant;
-    }
-
-    auto shape_tuple = constant->data.Shape();
-    if (!constant->shape_) {
-      Array<PrimExpr> values;
-      for (size_t dim = 0; dim < shape_tuple.size(); dim++) {
-        values.push_back(IntImm(DataType::Int(64), shape_tuple[dim]));
-      }
-      constant->shape_ = relax::ShapeExpr(values);
-    }
-
-    if (!constant->checked_type_.defined()) {
-      DataType dtype = constant->data.DataType();
-      Type type = relax::DynTensorType(shape_tuple.size(), dtype);
-      constant->checked_type_ = type;
-    }
-    return constant;
-  } else if (normalized.as<FunctionNode>()) {
-    Function func = Downcast<Function>(normalized);
-
-    // only do shape/type inference if the Function does not have shape/type
-    if (func->shape_ && func->checked_type_.defined()) {
-      return func;
-    }
-
-    if (!func->shape_ && func->body->shape_) {
-      func->shape_ = func->body->shape_;
-    }
-
-    if (!func->checked_type_.defined() && func->body->checked_type_.defined()) {
-      func->checked_type_ = func->body->checked_type_;
-    }
-    return func;
-  } else if (normalized.as<SeqExprNode>()) {
-    SeqExpr seq_expr = Downcast<SeqExpr>(normalized);
-
-    // only do shape/type inference if the SeqExpr does not have shape/type
-    if (seq_expr->shape_ && seq_expr->checked_type_.defined()) {
-      return seq_expr;
-    }
-
-    if (!seq_expr->shape_ && seq_expr->body->shape_) {
-      seq_expr->shape_ = seq_expr->body->shape_;
-    }
-
-    if (!seq_expr->checked_type_.defined() && seq_expr->body->checked_type_.defined()) {
-      seq_expr->checked_type_ = seq_expr->body->checked_type_;
-    }
-    return seq_expr;
-  }
   return normalized;
 }
 

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -505,7 +505,7 @@ Expr BlockBuilderNode::Normalize(const Expr& expr) {
     // FIXME(@altanh): potentially breaks idempotency
     Call call = Downcast<Call>(normalized);
 
-    // only do shape/type inference if the call does not have shape/type
+    // only do shape/type inference if the Call does not have shape/type
     if (call->shape_ && call->checked_type_.defined()) {
       return call;
     }
@@ -523,12 +523,11 @@ Expr BlockBuilderNode::Normalize(const Expr& expr) {
       auto inferred_type = InferType(call, this->diag_ctx_);
       call->checked_type_ = inferred_type;
     }
-
     return call;
   } else if (normalized.as<TupleNode>()) {
     Tuple tuple = Downcast<Tuple>(normalized);
 
-    // only do shape/type inference if the tuple does not have shape/type
+    // only do shape/type inference if the Tuple does not have shape/type
     if (tuple->shape_ && tuple->checked_type_.defined()) {
       return tuple;
     }
@@ -560,10 +559,10 @@ Expr BlockBuilderNode::Normalize(const Expr& expr) {
         tuple->checked_type_ = TupleType(tuple_type);
       }
     }
-
     return tuple;
   } else if (normalized.as<TupleGetItemNode>()) {
     TupleGetItem node = Downcast<TupleGetItem>(normalized);
+
     // only do shape/type inference if the TupleGetItem does not have shape/type
     if (node->shape_ && node->checked_type_.defined()) {
       return node;
@@ -580,11 +579,11 @@ Expr BlockBuilderNode::Normalize(const Expr& expr) {
         node->checked_type_ = type->fields[node->index];
       }
     }
-
     return node;
   } else if (normalized.as<ConstantNode>()) {
     Constant constant = Downcast<Constant>(normalized);
-    // only do shape/type inference if the TupleGetItem does not have shape/type
+
+    // only do shape/type inference if the Constant does not have shape/type
     if (constant->shape_ && constant->checked_type_.defined()) {
       return constant;
     }
@@ -603,12 +602,11 @@ Expr BlockBuilderNode::Normalize(const Expr& expr) {
       Type type = relax::DynTensorType(shape_tuple.size(), dtype);
       constant->checked_type_ = type;
     }
-
     return constant;
   } else if (normalized.as<FunctionNode>()) {
     Function func = Downcast<Function>(normalized);
 
-    // only do shape/type inference if the function does not have shape/type
+    // only do shape/type inference if the Function does not have shape/type
     if (func->shape_ && func->checked_type_.defined()) {
       return func;
     }
@@ -620,11 +618,11 @@ Expr BlockBuilderNode::Normalize(const Expr& expr) {
     if (!func->checked_type_.defined() && func->body->checked_type_.defined()) {
       func->checked_type_ = func->body->checked_type_;
     }
-
     return func;
   } else if (normalized.as<SeqExprNode>()) {
     SeqExpr seq_expr = Downcast<SeqExpr>(normalized);
 
+    // only do shape/type inference if the SeqExpr does not have shape/type
     if (seq_expr->shape_ && seq_expr->checked_type_.defined()) {
       return seq_expr;
     }
@@ -636,7 +634,6 @@ Expr BlockBuilderNode::Normalize(const Expr& expr) {
     if (!seq_expr->checked_type_.defined() && seq_expr->body->checked_type_.defined()) {
       seq_expr->checked_type_ = seq_expr->body->checked_type_;
     }
-
     return seq_expr;
   }
   return normalized;

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -45,17 +45,6 @@ using namespace tvm::runtime;
 
 Constant::Constant(runtime::NDArray data, Span span) {
   ObjectPtr<ConstantNode> n = make_object<ConstantNode>();
-  auto shape_tuple = data.Shape();
-  Array<PrimExpr> values;
-  for (size_t dim = 0; dim < shape_tuple.size(); dim++) {
-    values.push_back(IntImm(DataType::Int(64), shape_tuple[dim]));
-  }
-  n->shape_ = relax::ShapeExpr(values);
-
-  DataType dtype = data.DataType();
-  Type type = relax::DynTensorType(shape_tuple.size(), dtype);
-  n->checked_type_ = type;
-
   n->data = std::move(data);
   n->virtual_device_ = VirtualDevice::FullyUnconstrained();
   n->span = std::move(span);

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -29,8 +29,9 @@ from tvm.script import tir as T, relax as R
 
 
 def check_shape(e, s):
-
-    if isinstance(e, relax.Call):
+    if isinstance(e, relax.ShapeExpr):
+        pass
+    elif isinstance(e, relax.Call):
         e = e.shape
     elif isinstance(e, relax.Expr):
         e = e.shape_
@@ -605,8 +606,10 @@ def test_class_irmodule():
         def j(y: Tensor[(n, n), _]) -> Tensor:
             with relax.dataflow():
                 gv = relax.call_tir(my_matmul, (y, y), (n, n), dtype="float32")
-                relax.output(gv)
-            return gv
+                gv1 = (gv, gv)
+                gv2 = gv1[1]
+                relax.output(gv2)
+            return gv2
 
         @R.function
         def h(x, y, z):
@@ -635,17 +638,40 @@ def test_class_irmodule():
     check_shape(gv_bind.value, ("n", "n"))
     check_shape(gv_bind.var, ("n", "n"))
 
-    # check function type
+    # check function type/shape
     assert j.checked_type.dtype == "float32"
     assert j.checked_type.rank == 2
-    # check function shape
     check_shape(j, ("n", "n"))
-    # check SeqExpr type
+
+    # check SeqExpr type/shape
     assert isinstance(j.body, relax.SeqExpr)
     assert j.body.checked_type.dtype == "float32"
     assert j.body.checked_type.rank == 2
-    # check SeqExpr shape
     check_shape(j.body, ("n", "n"))
+
+    # check tuple type/shape
+    gv1_bind = j.body.blocks[0].bindings[1]
+    isinstance(gv1_bind.value, relax.Tuple)
+    isinstance(gv1_bind.value.checked_type, relax.TupleType)
+    isinstance(gv1_bind.var.checked_type, relax.TupleType)
+    assert gv1_bind.var.checked_type.fields[0].rank == 2
+    assert gv1_bind.var.checked_type.fields[0].dtype == "float32"
+    isinstance(gv1_bind.var.shape, relax.Tuple)
+    isinstance(gv1_bind.value.shape, relax.Tuple)
+    check_shape(gv1_bind.value.shape.fields[0], ("n", "n"))
+    check_shape(gv1_bind.value.shape.fields[1], ("n", "n"))
+    check_shape(gv1_bind.var.shape.fields[0], ("n", "n"))
+    check_shape(gv1_bind.var.shape.fields[1], ("n", "n"))
+
+    # check TupleGetItem type/shape
+    gv2_bind = j.body.blocks[0].bindings[2]
+    isinstance(gv2_bind.value, relax.TupleGetItem)
+    assert gv2_bind.value.checked_type.rank == 2
+    assert gv2_bind.value.checked_type.dtype == "float32"
+    assert gv2_bind.var.checked_type.rank == 2
+    assert gv2_bind.var.checked_type.dtype == "float32"
+    check_shape(gv2_bind.value.shape, ("n", "n"))
+    check_shape(gv2_bind.var, ("n", "n"))
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -635,6 +635,18 @@ def test_class_irmodule():
     check_shape(gv_bind.value, ("n", "n"))
     check_shape(gv_bind.var, ("n", "n"))
 
+    # check function type
+    assert j.checked_type.dtype == "float32"
+    assert j.checked_type.rank == 2
+    # check function shape
+    check_shape(j, ("n", "n"))
+    # check SeqExpr type
+    assert isinstance(j.body, relax.SeqExpr)
+    assert j.body.checked_type.dtype == "float32"
+    assert j.body.checked_type.rank == 2
+    # check SeqExpr shape
+    check_shape(j.body, ("n", "n"))
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -638,10 +638,10 @@ def test_class_irmodule():
     check_shape(gv_bind.value, ("n", "n"))
     check_shape(gv_bind.var, ("n", "n"))
 
-    # check function type/shape
-    assert j.checked_type.dtype == "float32"
-    assert j.checked_type.rank == 2
-    check_shape(j, ("n", "n"))
+    # check function type
+    assert isinstance(j.checked_type, relax.FuncType)
+    assert j.checked_type.ret_type.dtype == "float32"
+    assert j.checked_type.ret_type.rank == 2
 
     # check SeqExpr type/shape
     assert isinstance(j.body, relax.SeqExpr)

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -322,7 +322,7 @@ def test_to_anf():
     @tvm.script.ir_module
     class TestToANFInputModule:
         @R.function
-        def f(x: Tensor[(_), "float32"]):
+        def f(x: Tensor[_, "float32"]):
             gv = relax.add(x, x)
             gv1 = relax.add(gv, gv)
             gv2 = relax.add(gv, gv1)

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -319,27 +319,18 @@ def test_vm_shape_lowering_func_param_with_shape():
 
 
 def test_to_anf():
-    x = relax.Var("x", type_annotation=relax.DynTensorType())
-    gv = relax.op.add(x, x)
-    gv1 = relax.op.add(gv, gv)
-    gv2 = relax.op.add(gv, gv1)
-    body = relax.Tuple([gv, gv2])
-    gvar = relax.GlobalVar("f")
-    func = relax.Function([x], body, None, gvar)
-
-    mod: tvm.IRModule = tvm.IRModule({gvar: func})
-    new_mod = relax.transform.ToANF()(mod)
-
     @tvm.script.ir_module
-    class TestToANFExpected:
+    class TestToANFInputModule:
         @R.function
-        def f(x: Tensor[_, "float32"]):
+        def f(x: Tensor[(_), "float32"]):
             gv = relax.add(x, x)
             gv1 = relax.add(gv, gv)
             gv2 = relax.add(gv, gv1)
             return (gv, gv2)
 
-    assert_structural_equal(new_mod, TestToANFExpected, map_free_vars=True)
+    before_mod = TestToANFInputModule
+    after_mod = relax.transform.ToANF()(before_mod)
+    assert_structural_equal(before_mod, after_mod, map_free_vars=True)
 
 
 def test_to_anf_no_op():


### PR DESCRIPTION
Currently the BlockBuilder::Normalize only deduces the `shape_` and `checked_type_` for `CallNode`. This PR adds the shape and type deduction for other Expr such as ConstantNode, TupleNode, TupleGetItemNode, FunctionNode, SeqExpr, so that their `checked_type_` and `shape_` will be automatically filled during transformations.

shape of some Expr (likewise the checked type):
```python
SeqExpr->shape_ = SeqExpr->body->shape_
Tuple->shape_ = Tuple(field->shape_ for field in Tuple->fields)
TupleGetItem->shape_ = Tuple->shape_[Tuple->index]
Constant->shape_ = Constant->data.shape

# the shape_ of Function is left as null for now to be consistent with function->check_typed_ 
# is not func->body->checked_type, we can always query func->body->shape_
Function->shape_ = null
Function->checked_type = FuncType(param_types, ret_type)
```

We previously changed the constructor of `relay::Constant` to fill its shape/type, this PR changes it back. So now we have a unified place(BlockBuilder::Normalize) to fill shape/type for relax expressions.

The shape and type deduction logic are all moved into Normalizer.

cc: @Hzfengsy @yongwww @psrivas2 