### PR TITLE
Temporary remove function type deduction in normalizer.

### DIFF
--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -144,20 +144,10 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
       func = Function(op->name, op->params, new_body, op->ret_type);
     }
 
-    // only do shape/type inference if the Function does not have shape/type
-    if (func->shape_ && func->checked_type_.defined()) {
-      return func;
-    }
-
-    // Note: the shape_ of Function is left as Null for now, to be consitent with
-    // Function->checked_type_, which is a FuncType
-    if (!func->checked_type_.defined() && func->body->checked_type_.defined()) {
-      Array<Type> param_types;
-      for (auto param : func->params) {
-        param_types.push_back(param->checked_type_);
-      }
-      func->checked_type_ = FuncType(param_types, func->body->checked_type_, {}, {});
-    }
+    // NOTE: the shape_ of Function is left as null for now, to be consitent with
+    // Skip the deduction of function type of a function
+    // as the function type needs to be annotated in certain cases(mutual function call)
+    // TODO(tvm-team) deduce function's type in construction time.
     return func;
   }
 

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -510,9 +510,7 @@ Var ExprMutator::VisitVarDef_(const VarNode* var) {
 }
 
 Expr ExprMutator::VisitExpr(const Expr& expr) {
-  Expr res = ExprFunctor::VisitExpr(expr);
-  if (res.same_as(expr)) return res;
-  return builder_->Normalize(res);
+  return builder_->Normalize(ExprFunctor::VisitExpr(expr));
 }
 
 void ExprMutator::VisitBinding(const Binding& binding) {

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -510,7 +510,9 @@ Var ExprMutator::VisitVarDef_(const VarNode* var) {
 }
 
 Expr ExprMutator::VisitExpr(const Expr& expr) {
-  return builder_->Normalize(ExprFunctor::VisitExpr(expr));
+  Expr res = ExprFunctor::VisitExpr(expr);
+  if (res.same_as(expr)) return res;
+  return builder_->Normalize(res);
 }
 
 void ExprMutator::VisitBinding(const Binding& binding) {

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -639,9 +639,9 @@ def test_class_irmodule():
     check_shape(gv_bind.var, ("n", "n"))
 
     # check function type
-    assert isinstance(j.checked_type, relax.FuncType)
-    assert j.checked_type.ret_type.dtype == "float32"
-    assert j.checked_type.ret_type.rank == 2
+    # assert isinstance(j.checked_type, relax.FuncType)
+    # assert j.checked_type.ret_type.dtype == "float32"
+    # assert j.checked_type.ret_type.rank == 2
 
     # check SeqExpr type/shape
     assert isinstance(j.body, relax.SeqExpr)


### PR DESCRIPTION
This PR temporary removes the function type deduction in normalizer
to unblock some of the followup passes that needs to check function
type equality.

Function's checked_type_ are left as nullptr for now.
We should followup to add function type deduction from annotations.