### PR TITLE
Add a new Expr derived class to represent runtime dependent shapes

### DIFF
--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -101,6 +101,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
   virtual R VisitExpr_(const VarNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const DataflowVarNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const ShapeExprNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
+  virtual R VisitExpr_(const RuntimeDepShapeNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const ExternFuncNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const GlobalVarNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const FunctionNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
@@ -124,6 +125,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     RELAX_EXPR_FUNCTOR_DISPATCH(VarNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(DataflowVarNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(ShapeExprNode);
+    RELAX_EXPR_FUNCTOR_DISPATCH(RuntimeDepShapeNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(ExternFuncNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(GlobalVarNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(FunctionNode);
@@ -153,6 +155,7 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
   void VisitExpr_(const VarNode* op) override;
   void VisitExpr_(const DataflowVarNode* op) override;
   void VisitExpr_(const ShapeExprNode* op) override;
+  void VisitExpr_(const RuntimeDepShapeNode* op) override;
   void VisitExpr_(const ExternFuncNode* op) override;
   void VisitExpr_(const GlobalVarNode* op) override;
   void VisitExpr_(const FunctionNode* op) override;
@@ -213,6 +216,7 @@ class ExprMutator : public ExprFunctor<Expr(const Expr&)> {
   Expr VisitExpr_(const VarNode* op) override;
   Expr VisitExpr_(const DataflowVarNode* op) override;
   Expr VisitExpr_(const ShapeExprNode* op) override;
+  Expr VisitExpr_(const RuntimeDepShapeNode* op) override;
   Expr VisitExpr_(const ExternFuncNode* op) override;
   Expr VisitExpr_(const GlobalVarNode* op) override;
   Expr VisitExpr_(const FunctionNode* op) override;

--- a/include/tvm/relax/ir_functor.h
+++ b/include/tvm/relax/ir_functor.h
@@ -80,6 +80,7 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
   virtual R VisitNode_(const relax::VarNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::DataflowVarNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::ShapeExprNode* op, Args... args) IR_FUNCTOR_DEFAULT;
+  virtual R VisitNode_(const relax::RuntimeDepShapeNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::MatchShapeNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::VarBindingNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::BindingBlockNode* op, Args... args) IR_FUNCTOR_DEFAULT;
@@ -106,6 +107,7 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
     RELAX_IR_FUNCTOR_DISPATCH(relax::VarNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::DataflowVarNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::ShapeExprNode);
+    RELAX_IR_FUNCTOR_DISPATCH(relax::RuntimeDepShapeNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::MatchShapeNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::VarBindingNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::BindingBlockNode);

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -41,6 +41,7 @@ BindingBlock = expr.BindingBlock
 DataflowBlock = expr.DataflowBlock
 SeqExpr = expr.SeqExpr
 ShapeExpr = expr.ShapeExpr
+RuntimeDepShape = expr.RuntimeDepShape
 Tuple = expr.Tuple
 TupleGetItem = expr.TupleGetItem
 Function = expr.Function

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -58,6 +58,14 @@ def make_shape(shape: List[PrimExpr]) -> ShapeExpr:
     raise ValueError("Wrong type")
 
 
+@tvm._ffi.register_object("relax.expr.RuntimeDepShape")
+class RuntimeDepShape(Expr):
+    """A shape expression which allows users to construct a runtime dependent shape."""
+
+    def __init__(self, span: Span = None) -> None:
+        self.__init_handle_by_constructor__(_ffi_api.RuntimeDepShape, span)
+
+
 @tvm._ffi.register_object("relax.expr.Var")
 class Var(Expr):
     """The variable class for all Relax bindings."""

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -280,7 +280,14 @@ class RelaxTransformer(Transformer):
                 shape, dtype, rank = None, None, -1
 
                 # parse the shape annotation
-                if isinstance(shape_annotation, ast.TypeVar):
+                if isinstance(shape_annotation, ast.TypeConstant):
+                    if shape_annotation.value != "RuntimeDepShape":
+                        self.report_error(
+                            "invalid shape annotation",
+                            shape_annotation.span,
+                        )
+                    shape = relax.RuntimeDepShape(span=self.to_tvm_span(shape_annotation.span))
+                elif isinstance(shape_annotation, ast.TypeVar):
                     if shape_annotation.id.name != "_":
                         # TODO(@altanh): handle variable annotations, e.g. x: Tensor[my_shape, _]
                         self.report_error(

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -230,6 +230,13 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::ShapeExprNode* op) {
   return doc;
 }
 
+Doc RelaxScriptPrinter::VisitNode_(const relax::RuntimeDepShapeNode* op) {
+  Doc doc;
+
+  doc << "\"RuntimeDepShape\"";
+  return doc;
+}
+
 Doc RelaxScriptPrinter::VisitNode_(const relax::MatchShapeNode* op) {
   Doc doc;
   if (op->var.defined()) {

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -277,6 +277,7 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   Doc VisitNode_(const relax::VarNode* op) override;
   Doc VisitNode_(const relax::DataflowVarNode* op) override;
   Doc VisitNode_(const relax::ShapeExprNode* op) override;
+  Doc VisitNode_(const relax::RuntimeDepShapeNode* op) override;
   Doc VisitNode_(const relax::MatchShapeNode* op) override;
   Doc VisitNode_(const relax::VarBindingNode* op) override;
   Doc VisitNode_(const relax::BindingBlockNode* op) override;
@@ -585,7 +586,8 @@ class TextPrinter {
                 node->IsInstance<tir::StmtNode>())) {
       doc << tir_text_printer_.Print(node);
     } else if (node.defined() && (node->IsInstance<relax::FunctionNode>() ||
-                                  node->IsInstance<relax::ShapeExprNode>())) {
+                                  node->IsInstance<relax::ShapeExprNode>() ||
+                                  node->IsInstance<relax::RuntimeDepShapeNode>())) {
       doc << relax_text_printer_.Print(node);
     } else {
       doc << relay_text_printer_.PrintFinal(node);

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -86,6 +86,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   RELAX_EXPR_NORMALIZER_LEAF(VarNode);
   RELAX_EXPR_NORMALIZER_LEAF(DataflowVarNode);
   RELAX_EXPR_NORMALIZER_LEAF(ShapeExprNode);
+  RELAX_EXPR_NORMALIZER_LEAF(RuntimeDepShapeNode);
   RELAX_EXPR_NORMALIZER_LEAF(ExternFuncNode);
   RELAX_EXPR_NORMALIZER_LEAF(GlobalVarNode);
   RELAX_EXPR_NORMALIZER_LEAF(OpNode);
@@ -408,8 +409,8 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     // NB: tuples are treated as leaf nodes for ergonomics
     // TODO(@altanh, @yuchen): remove TupleNode from leaf
     return expr.as<VarNode>() || expr.as<GlobalVarNode>() || expr.as<ConstantNode>() ||
-           expr.as<ShapeExprNode>() || expr.as<ExternFuncNode>() || expr.as<OpNode>() ||
-           expr.as<TupleNode>();
+           expr.as<ShapeExprNode>() || expr.as<RuntimeDepShapeNode>() ||
+           expr.as<ExternFuncNode>() || expr.as<OpNode>() || expr.as<TupleNode>();
   }
 
   Expr VisitWithNewScope(const Expr& expr) {

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -48,6 +48,18 @@ TVM_REGISTER_GLOBAL("relax.ShapeExpr").set_body_typed([](Array<PrimExpr> values,
   return ShapeExpr(values, span);
 });
 
+TVM_REGISTER_NODE_TYPE(RuntimeDepShapeNode);
+
+RuntimeDepShape::RuntimeDepShape(Span span) {
+  ObjectPtr<RuntimeDepShapeNode> n = make_object<RuntimeDepShapeNode>();
+  n->span = span;
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_GLOBAL("relax.RuntimeDepShape").set_body_typed([](Span span) {
+  return RuntimeDepShape(span);
+});
+
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     .set_dispatch<ShapeExprNode>([](const ObjectRef& ref, ReprPrinter* p) {
       const ShapeExprNode* node = static_cast<const ShapeExprNode*>(ref.get());

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -102,6 +102,8 @@ void ExprVisitor::VisitExpr_(const TupleGetItemNode* op) {
 
 void ExprVisitor::VisitExpr_(const ShapeExprNode* op) { this->VisitSpan(op->span); }
 
+void ExprVisitor::VisitExpr_(const RuntimeDepShapeNode* op) { this->VisitSpan(op->span); }
+
 void ExprVisitor::VisitExpr_(const ExternFuncNode* op) { this->VisitSpan(op->span); }
 
 void ExprVisitor::VisitExpr_(const SeqExprNode* op) {
@@ -333,6 +335,8 @@ Expr ExprMutator::VisitExpr_(const TupleGetItemNode* get_item) {
 }
 
 Expr ExprMutator::VisitExpr_(const ShapeExprNode* op) { return GetRef<Expr>(op); }
+
+Expr ExprMutator::VisitExpr_(const RuntimeDepShapeNode* op) { return GetRef<Expr>(op); }
 
 Expr ExprMutator::VisitExpr_(const ExternFuncNode* op) { return GetRef<Expr>(op); }
 

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -314,5 +314,10 @@ def test_shapeexpr():
     assert x.__str__() == "(10, 5)"
 
 
+def test_runtime_dep_shape():
+    x = relax.RuntimeDepShape()
+    assert x.__str__() == '"RuntimeDepShape"'
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Sometimes shape of a tensor cannot be deduced at compile time, either because the shape is truly data dependent (for example output of `Unique` operation) or because of limitations of shape inference capability of the compiler. Such shapes can now be represented as `RuntimeDepShapeExpr`. 

This is used to distinguish between the case when the shape has not been deduced (`shape_ == nullptr`) vs. shape is runtime dependent (`shape_` is an instance of `RuntimeDepShapeExpr`).

This addresses the concern in [thread](https://github.com/tlc-pack/relax/issues/88#issuecomment-1075729367).
