### PR TITLE
[VM] Copy constant tensors to device

### DIFF
--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -195,6 +195,8 @@ class VirtualMachine : public runtime::ModuleNode {
   Index pc_{0};
   /*! \brief The special return register. */
   RegType return_value_;
+  /*! \brief The global constant pool */
+  std::vector<TVMRetValue> constants;
 };
 
 }  // namespace relax_vm


### PR DESCRIPTION
This PR improves the Relax VM to make it able to copy constants to backend devices (such as CUDA GPU). Prior to this PR, our VM only allocated on-device memory for intermediate tensors, while didn’t take constant tensors into account. And this PR solves the problem, with proper unit tests.

NOTE: Currently only single device is supported. In the future when we support multiple devices, we need to extend the constant copy as well.

cc @YuchenJin @ZihengJiang @yongwww 