### PR TITLE
[Printer][Parser] Deprecate `[]` in favor `()` in Tensor annotation.

### DIFF
--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -433,7 +433,7 @@ class BlockBuilder(Object):
                             compute[i, j] = rxplaceholder[i, j] + rxplaceholder_1[i, j]
 
                 @R.function
-                def rx_func(x: Tensor[(n, m), "float32"], y: Tensor[(n, m), "float32"]) -> Tensor:
+                def rx_func(x: Tensor((n, m), "float32"), y: Tensor((n, m), "float32")) -> Tensor:
                     # block 0
                     gv = relax.call_tir("te_func", (x, y), (128, 128), dtype="float32")
                     return gv
@@ -480,8 +480,8 @@ class BlockBuilder(Object):
                             compute[i] = rxplaceholder[i]
 
                 @R.function
-                def rx_func(x: Tensor[(n,), "float32"], y: Tensor[((n + 1),), "float32"])
-                    -> Tensor[_, "float32"]:
+                def rx_func(x: Tensor((n,), "float32"), y: Tensor(((n + 1),), "float32"))
+                    -> Tensor(_, "float32"):
                     # block 0
                     gv = relax.call_tir(te_func, (y,), ((n + 1),), (n,), dtype="float32")
                     return gv

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -41,7 +41,7 @@ def call_tir(
         The input arguments.
 
     shape: Union[Tuple, ShapeExpr, List[int]]
-        The output shape. Tuple[ShapeExpr] if multiple outputs, ShapeExpr if single output.
+        The output shape. Tuple(ShapeExpr) if multiple outputs, ShapeExpr if single output.
 
     dtype: Union[str, List[str]]
         The output dtype. List[str] if multiple outputs, str if single output.

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -167,7 +167,7 @@ def build(mod: tvm.IRModule, target: tvm.target.Target) -> Executable:
     .. code-block:: python
         class InputModule:
             @R.function
-            def foo(x: Tensor[(3, 4), "float32"], y: Tensor[(3, 4), "float32"]):
+            def foo(x: Tensor((3, 4), "float32"), y: Tensor((3, 4), "float32")):
                 z = R.add(x, y)
                 return z
 

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -266,10 +266,10 @@ class RelaxTransformer(Transformer):
             self.report_error("unknown type in annotation", span)
 
         # annotation with type arguments/shape annotation
-        if isinstance(ty, ast.TypeApply):
+        if isinstance(ty, ast.TypeCall):
             if ty.func_name.id.name == "Tensor":
-                # TODO(@altanh): forgetting dtype like "Tensor[(n, m)]" ends up getting parsed as
-                #                Tensor[n, m] which makes correct errors difficult here...
+                # TODO(@altanh): forgetting dtype like "Tensor((n, m))" ends up getting parsed as
+                #                Tensor(n, m) which makes correct errors difficult here...
                 if len(ty.params) != 2:
                     self.report_error(
                         "Tensor type annotations must have 2 fields (shape and dtype)",
@@ -289,7 +289,7 @@ class RelaxTransformer(Transformer):
                     shape = relax.RuntimeDepShape(span=self.to_tvm_span(shape_annotation.span))
                 elif isinstance(shape_annotation, ast.TypeVar):
                     if shape_annotation.id.name != "_":
-                        # TODO(@altanh): handle variable annotations, e.g. x: Tensor[my_shape, _]
+                        # TODO(@altanh): handle variable annotations, e.g. x: Tensor(my_shape, _)
                         self.report_error(
                             "variable Tensor shape annotations not yet supported",
                             shape_annotation.span,

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -362,7 +362,7 @@ Doc RelaxScriptPrinter::VisitType_(const relax::DynTensorTypeNode* node) {
 
 Doc RelaxScriptPrinter::VisitType_(const relay::TupleTypeNode* node) {
   if (node->fields.empty()) {
-    return Doc::Text("Tuple[]");
+    return Doc::Text("Tuple()");
   }
 
   Doc doc;
@@ -371,7 +371,7 @@ Doc RelaxScriptPrinter::VisitType_(const relay::TupleTypeNode* node) {
   for (Type ty : node->fields) {
     fields.push_back(Print(ty));
   }
-  doc << "Tuple[" << Doc::Concat(fields) << "]";
+  doc << "Tuple(" << Doc::Concat(fields) << ")";
 
   return doc;
 }
@@ -522,7 +522,7 @@ Doc RelaxScriptPrinter::PrintVarAnnotation(const relax::Var& var) {
 Doc RelaxScriptPrinter::PrintTensorAnnotation(const relax::DynTensorType& ty,
                                               const Optional<ObjectRef>& shape) {
   Doc doc;
-  doc << "Tensor[";
+  doc << "Tensor(";
   if (shape.defined()) {
     doc << Print(Downcast<relay::Expr>(shape.value()));
   } else if (ty->rank != -1) {
@@ -542,14 +542,14 @@ Doc RelaxScriptPrinter::PrintTensorAnnotation(const relax::DynTensorType& ty,
   } else {
     doc << Doc::StrLiteral(runtime::DLDataType2String(ty->dtype));
   }
-  doc << "]";
+  doc << ")";
   return doc;
 }
 
 Doc RelaxScriptPrinter::PrintTupleAnnotation(const TupleType& ty,
                                              const Optional<ObjectRef>& shape) {
   Doc doc;
-  doc << "Tuple[";
+  doc << "Tuple";
   std::vector<Doc> fields;
   for (size_t i = 0; i < ty->fields.size(); i++) {
     if (shape) {
@@ -565,7 +565,7 @@ Doc RelaxScriptPrinter::PrintTupleAnnotation(const TupleType& ty,
       }
     }
   }
-  doc << "(" << Doc::Concat(fields, Doc::Text(", ")) << ")]";
+  doc << "(" << Doc::Concat(fields, Doc::Text(", ")) << ")";
   return doc;
 }
 

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -35,7 +35,7 @@ namespace relax {
 // CallTIRMutator
 // Perform explicit tensor allocation for call_tir.
 // Example:
-// lv0: Tensor[n, m] = rx.call_tir(func, (x), (n, m), dtype="float32")
+// lv0: Tensor(n, m) = rx.call_tir(func, (x), (n, m), dtype="float32")
 // -->
 // gv0 = rx.call("relax.builtin.alloc_tensor", [n, m], dtype="float32")
 // rx.call_packed(func, x, gv0)

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -65,7 +65,7 @@ class InputModule:
                 B[vi, vj] = T.max(A[vi, vj], 0.0)
 
     @R.function
-    def main(x:Tensor[(m,n), "float32"], w:Tensor[(n,k), "float32"]) -> Tensor:
+    def main(x:Tensor((m,n), "float32"), w:Tensor((n,k), "float32")) -> Tensor:
         with R.dataflow():
             sh = relax.call_packed("vm.builtin.shape_of", x)
             x0 = relax.match_shape(sh, (m, n))
@@ -151,7 +151,7 @@ def test_autotir(dev: str):
                     B[vi, vj] = T.max(A[vi, vj], 0.0)
 
         @R.function
-        def main(x: Tensor[(32, 32), "float32"], w: Tensor[(32, 32), "float32"]) -> Tensor:
+        def main(x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")) -> Tensor:
             with R.dataflow():
                 lv0 = R.call_tir(tir_matmul, (x, w), (32, 32), dtype="float32")
                 lv1 = R.call_tir(tir_relu, (lv0), (32, 32), dtype="float32")

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -225,8 +225,8 @@ def test_emit_match_shape():
 
     with bb.function("func", [x, y]):
         with bb.dataflow() as df:
-            # lv0: Tensor[(m, n), "float32"] =
-            #   match_shape(x: Tensor[_, "float32"], [m, n])
+            # lv0: Tensor((m, n), "float32") =
+            #   match_shape(x: Tensor(_, "float32"], [m, n))
             lv0 = bb.match_shape(x, [m, n])
             assert isinstance(lv0, rx.DataflowVar)
             assert lv0.shape[0] == m

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -63,8 +63,8 @@ def test_match_shape() -> None:
     assert b0.var is not None
     assert b0.var.checked_type == rx.ShapeType()
 
-    # var1: Tensor[(m, n), "float32"] =
-    #   match_shape(var0: Tensor[_, "float32"], [m, n])
+    # var1: Tensor((m, n), "float32") =
+    #   match_shape(var0: Tensor(_, "float32"), [m, n])
     type_anno0 = rx.DynTensorType(-1, "float32")
     value = rx.Var("value", type_annotation=type_anno0)
 

--- a/tests/python/relax/test_structual_equal_hash.py
+++ b/tests/python/relax/test_structual_equal_hash.py
@@ -117,7 +117,7 @@ def test_match_shape_symbolic():
     @tvm.script.ir_module
     class InputModule:
         @R.function
-        def f(x: Tensor[(_, _), "float32"]):
+        def f(x: Tensor((_, _), "float32")):
             x0 = R.match_shape(x, (n, m))
             return (x0, (n + 1, m))
 

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -32,7 +32,7 @@ def test_fma_rewrite():
     @tvm.script.ir_module
     class Before:
         @R.function
-        def main(x: Tensor[(m, n), "float32"], y: Tensor[(m, n), "float32"]):
+        def main(x: Tensor((m, n), "float32"), y: Tensor((m, n), "float32")):
             with relax.dataflow():
                 lv0 = relax.multiply(x, y)
                 gv0 = relax.add(lv0, y)
@@ -44,7 +44,7 @@ def test_fma_rewrite():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: Tensor[(m, n), "float32"], y: Tensor[(m, n), "float32"]):
+        def main(x: Tensor((m, n), "float32"), y: Tensor((m, n), "float32")):
             with relax.dataflow():
                 lv0 = relax.multiply(x, y)
                 gv0 = relax.ewise_fma(x, y, y)
@@ -65,7 +65,7 @@ def test_dataflowpass_fail():
         @tvm.script.ir_module
         class TestRemoveGlobalScopeVar:
             @R.function
-            def main(x: Tensor[_, "float32"], y: Tensor[_, "float32"]):
+            def main(x: Tensor(_, "float32"), y: Tensor(_, "float32")):
                 with relax.dataflow():
                     gv_remove = relax.add(x, y)
                     gv1 = relax.add(x, y)
@@ -79,7 +79,7 @@ def test_dataflowpass_fail():
         @tvm.script.ir_module
         class TestRewriteGlobalScopeVar:
             @R.function
-            def main(x: Tensor[_, "float32"], y: Tensor[_, "float32"]):
+            def main(x: Tensor(_, "float32"), y: Tensor(_, "float32")):
                 with relax.dataflow():
                     gv_rewrite = relax.add(x, y)
                     gv1 = relax.add(x, y)
@@ -95,7 +95,7 @@ def test_dataflowpass_fail():
         @tvm.script.ir_module
         class TestRewriteSymbolicVar:
             @R.function
-            def main(x: Tensor[_, "float32"], y: Tensor[_, "float32"]):
+            def main(x: Tensor(_, "float32"), y: Tensor(_, "float32")):
                 with relax.dataflow():
                     lv0 = R.match_shape(x, (m, n))
                     gv0 = relax.add(lv0, y)
@@ -109,7 +109,7 @@ def test_dataflowpass_fail():
         @tvm.script.ir_module
         class TestRemoveSymbolicVar:
             @R.function
-            def main(x: Tensor[_, "float32"], y: Tensor[_, "float32"]):
+            def main(x: Tensor(_, "float32"), y: Tensor(_, "float32")):
                 with relax.dataflow():
                     lv0 = R.match_shape(x, (m, n, d))
                     gv0 = relax.add(lv0, y)
@@ -123,7 +123,7 @@ def test_visit_shape():
     @tvm.script.ir_module
     class TestVisitShape:
         @R.function
-        def foo(x: Tensor[(m, n), "float32"]):
+        def foo(x: Tensor((m, n), "float32")):
             gv0 = R.add(x, x)
             return gv0
 
@@ -150,7 +150,7 @@ def test_to_non_dataflow():
     @tvm.script.ir_module
     class TestToNonDataflow:
         @R.function
-        def foo(x: Tensor[(m, n), "float32"]):
+        def foo(x: Tensor((m, n), "float32")):
             with relax.dataflow():
                 lv0 = relax.call_tir("test.op.identity", (x,), (m, n), dtype="float32")
                 gv0 = relax.call_tir("test.op.identity", (lv0,), (m, n), dtype="float32")
@@ -194,7 +194,7 @@ def test_call_tir_rewrite():
     @tvm.script.ir_module
     class TestCallTIRRewrite:
         @R.function
-        def foo(x: Tensor[(m, n), "float32"]):
+        def foo(x: Tensor((m, n), "float32")):
             gv0 = relax.call_tir("test.op.identity", (x,), (m, n), dtype="float32")
             return gv0
 
@@ -226,7 +226,7 @@ def test_vm_memory_lower():
     @tvm.script.ir_module
     class TestVMMemoryLower:
         @R.function
-        def foo(x: Tensor[(m, n), "float32"]):
+        def foo(x: Tensor((m, n), "float32")):
             alloc = relax.builtin.alloc_tensor((m, n), runtime_device_index=0, dtype="float32")
             _ = relax.call_packed("test.op.identity", (x,), alloc)
             gv0 = alloc
@@ -257,7 +257,7 @@ def test_vm_shape_lowering():
     @tvm.script.ir_module
     class TestVMShapeLower:
         @R.function
-        def foo(x: Tensor[_, "float32"]) -> Shape:
+        def foo(x: Tensor(_, "float32")) -> Shape:
             relax.match_shape(x, (n, m))
             return (n * 2, m * 3)
 
@@ -293,7 +293,7 @@ def test_vm_static_shape_lowering():
     @tvm.script.ir_module
     class TestVMStaticShapeLower:
         @R.function
-        def foo(x: Tensor[(2, 3), "float32"]) -> Tensor:
+        def foo(x: Tensor((2, 3), "float32")) -> Tensor:
             with relax.dataflow():
                 y = R.call_tir("test.vm.tile", (x), (2, 6), dtype="float32")
                 relax.output(y)
@@ -330,7 +330,7 @@ def test_vm_shape_lowering_func_param_with_shape():
                     C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
 
         @R.function
-        def foo(x: Tensor[(m, n), "float32"], w: Tensor[(n, k), "float32"]) -> Tensor:
+        def foo(x: Tensor((m, n), "float32"), w: Tensor((n, k), "float32")) -> Tensor:
             gv0 = R.call_tir(tir_matmul, (x, w), (m, k), dtype="float32")
             return gv0
 
@@ -372,7 +372,7 @@ def test_to_anf():
     @tvm.script.ir_module
     class TestToANFInputModule:
         @R.function
-        def f(x: Tensor[_, "float32"]):
+        def f(x: Tensor(_, "float32")):
             gv = relax.add(x, x)
             gv1 = relax.add(gv, gv)
             gv2 = relax.add(gv, gv1)
@@ -387,7 +387,7 @@ def test_to_anf_no_op():
     @tvm.script.ir_module
     class TestANFNoOp:
         @R.function
-        def foo(x: Tensor[(m, n), "float32"]):
+        def foo(x: Tensor((m, n), "float32")):
             with relax.dataflow():
                 lv0 = relax.call_tir("test.op.identity", (x,), (m, n), dtype="float32")
                 gv0 = relax.call_tir("test.op.identity", (lv0,), (m, n), dtype="float32")

--- a/tests/python/relax/test_transform_bind_params.py
+++ b/tests/python/relax/test_transform_bind_params.py
@@ -45,8 +45,8 @@ def test_bind_params():
 
         @R.function
         def main(
-            x: Tensor[(16, 16), "float32"], w: Tensor[(16, 16), "float32"]
-        ) -> Tensor[(16, 16), "float32"]:
+            x: Tensor((16, 16), "float32"), w: Tensor((16, 16), "float32")
+        ) -> Tensor((16, 16), "float32"):
             gv0 = R.call_tir(tir_matmul, (x, w), (16, 16), dtype="float32")
             return gv0
 

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -68,12 +68,12 @@ def test_one_fold_addone():
                     B[vi, vj] = A[vi, vj] + T.float32(1)
 
         @R.function
-        def before(c0: Tensor[(16, 16), "float32"]):
+        def before(c0: Tensor((16, 16), "float32")):
             lv0 = relax.call_tir(addone, (c0,), (16, 16), dtype="float32")
             return lv0
 
         @R.function
-        def expected(c1: Tensor[(16, 16), "float32"]):
+        def expected(c1: Tensor((16, 16), "float32")):
             lv0 = c1
             return c1
 
@@ -98,12 +98,12 @@ def test_one_fold_transpose():
                     B[vi, vj] = A[vj, vi]
 
         @R.function
-        def before(c0: Tensor[(2, 3), "float32"]):
+        def before(c0: Tensor((2, 3), "float32")):
             lv0 = relax.call_tir(func, (c0,), (3, 2), dtype="float32")
             return lv0
 
         @R.function
-        def expected(c1: Tensor[(3, 2), "float32"]):
+        def expected(c1: Tensor((3, 2), "float32")):
             lv0 = c1
             return c1
 
@@ -127,13 +127,13 @@ def test_two_hop_addone():
                     B[vi, vj] = A[vi, vj] + T.float32(1)
 
         @R.function
-        def before(c0: Tensor[(2, 2), "float32"]):
+        def before(c0: Tensor((2, 2), "float32")):
             lv0 = relax.call_tir(addone, (c0,), (2, 2), dtype="float32")
             lv1 = relax.call_tir(addone, (lv0,), (2, 2), dtype="float32")
             return lv1
 
         @R.function
-        def expected(c1: Tensor[(2, 2), "float32"], c2: Tensor[(2, 2), "float32"]):
+        def expected(c1: Tensor((2, 2), "float32"), c2: Tensor((2, 2), "float32")):
             lv0 = c1
             lv1 = c2
             return c2
@@ -159,14 +159,14 @@ def test_dataflow_fold():
                     B[vi, vj] = A[vi, vj]
 
         @R.function
-        def before(c0: Tensor[(16, 16), "float32"]):
+        def before(c0: Tensor((16, 16), "float32")):
             with R.dataflow():
                 gv0 = relax.call_tir(identity, (c0,), (16, 16), dtype="float32")
                 R.output(gv0)
             return gv0
 
         @R.function
-        def expected(c1: Tensor[(16, 16), "float32"]):
+        def expected(c1: Tensor((16, 16), "float32")):
             with R.dataflow():
                 gv0 = c1
                 R.output(gv0)
@@ -207,7 +207,7 @@ def test_fold_mixed_case():
                     C[vi, vj] = A[vi, vj] - B[vi, vj]
 
         @R.function
-        def before(c0: Tensor[(16, 16), "float32"], x: Tensor[(_, _), "float32"]):
+        def before(c0: Tensor((16, 16), "float32"), x: Tensor((_, _), "float32")):
             x0 = R.match_shape(x, (n, m))
             # this line cannot be folded because n is unknown
             lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
@@ -221,10 +221,10 @@ def test_fold_mixed_case():
 
         @R.function
         def expected(
-            c0: Tensor[(16, 16), "float32"],
-            c1: Tensor[(16, 16), "float32"],
-            c2: Tensor[(16, 16), "float32"],
-            x: Tensor[(_, _), "float32"],
+            c0: Tensor((16, 16), "float32"),
+            c1: Tensor((16, 16), "float32"),
+            c2: Tensor((16, 16), "float32"),
+            x: Tensor((_, _), "float32"),
         ):
             x0 = R.match_shape(x, (n, m))
             # this line cannot be folded because n is unknown
@@ -258,12 +258,12 @@ def test_int32_fold():
                     B[vi, vj] = A[vi, vj] + T.int32(1)
 
         @R.function
-        def before(c0: Tensor[(16, 16), "int32"]):
+        def before(c0: Tensor((16, 16), "int32")):
             lv0 = relax.call_tir(addone, (c0,), (16, 16), dtype="int32")
             return lv0
 
         @R.function
-        def expected(c1: Tensor[(16, 16), "int32"]):
+        def expected(c1: Tensor((16, 16), "int32")):
             lv0 = c1
             return c1
 

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -137,7 +137,7 @@ def test_vm_exec_serialize_export_library():
     @tvm.script.ir_module
     class TestVMMove:
         @R.function
-        def foo(x: Tensor[(3, 4), "float32"]):
+        def foo(x: Tensor((3, 4), "float32")):
             z = R.call_packed("vm.builtin.copy", x)
             return z
 
@@ -271,7 +271,7 @@ def test_vm_copy():
     @tvm.script.ir_module
     class TestVMMove:
         @R.function
-        def foo(x: Tensor[(3, 4), "float32"]):
+        def foo(x: Tensor((3, 4), "float32")):
             z = R.call_packed("vm.builtin.copy", x)
             return z
 
@@ -337,7 +337,7 @@ def test_vm_compile_if():
     @tvm.script.ir_module
     class TestVMCompileIf:
         @R.function
-        def ife(cond: Tensor[(), "bool"], x: Tensor[(3, 4), "float32"]):
+        def ife(cond: Tensor((), "bool"), x: Tensor((3, 4), "float32")):
             if cond:
                 w = relax.call_packed("test.vm.add", x, x)
             else:
@@ -359,7 +359,7 @@ def test_vm_compile_stage0():
     @tvm.script.ir_module
     class TestVMCompileStage0:
         @R.function
-        def foo(x: Tensor[(3, 4), "float32"], y: Tensor[(3, 4), "float32"]):
+        def foo(x: Tensor((3, 4), "float32"), y: Tensor((3, 4), "float32")):
             z = R.call_packed("test.vm.identity", x, y)
             return y
 
@@ -393,8 +393,8 @@ def test_vm_compile_stage1():
             H[3] = H[1] * T.int64(3)
 
         @R.function
-        def foo(x: Tensor[_, "float32"]) -> Shape:
-            shape_heap: Tensor[(4,), "int64"] = relax.call_packed(
+        def foo(x: Tensor(_, "float32")) -> Shape:
+            shape_heap: Tensor((4,), "int64") = relax.call_packed(
                 "vm.builtin.alloc_shape_heap", (4,)
             )
             gv0 = relax.call_packed("vm.builtin.shape_of", x)
@@ -419,7 +419,7 @@ def test_vm_compile_stage2():
     @tvm.script.ir_module
     class TestVMCompileStage2:
         @R.function
-        def foo(x: Tensor[_, "float32"]) -> Shape:
+        def foo(x: Tensor(_, "float32")) -> Shape:
             R.match_shape(x, (n, m))
             return (n * 2, m * 3)
 
@@ -439,7 +439,7 @@ def test_vm_compile_stage3():
     @tvm.script.ir_module
     class TestVMCompileStage3:
         @R.function
-        def foo(x: Tensor[(32, 16), "float32"]) -> Tensor:
+        def foo(x: Tensor((32, 16), "float32")) -> Tensor:
             with R.dataflow():
                 y = R.call_tir("test.vm.identity", (x), (32, 16), dtype="float32")
                 R.output(y)
@@ -460,7 +460,7 @@ def test_vm_compile_e2e():
     @tvm.script.ir_module
     class TestVMCompileE2E:
         @R.function
-        def foo(x: Tensor[_, "float32"]) -> Tensor:
+        def foo(x: Tensor(_, "float32")) -> Tensor:
             with R.dataflow():
                 R.match_shape(x, (n, m))
                 y = R.call_tir("test.vm.tile", (x), (n, m * 2), dtype="float32")
@@ -500,7 +500,7 @@ def test_vm_compile_e2e_func_param_with_shape():
                     C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
 
         @R.function
-        def func(x: Tensor[(m, n), "float32"], w: Tensor[(n, k), "float32"]) -> Tensor:
+        def func(x: Tensor((m, n), "float32"), w: Tensor((n, k), "float32")) -> Tensor:
             gv0 = R.call_tir(tir_matmul, (x, w), (m, k), dtype="float32")
             return gv0
 
@@ -794,7 +794,7 @@ def test_vm_tuplegetitem():
     @tvm.script.ir_module
     class TestVMTupleGetItem:
         @R.function
-        def tuple_get_item(x: Tensor[(_, _), "float32"], y: Tensor[(_, _), "float32"]):
+        def tuple_get_item(x: Tensor((_, _), "float32"), y: Tensor((_, _), "float32")):
             t = relax.Tuple((x, y))
             a = relax.TupleGetItem(t, 0)
             b = relax.TupleGetItem(t, 1)
@@ -833,7 +833,7 @@ def test_sub_func_call():
 
         @R.function
         def relax_matmul_tir(
-            x: Tensor[(32, 32), "float32"], w: Tensor[(32, 32), "float32"]
+            x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")
         ) -> Tensor:
             with R.dataflow():
                 gv0 = R.call_tir(tir_matmul, (x, w), (32, 32), dtype="float32")
@@ -842,13 +842,13 @@ def test_sub_func_call():
 
         @R.function
         def relax_matmul_packed(
-            x: Tensor[(32, 32), "float32"], w: Tensor[(32, 32), "float32"]
+            x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")
         ) -> Tensor:
             gv0 = relax.call_packed("test.vm.mul", x, w)
             return gv0
 
         @R.function
-        def main(x: Tensor[(32, 32), "float32"], w: Tensor[(32, 32), "float32"]) -> Tensor:
+        def main(x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")) -> Tensor:
             gv0 = relax_matmul_tir(x, w)
             gv1 = relax_matmul_packed(gv0, gv0)
             return gv1
@@ -868,7 +868,7 @@ def test_recursion():
     @tvm.script.ir_module
     class TestVMRecursion:
         @R.function
-        def recursion(n: Tensor[(1,), "float32"]):
+        def recursion(n: Tensor((1,), "float32")):
             cond = relax.call_packed("test.vm.equal_zero", n)
             if cond:
                 res = relax.const(1.0)


### PR DESCRIPTION
This PR changes how we print/parse Tensor annotation.

Deprecate `[]` in favor `()` in Tensor annotation.
    
This would allow us to use "?" and other symbols in tensor shape annotations as they would no longer need to be type annotations.

Changes `Tensor[<shape>, <dtype>]` to `Tensor(<shape>, <dtype>)`.

Follow up PRs would implement the remaining decisions in https://github.com/tlc-pack/relax/issues/120#issuecomment-1097361527