### PR TITLE
[AST] Remove type annotation from Var.

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -126,8 +126,6 @@ class VarNode : public ExprNode {
   /*! \brief The identifier of the variable, which is used for comparing stable equality across
    * transformations. */
   Id vid;
-  /*! \brief The type annotation, used by binding sites and parameter declarations. */
-  runtime::Optional<Type> type_annotation;
 
   /*! \return The name hint of the variable */
   const String& name_hint() const { return vid->name_hint; }
@@ -135,20 +133,18 @@ class VarNode : public ExprNode {
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("_checked_type_", &checked_type_);
     v->Visit("vid", &vid);
-    v->Visit("type_annotation", &type_annotation);
     v->Visit("span", &span);
     v->Visit("shape_", &shape_);
   }
 
   bool SEqualReduce(const VarNode* other, SEqualReducer equal) const {
     equal->MarkGraphNode();
-    return equal(vid, other->vid) && equal(type_annotation, other->type_annotation) &&
-           equal(checked_type_, other->checked_type_) && equal(shape_, other->shape_);
+    return equal(vid, other->vid) && equal(checked_type_, other->checked_type_) &&
+           equal(shape_, other->shape_);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
     hash_reduce(vid);
-    hash_reduce(type_annotation);
     hash_reduce(shape_);
     hash_reduce(checked_type_);
   }
@@ -179,7 +175,6 @@ class DataflowVarNode : public VarNode {
  public:
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("vid", &vid);
-    v->Visit("type_annotation", &type_annotation);
     v->Visit("span", &span);
     v->Visit("shape_", &shape_);
     v->Visit("_checked_type_", &checked_type_);
@@ -187,13 +182,12 @@ class DataflowVarNode : public VarNode {
 
   bool SEqualReduce(const DataflowVarNode* other, SEqualReducer equal) const {
     equal->MarkGraphNode();
-    return equal(vid, other->vid) && equal(type_annotation, other->type_annotation) &&
-           equal(shape_, other->shape_) && equal(checked_type_, other->checked_type_);
+    return equal(vid, other->vid) && equal(shape_, other->shape_) &&
+           equal(checked_type_, other->checked_type_);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
     hash_reduce(vid);
-    hash_reduce(type_annotation);
     hash_reduce(shape_);
     hash_reduce(checked_type_);
   }

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -84,10 +84,10 @@ class BlockBuilder(Object):
 
         m = tir.Var("m", "int32")
         n = tir.Var("n", "int32")
-        dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-        dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-        x = rx.Var("x", [m, n], dtype0)
-        y = rx.Var("y", [n], dtype1)
+        type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+        type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+        x = rx.Var("x", [m, n], type_anno0)
+        y = rx.Var("y", [n], type_anno1)
         bb = rx.BlockBuilder()
         with bb.function([x, y], "func"):
             with bb.dataflow() as df:

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -506,9 +506,6 @@ Doc RelaxScriptPrinter::PrintVarAnnotation(const relax::Var& var) {
   // TODO(@altanh): we should consider moving annotation into binding
   Doc doc;
   Type annotation = var->checked_type_;
-  if (!annotation.defined()) {
-    annotation = var->type_annotation.value_or(Type());
-  }
   if (annotation.defined()) {
     doc << ": ";
     if (const relax::DynTensorTypeNode* tty = annotation.as<relax::DynTensorTypeNode>()) {

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -79,9 +79,8 @@ Var::Var(Id vid, Optional<Expr> shape_annotation, Optional<Type> type_annotation
   ObjectPtr<VarNode> n = make_object<VarNode>();
   n->vid = std::move(vid);
   n->shape_ = std::move(shape_annotation);
-  n->type_annotation = std::move(type_annotation);
-  if (n->type_annotation) {
-    n->checked_type_ = n->type_annotation.value();
+  if (type_annotation) {
+    n->checked_type_ = std::move(type_annotation.value());
   }
   n->span = std::move(span);
   data_ = std::move(n);
@@ -100,9 +99,8 @@ DataflowVar::DataflowVar(Id vid, Optional<Expr> shape_annotation, Optional<Type>
   ObjectPtr<DataflowVarNode> n = make_object<DataflowVarNode>();
   n->vid = std::move(vid);
   n->shape_ = std::move(shape_annotation);
-  n->type_annotation = std::move(type_annotation);
-  if (n->type_annotation) {
-    n->checked_type_ = n->type_annotation.value();
+  if (type_annotation) {
+    n->checked_type_ = std::move(type_annotation.value());
   }
   n->span = std::move(span);
   data_ = std::move(n);
@@ -193,6 +191,10 @@ Function::Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr bo
                    Span span) {
   ObjectPtr<FunctionNode> n = make_object<FunctionNode>();
   n->name = std::move(name);
+  for (Var param : params) {
+    ICHECK(param->checked_type_.defined())
+        << "The checked_type_ of Function parameters must be filled.";
+  }
   n->params = std::move(params);
   n->body = std::move(body);
   n->ret_type = std::move(ret_type);

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -24,10 +24,10 @@ from tvm.ir import structural_equal
 def test_dispatch_var():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    v0 = rx.Var("v0", [m, n], dtype0)
-    v1 = rx.DataflowVar("v1", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    v0 = rx.Var("v0", [m, n], type_anno0)
+    v1 = rx.DataflowVar("v1", [n], type_anno1)
     t = None
 
     def fvisit(e):
@@ -43,10 +43,10 @@ def test_dispatch_var():
 def test_post_order_visit():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     ib = rx.BlockBuilder()
     with ib.function("func", [x, y]):
         with ib.dataflow() as df:

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -37,10 +37,10 @@ def nop():
 def test_block_builder():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
 
     bb._begin_binding_block()
@@ -64,10 +64,10 @@ def test_block_builder():
 def test_function_single_block():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
 
     with bb.function("func", [x, y]):
@@ -95,10 +95,10 @@ def test_function_single_block():
 def test_function_multi_blocks():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
 
     with bb.function("func", [x, y]):
@@ -133,10 +133,10 @@ def test_function_multi_blocks():
 def test_multi_functions():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
 
     with bb.function("func1", [x, y]):
@@ -171,12 +171,12 @@ def test_binary_shape_type_deduction():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
     k = tir.Var("k", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, 1], dtype0)
-    y = rx.Var("y", [n], dtype1)
-    z = rx.Var("z", [5], dtype1)
-    w = rx.Var("w", [k], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, 1], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
+    z = rx.Var("z", [5], type_anno1)
+    w = rx.Var("w", [k], type_anno1)
     bb = rx.BlockBuilder()
 
     with bb.function("func", [x, y, z, w]):
@@ -260,10 +260,10 @@ def test_emit_match_shape():
 def test_normalize():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
 
     add_call = rx.op.multiply(x, y)
@@ -485,10 +485,10 @@ def test_emit_tuple_get_item():
 def test_nested_function_fail():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
 
     with pytest.raises(RuntimeError):
@@ -502,10 +502,10 @@ def test_nested_function_fail():
 def test_emit_func_output_twice_fail():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
 
     with pytest.raises(RuntimeError):
@@ -518,10 +518,10 @@ def test_emit_func_output_twice_fail():
 def test_func_params_twice_fail():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
 
     with pytest.raises(RuntimeError):
@@ -533,10 +533,10 @@ def test_func_params_twice_fail():
 def test_no_func_params_fail():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = rx.DynTensorType(rank=2, dtype="float16")
-    dtype1 = rx.DynTensorType(rank=1, dtype="float16")
-    x = rx.Var("x", [m, n], dtype0)
-    y = rx.Var("y", [n], dtype1)
+    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    x = rx.Var("x", [m, n], type_anno0)
+    y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
 
     with pytest.raises(RuntimeError):

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -25,28 +25,28 @@ def test_var() -> None:
     v0 = rx.Var("v0")
     assert v0.name_hint == "v0"
     assert v0.shape_ is None
-    assert v0.type_annotation is None
+    assert v0._checked_type_ is None
     shape_anno = [54, 96]
     type_anno = rx.DynTensorType(2, "float32")
     v1 = rx.Var("v1", shape_anno, type_anno)
     assert v1.name_hint == "v1"
     for s0, s1 in zip(v1.shape_, shape_anno):
         assert s0 == s1
-    assert v1.type_annotation == type_anno
+    assert v1._checked_type_ == type_anno
 
 
 def test_dataflow_var() -> None:
     v0 = rx.DataflowVar("v0")
     assert v0.name_hint == "v0"
     assert v0.shape_ is None
-    assert v0.type_annotation is None
+    assert v0._checked_type_ is None
     shape_anno = [54, 96]
     type_anno = rx.DynTensorType(2, "float16")
     v1 = rx.DataflowVar("v1", shape_anno, type_anno)
     assert v1.name_hint == "v1"
     for s0, s1 in zip(v1.shape_, shape_anno):
         assert s0 == s1
-    assert v1.type_annotation == type_anno
+    assert v1._checked_type_ == type_anno
     assert isinstance(v1, rx.DataflowVar)
 
 
@@ -138,7 +138,8 @@ def test_shape_expr() -> None:
 
 
 def test_func():
-    x = rx.Var("foo")
+    type_anno = rx.DynTensorType(2, "float32")
+    x = rx.Var("foo", type_annotation=type_anno)
     bindings = [rx.VarBinding(x, rx.const(1))]
     blocks = [rx.BindingBlock(bindings)]
     seqe = rx.SeqExpr(blocks, x)

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -56,12 +56,12 @@ def check_shape(e, s):
 
 
 def check_tensor_var(v, s, d, rank=None):
-    assert isinstance(v.type_annotation, relax.ty.DynTensorType)
-    assert v.type_annotation.dtype == d
+    assert isinstance(v._checked_type_, relax.ty.DynTensorType)
+    assert v._checked_type_.dtype == d
     if isinstance(s, (list, tuple)):
-        assert v.type_annotation.rank == len(s)
+        assert v._checked_type_.rank == len(s)
     if rank is not None:
-        assert v.type_annotation.rank == rank
+        assert v._checked_type_.rank == rank
     check_shape(v, s)
 
 
@@ -101,8 +101,8 @@ def test_annotations():
     check_tensor_var(z, (32, "k"), "float32")
     check_tensor_var(w, None, "")
     check_tensor_var(q, None, "", rank=2)
-    assert t.type_annotation is None
-    assert isinstance(sh.type_annotation, relax.ty.ShapeType)
+    assert t._checked_type_ is None
+    assert isinstance(sh._checked_type_, relax.ty.ShapeType)
 
     check_call(mm, "nn.matmul", [x, y])
     check_call(mul, "multiply", [z, z])
@@ -260,8 +260,8 @@ def test_tuple():
     t_bind = f.body.blocks[0].bindings[0]
     t, tup = t_bind.var, t_bind.value
 
-    assert isinstance(t.type_annotation, relay.TupleType)
-    annot = t.type_annotation
+    annot = t._checked_type_
+    assert isinstance(annot, relay.TupleType)
     assert isinstance(annot.fields[0], relax.ty.DynTensorType) and annot.fields[0].dtype == ""
     assert (
         isinstance(annot.fields[1], relax.ty.DynTensorType) and annot.fields[1].dtype == "float32"
@@ -629,7 +629,7 @@ def test_class_irmodule():
             return gv2
 
         @R.function
-        def h(x, y, z):
+        def h(x: Tensor[(n, n), _], y: Tensor[(n, n), _], z: Tensor[(n, n), _]) -> Tensor:
             _ = my_matmul(x, y, z)
             return z
 

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -296,7 +296,7 @@ def test_class_irmodule():
             return relax.call_tir(my_matmul, (y, y), (n, n), dtype="float32")
 
         @R.function
-        def h(x, y, z):
+        def h(x: Tensor[(n, n), _], y: Tensor[(n, n), _], z: Tensor[(n, n), _]) -> Tensor:
             _ = my_matmul(x, y, z)
             return z
 

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -31,10 +31,10 @@ from tvm.script import tir as T, relax as R
 def test_fma_rewrite():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    dtype0 = relax.DynTensorType(rank=2, dtype="float16")
-    dtype1 = relax.DynTensorType(rank=2, dtype="float16")
-    x = relax.Var("x", [m, n], dtype0)
-    y = relax.Var("y", [m, n], dtype1)
+    type_anno0 = relax.DynTensorType(rank=2, dtype="float16")
+    type_anno1 = relax.DynTensorType(rank=2, dtype="float16")
+    x = relax.Var("x", [m, n], type_anno0)
+    y = relax.Var("y", [m, n], type_anno1)
     ib = relax.BlockBuilder()
     with ib.function("func", [x, y]):
         with ib.dataflow() as df:


### PR DESCRIPTION
This PR removes `type_annotation` field in `relax::VarNode`, which was used to store the user-provided type annotation.

The reasons for removing it as discussed in #105 and in the Relax open dev meeting:
R0. It stores duplicated type information with`checked_type_`;
R1. It can confuses pass writers: people don't know if they should visit `checked_type_` or `type_annotation` when visiting a Var.

For most cases in Relax, a VarNode is defined on the lhs of binding, where its `checked_type_` should be deduced from the rhs, so `type_annotation` is not quite useful; when a VarNode is defined as the parameter of `relax::FunctionNode`, we can use `checked_type_` to store the type information, and do the check in the constructor of FunctionNode to ensure its parameters' `checked_type_` are all filled (as this pr does).

cc: @yongwww @ZihengJiang @hypercubestart 

