### PR TITLE
[Printer][Parser] Modify Tensor annotation printing and parsing.

### DIFF
--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -59,28 +59,29 @@ class ShapeType : public Type {
 class DynTensorTypeNode : public BaseTensorTypeNode {
  public:
   /*!
-   * \brief The rank of the tensor, use -1 to denote dynamic rank tensor.
+   * \brief The number of dimensions of the tensor, use -1 to denote tensor with unknwon number of
+   * dimensions.
    */
-  int rank;
+  int ndim;
   /*! \brief The content data type, use void to denote the dtype is unknown. */
   DataType dtype;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
-    v->Visit("rank", &rank);
+    v->Visit("ndim", &ndim);
     v->Visit("dtype", &dtype);
     v->Visit("span", &span);
   }
 
   bool SEqualReduce(const DynTensorTypeNode* other, SEqualReducer equal) const {
-    return equal(rank, other->rank) && equal(dtype, other->dtype);
+    return equal(ndim, other->ndim) && equal(dtype, other->dtype);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
-    hash_reduce(rank);
+    hash_reduce(ndim);
     hash_reduce(dtype);
   }
 
-  inline bool IsUnknownRank() const { return rank == -1; }
+  inline bool IsUnknownNdim() const { return ndim == -1; }
 
   inline bool IsUnknownDtype() const { return dtype.is_void(); }
 
@@ -99,7 +100,7 @@ class DynTensorType : public Type {
    * \param shape The shape of the tensor.
    * \param dtype The runtime dtype of the tensor's elements.
    */
-  TVM_DLL DynTensorType(int rank, DataType dtype, Span span = Span());
+  TVM_DLL DynTensorType(int ndim, DataType dtype, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(DynTensorType, Type, DynTensorTypeNode);
 };

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -84,8 +84,8 @@ class BlockBuilder(Object):
 
         m = tir.Var("m", "int32")
         n = tir.Var("n", "int32")
-        type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-        type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+        type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+        type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
         x = rx.Var("x", [m, n], type_anno0)
         y = rx.Var("y", [n], type_anno1)
         bb = rx.BlockBuilder()
@@ -481,7 +481,7 @@ class BlockBuilder(Object):
 
                 @R.function
                 def rx_func(x: Tensor((n,), "float32"), y: Tensor(((n + 1),), "float32"))
-                    -> Tensor(_, "float32"):
+                    -> Tensor(None, "float32", ndim=-1):
                     # block 0
                     gv = relax.call_tir(te_func, (y,), ((n + 1),), (n,), dtype="float32")
                     return gv

--- a/python/tvm/relax/testing/nn.py
+++ b/python/tvm/relax/testing/nn.py
@@ -34,8 +34,8 @@ class Placeholder(relax.Var):
     def __init__(self, shape, dtype="float32", name="data"):
         if not isinstance(shape, (list, tuple)):
             raise TypeError("the shape of Placeholder is expected to be a list or a tuple")
-        rank = len(shape)
-        type_anno = relax.DynTensorType(rank, dtype)
+        ndim = len(shape)
+        type_anno = relax.DynTensorType(ndim, dtype)
         super().__init__(relax.BlockBuilder.current().get_unique_name(name), shape, type_anno)
 
 
@@ -45,8 +45,8 @@ class Parameter(relax.Var):
     def __init__(self, shape, dtype="float32", name="param"):
         if not isinstance(shape, (list, tuple)):
             raise TypeError("the shape of Parameter is expected to be a list or a tuple")
-        rank = len(shape)
-        type_anno = relax.DynTensorType(rank, dtype)
+        ndim = len(shape)
+        type_anno = relax.DynTensorType(ndim, dtype)
         super().__init__(relax.BlockBuilder.current().get_unique_name(name), shape, type_anno)
 
 

--- a/python/tvm/relax/ty.py
+++ b/python/tvm/relax/ty.py
@@ -36,15 +36,15 @@ class DynTensorType(Type):
 
     Parameters
     ----------
-    rank : Optional[int]
-        The rank of the Tensor
+    ndim : Optional[int]
+        The ndim of the Tensor
 
     dtype : Optional[str]
         The content data type.
     """
 
-    def __init__(self, rank=-1, dtype="float32", span: Span = None):
-        self.__init_handle_by_constructor__(_ffi_api.DynTensorType, rank, dtype, span)
+    def __init__(self, ndim=-1, dtype="float32", span: Span = None):
+        self.__init_handle_by_constructor__(_ffi_api.DynTensorType, ndim, dtype, span)
 
 
 @tvm._ffi.register_object("relax.DimType")

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -285,7 +285,7 @@ class RelaxTransformer(Transformer):
 
         Returns
         -------
-        dict[str, Any]
+        dict[str, int]
             Parsed keyword parameters in dict[key, value] format
         """
         kwargs = {}
@@ -293,7 +293,7 @@ class RelaxTransformer(Transformer):
             assert isinstance(key, ast.TypeConstant) and isinstance(key.value, str)
             kwargs[key.value] = self.parse_tensor_kwargs_value(val, ty.span)
 
-        # sanity check for Tensor type kewword arguments
+        # sanity check for Tensor type keyword arguments
         if len(kwargs) == 0:
             return kwargs
         if not (len(kwargs) == 1 and "ndim" in kwargs.keys()):
@@ -345,7 +345,8 @@ class RelaxTransformer(Transformer):
                 #                Tensor(n, m) which makes correct errors difficult here...
                 if len(ty.params) != 2:
                     self.report_error(
-                        "Tensor type annotations must have 2 fields (shape and dtype)",
+                        "Tensor type annotations must have 2 positional fields (shape and dtype)"
+                        " and one optional keyword field ndim",
                         ty.span,
                     )
 

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -280,13 +280,11 @@ class RelaxTransformer(Transformer):
                 shape, dtype, rank = None, None, -1
 
                 # parse the shape annotation
-                if isinstance(shape_annotation, ast.TypeConstant):
-                    if shape_annotation.value != "RuntimeDepShape":
-                        self.report_error(
-                            "invalid shape annotation",
-                            shape_annotation.span,
-                        )
-                    shape = relax.RuntimeDepShape(span=self.to_tvm_span(shape_annotation.span))
+                if (
+                    isinstance(shape_annotation, ast.TypeConstant)
+                    and shape_annotation.value is None
+                ):
+                    pass  # shape = None
                 elif isinstance(shape_annotation, ast.TypeVar):
                     if shape_annotation.id.name != "_":
                         # TODO(@altanh): handle variable annotations, e.g. x: Tensor(my_shape, _)
@@ -295,8 +293,7 @@ class RelaxTransformer(Transformer):
                             shape_annotation.span,
                         )
                     else:
-                        # FIXME(@altanh): use a special node for unknown shape vs no shape?
-                        pass  # shape = None
+                        shape = relax.RuntimeDepShape(span=self.to_tvm_span(shape_annotation.span))
                 elif isinstance(shape_annotation, ast.TypeTuple):
                     # the syntax for fixed rank k but unknown/unmatched shape is a tuple of length
                     # k, where each element is "_" (e.g. "(_, _)" for rank 2)

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -101,7 +101,7 @@ Doc RelaxScriptPrinter::VisitNode_(const relay::CallNode* op) {
         } else {
           LOG(FATAL) << "TypeError: Invalid type: " << field_type->GetTypeKey();
         }
-      };
+      }
       doc << ", dtype=(" << Doc::Concat(dtypes, Doc::Text(", ")) << "))";
     } else {
       LOG(FATAL) << "TypeError: Invalid type: " << output_type->GetTypeKey();
@@ -523,24 +523,22 @@ Doc RelaxScriptPrinter::PrintTensorAnnotation(const relax::DynTensorType& ty,
                                               const Optional<ObjectRef>& shape) {
   Doc doc;
   doc << "Tensor(";
+  // Print shape annotation
   if (shape.defined()) {
     doc << Print(Downcast<relay::Expr>(shape.value()));
-  } else if (ty->rank != -1) {
-    ICHECK_GE(ty->rank, 0) << "DynTensor ranks must be -1 (unknown) or nonnegative";
-    std::vector<Doc> dims(ty->rank, Doc::Text("_"));
-    doc << "(" << Doc::Concat(dims, Doc::Text(", "));
-    if (ty->rank == 1) {
-      doc << ",";
-    }
-    doc << ")";
   } else {
     doc << "None";
   }
+  // Print dtype annotation
   doc << ", ";
   if (ty->dtype.is_void()) {
     doc << "_";
   } else {
     doc << Doc::StrLiteral(runtime::DLDataType2String(ty->dtype));
+  }
+  // Print rank annotation only when it cannot be inferred from shape itself.
+  if (!shape.defined() || shape->IsInstance<relax::RuntimeDepShapeNode>()) {
+    doc << ", rank = " << ty->rank;
   }
   doc << ")";
   return doc;

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -536,9 +536,9 @@ Doc RelaxScriptPrinter::PrintTensorAnnotation(const relax::DynTensorType& ty,
   } else {
     doc << Doc::StrLiteral(runtime::DLDataType2String(ty->dtype));
   }
-  // Print rank annotation only when it cannot be inferred from shape itself.
+  // Print ndim annotation only when it cannot be inferred from shape itself.
   if (!shape.defined() || shape->IsInstance<relax::RuntimeDepShapeNode>()) {
-    doc << ", rank = " << ty->rank;
+    doc << ", ndim = " << ty->ndim;
   }
   doc << ")";
   return doc;

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -233,7 +233,7 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::ShapeExprNode* op) {
 Doc RelaxScriptPrinter::VisitNode_(const relax::RuntimeDepShapeNode* op) {
   Doc doc;
 
-  doc << "\"RuntimeDepShape\"";
+  doc << "_";
   return doc;
 }
 
@@ -534,7 +534,7 @@ Doc RelaxScriptPrinter::PrintTensorAnnotation(const relax::DynTensorType& ty,
     }
     doc << ")";
   } else {
-    doc << "_";
+    doc << "None";
   }
   doc << ", ";
   if (ty->dtype.is_void()) {

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -778,7 +778,7 @@ Doc RelayTextPrinter::VisitType_(const TypeDataNode* node) {
 
 Doc RelayTextPrinter::VisitType_(const relax::DynTensorTypeNode* node) {
   Doc doc;
-  doc << "Tensor[rank=" << node->rank << ", dtype=\"" << PrintDType(node->dtype) << "\"]";
+  doc << "Tensor[ndim=" << node->ndim << ", dtype=\"" << PrintDType(node->dtype) << "\"]";
   return doc;
 }
 

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -94,7 +94,7 @@ class VMShapeLowerMutator : public ExprMutator {
       for (Var param : node->params) {
         if (param->shape_.operator bool() && param->shape_.value().as<ShapeExprNode>()) {
           if (auto* param_type = param->checked_type_.as<DynTensorTypeNode>()) {
-            if (param_type->rank != 0) {
+            if (param_type->ndim != 0) {
               Var shape = builder_->Emit(Call(ExternFunc("vm.builtin.shape_of"), {param}), "sh");
               StoreShape(shape, Downcast<ShapeExpr>(param->shape_.value())->values);
             }

--- a/src/relax/ir/type.cc
+++ b/src/relax/ir/type.cc
@@ -37,9 +37,9 @@ ShapeType::ShapeType(Span span) {
 
 TVM_REGISTER_GLOBAL("relax.ShapeType").set_body_typed([](Span span) { return ShapeType(span); });
 
-DynTensorType::DynTensorType(int rank, DataType dtype, Span span) {
+DynTensorType::DynTensorType(int ndim, DataType dtype, Span span) {
   ObjectPtr<DynTensorTypeNode> n = make_object<DynTensorTypeNode>();
-  n->rank = std::move(rank);
+  n->ndim = std::move(ndim);
   n->dtype = std::move(dtype);
   n->span = span;
   data_ = std::move(n);
@@ -47,8 +47,8 @@ DynTensorType::DynTensorType(int rank, DataType dtype, Span span) {
 
 TVM_REGISTER_NODE_TYPE(DynTensorTypeNode);
 
-TVM_REGISTER_GLOBAL("relax.DynTensorType").set_body_typed([](int rank, DataType dtype, Span span) {
-  return DynTensorType(rank, dtype, span);
+TVM_REGISTER_GLOBAL("relax.DynTensorType").set_body_typed([](int ndim, DataType dtype, Span span) {
+  return DynTensorType(ndim, dtype, span);
 });
 
 DimType::DimType(Span span) {

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -103,13 +103,13 @@ Type InferTypeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx) {
     output_dtype = t0->dtype;
   }
 
-  int output_rank;
-  if (t0->IsUnknownRank() || t1->IsUnknownRank()) {
-    output_rank = -1;
+  int output_ndim;
+  if (t0->IsUnknownNdim() || t1->IsUnknownNdim()) {
+    output_ndim = -1;
   } else {
-    output_rank = std::max(t0->rank, t1->rank);
+    output_ndim = std::max(t0->ndim, t1->ndim);
   }
-  return DynTensorType(output_rank, output_dtype);
+  return DynTensorType(output_ndim, output_dtype);
 }
 
 }  // namespace relax

--- a/src/relax/op/tensor/ternary.h
+++ b/src/relax/op/tensor/ternary.h
@@ -100,13 +100,13 @@ Type InferTypeEwiseFMA(const Call& call, DiagnosticContext diag_ctx) {
     output_dtype = t0->dtype;
   }
 
-  int output_rank;
-  if (t0->IsUnknownRank() || t1->IsUnknownRank() || t2->IsUnknownRank()) {
-    output_rank = -1;
+  int output_ndim;
+  if (t0->IsUnknownNdim() || t1->IsUnknownNdim() || t2->IsUnknownNdim()) {
+    output_ndim = -1;
   } else {
-    output_rank = t0->rank;
+    output_ndim = t0->ndim;
   }
-  return DynTensorType(output_rank, output_dtype);
+  return DynTensorType(output_ndim, output_dtype);
 }
 
 }  // namespace relax

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -24,8 +24,8 @@ from tvm.ir import structural_equal
 def test_dispatch_var():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     v0 = rx.Var("v0", [m, n], type_anno0)
     v1 = rx.DataflowVar("v1", [n], type_anno1)
     t = None
@@ -43,8 +43,8 @@ def test_dispatch_var():
 def test_post_order_visit():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     ib = rx.BlockBuilder()

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -37,8 +37,8 @@ def nop():
 def test_block_builder():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
@@ -64,8 +64,8 @@ def test_block_builder():
 def test_function_single_block():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
@@ -86,7 +86,7 @@ def test_function_single_block():
     assert func.body.body == gv0
     assert gv0.shape[0] == m
     assert gv0.shape[1] == n
-    assert gv0.checked_type.rank == 2
+    assert gv0.checked_type.ndim == 2
     assert gv0.checked_type.dtype == "float16"
     assert len(func.body.blocks) == 1
     assert len(func.body.blocks[0].bindings) == 3
@@ -95,8 +95,8 @@ def test_function_single_block():
 def test_function_multi_blocks():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
@@ -118,7 +118,7 @@ def test_function_multi_blocks():
     func = bb.get()["func"]
     assert gv2.shape[0] == m
     assert gv2.shape[1] == n
-    assert gv2.checked_type.rank == 2
+    assert gv2.checked_type.ndim == 2
     assert gv2.checked_type.dtype == "float16"
     assert func.params[0] == x
     assert func.params[1] == y
@@ -133,8 +133,8 @@ def test_function_multi_blocks():
 def test_multi_functions():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
@@ -171,8 +171,8 @@ def test_binary_shape_type_deduction():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
     k = tir.Var("k", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, 1], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     z = rx.Var("z", [5], type_anno1)
@@ -185,32 +185,32 @@ def test_binary_shape_type_deduction():
             assert lv0.shape[0] == m
             assert lv0.shape[1] == n
             assert isinstance(lv0.checked_type, rx.DynTensorType)
-            assert lv0.checked_type.rank == 2
+            assert lv0.checked_type.ndim == 2
             assert lv0.checked_type.dtype == "float16"
 
             lv1 = bb.emit(rx.op.multiply(x, z))
             assert lv1.shape[0] == m
             assert lv1.shape[1] == 5
             assert isinstance(lv1.checked_type, rx.DynTensorType)
-            assert lv1.checked_type.rank == 2
+            assert lv1.checked_type.ndim == 2
             assert lv1.checked_type.dtype == "float16"
 
             lv2 = bb.emit(rx.op.multiply(z, w))
             assert isinstance(lv2.shape, rx.Call)
             assert isinstance(lv2.checked_type, rx.DynTensorType)
-            assert lv2.checked_type.rank == 1
+            assert lv2.checked_type.ndim == 1
             assert lv2.checked_type.dtype == "float16"
 
             lv3 = bb.emit(rx.op.multiply(y, w))
             assert isinstance(lv3.shape, rx.Call)
             assert isinstance(lv3.checked_type, rx.DynTensorType)
-            assert lv3.checked_type.rank == 1
+            assert lv3.checked_type.ndim == 1
             assert lv3.checked_type.dtype == "float16"
             gv0 = bb.emit_output(lv3)
         bb.emit_func_output(gv0)
         assert isinstance(gv0.shape, rx.Call)
         assert isinstance(gv0.checked_type, rx.DynTensorType)
-        assert gv0.checked_type.rank == 1
+        assert gv0.checked_type.ndim == 1
         assert gv0.checked_type.dtype == "float16"
 
 
@@ -231,7 +231,7 @@ def test_emit_match_shape():
             assert isinstance(lv0, rx.DataflowVar)
             assert lv0.shape[0] == m
             assert lv0.shape[1] == n
-            assert lv0.checked_type.rank == 2
+            assert lv0.checked_type.ndim == 2
             assert lv0.checked_type.dtype == "float32"
 
             # lv1: Shape = match_shape(shape, [m, n])
@@ -260,8 +260,8 @@ def test_emit_match_shape():
 def test_normalize():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
@@ -277,7 +277,7 @@ def test_normalize():
 
 def test_call_te():
     bb = rx.BlockBuilder()
-    dtype = rx.DynTensorType(rank=2, dtype="float32")
+    dtype = rx.DynTensorType(ndim=2, dtype="float32")
     n, m = tir.Var("n", "int64"), tir.Var("m", "int64")
     x = rx.Var("x", [n, m], dtype)
     y = rx.Var("y", [n, m], dtype)
@@ -466,7 +466,7 @@ def test_emit_tuple_get_item():
         assert z.shape[1] == m
         assert z.shape[2] == 224
         assert z.shape[3] == 224
-        assert z.checked_type.rank == 4
+        assert z.checked_type.ndim == 4
         assert z.checked_type.dtype == "float32"
 
         w = bb.emit(rx.TupleGetItem(y, 1))
@@ -485,8 +485,8 @@ def test_emit_tuple_get_item():
 def test_nested_function_fail():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
@@ -502,8 +502,8 @@ def test_nested_function_fail():
 def test_emit_func_output_twice_fail():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
@@ -518,8 +518,8 @@ def test_emit_func_output_twice_fail():
 def test_func_params_twice_fail():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()
@@ -533,8 +533,8 @@ def test_func_params_twice_fail():
 def test_no_func_params_fail():
     m = tir.Var("m", "int32")
     n = tir.Var("n", "int32")
-    type_anno0 = rx.DynTensorType(rank=2, dtype="float16")
-    type_anno1 = rx.DynTensorType(rank=1, dtype="float16")
+    type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
+    type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
     y = rx.Var("y", [n], type_anno1)
     bb = rx.BlockBuilder()

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -78,10 +78,10 @@ def test_annotations():
     def f(
         x: Tensor((32, m), "float32"),
         y: Tensor((m, k), "float32"),
-        r: Tensor("RuntimeDepShape", "int64"),
+        r: Tensor(_, "int64"),
     ) -> Tensor:
         z: Tensor((32, k), "float32") = nn.matmul(x, y, units=None)
-        w: Tensor(_, _) = multiply(z, z)
+        w: Tensor(None, _) = multiply(z, z)
         q: Tensor((_, _), _) = add(w, w)
         t = subtract(w, z)
         sh: Shape = t.shape

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -55,13 +55,13 @@ def check_shape(e, s):
             assert edim.value == sdim
 
 
-def check_tensor_var(v, s, d, rank=None):
+def check_tensor_var(v, s, d, ndim=None):
     assert isinstance(v._checked_type_, relax.ty.DynTensorType)
     assert v._checked_type_.dtype == d
     if isinstance(s, (list, tuple)):
-        assert v._checked_type_.rank == len(s)
-    if rank is not None:
-        assert v._checked_type_.rank == rank
+        assert v._checked_type_.ndim == len(s)
+    if ndim is not None:
+        assert v._checked_type_.ndim == ndim
     check_shape(v, s)
 
 
@@ -82,7 +82,7 @@ def test_annotations():
     ) -> Tensor:
         z: Tensor((32, k), "float32") = nn.matmul(x, y, units=None)
         w: Tensor(None, _) = multiply(z, z)
-        q: Tensor(None, _, rank=2) = add(w, w)
+        q: Tensor(None, _, ndim=2) = add(w, w)
         t = subtract(w, z)
         sh: Shape = t.shape
         return t
@@ -100,7 +100,7 @@ def test_annotations():
     check_tensor_var(r, relax.RuntimeDepShape(), "int64")
     check_tensor_var(z, (32, "k"), "float32")
     check_tensor_var(w, None, "")
-    check_tensor_var(q, None, "", rank=2)
+    check_tensor_var(q, None, "", ndim=2)
     assert t._checked_type_ is None
     assert isinstance(sh._checked_type_, relax.ty.ShapeType)
 
@@ -121,11 +121,12 @@ def test_annotations_fail():
         def f(x: Tensor("u", "int64")):
             return x
 
-def test_mismatch_shape_dims_and_rank():
+
+def test_mismatch_shape_dims_and_ndim():
     with pytest.raises(tvm.error.DiagnosticError):
 
         @R.function
-        def f(x: Tensor((2, 3), "float32", rank=3)):
+        def f(x: Tensor((2, 3), "float32", ndim=3)):
             return x
 
 
@@ -133,7 +134,7 @@ def test_unexpected_num_kw_args():
     with pytest.raises(tvm.error.DiagnosticError):
 
         @R.function
-        def f(x: Tensor(_, "float32", rank=1, foo=2)):
+        def f(x: Tensor(_, "float32", ndim=1, foo=2)):
             return x
 
 
@@ -145,20 +146,21 @@ def test_unexpected_kw_arg():
             return x
 
 
-def test_unexpected_rank():
+def test_unexpected_ndim():
     with pytest.raises(tvm.error.DiagnosticError):
 
         @R.function
-        def f(x: Tensor(_, "float32", rank=-2)):
+        def f(x: Tensor(_, "float32", ndim=-2)):
             return x
 
 
-def test_unexpected_rank_type():
+def test_unexpected_ndim_type():
     with pytest.raises(tvm.error.DiagnosticError):
 
         @R.function
-        def f(x: Tensor(_, "float32", rank="1")):
+        def f(x: Tensor(_, "float32", ndim="1")):
             return x
+
 
 def test_match_shape():
     @R.function
@@ -517,7 +519,7 @@ def test_call_tir():
     call_tir_node = foo.body.blocks[0].bindings[0].value
     assert call_tir_node.attrs is None
     assert_structural_equal(
-        call_tir_node.type_args[0], relax.DynTensorType(rank=2, dtype="float32")
+        call_tir_node.type_args[0], relax.DynTensorType(ndim=2, dtype="float32")
     )
 
 
@@ -686,9 +688,9 @@ def test_class_irmodule():
     assert g.body.body.args[0] == var_my_matmul
 
     gv_bind = j.body.blocks[0].bindings[0]
-    assert gv_bind.value.checked_type.rank == 2
+    assert gv_bind.value.checked_type.ndim == 2
     assert gv_bind.value.checked_type.dtype == "float32"
-    assert gv_bind.var.checked_type.rank == 2
+    assert gv_bind.var.checked_type.ndim == 2
     assert gv_bind.var.checked_type.dtype == "float32"
     check_shape(gv_bind.value, ("n", "n"))
     check_shape(gv_bind.var, ("n", "n"))
@@ -696,12 +698,12 @@ def test_class_irmodule():
     # check function type
     # assert isinstance(j.checked_type, relax.FuncType)
     # assert j.checked_type.ret_type.dtype == "float32"
-    # assert j.checked_type.ret_type.rank == 2
+    # assert j.checked_type.ret_type.ndim == 2
 
     # check SeqExpr type/shape
     assert isinstance(j.body, relax.SeqExpr)
     assert j.body.checked_type.dtype == "float32"
-    assert j.body.checked_type.rank == 2
+    assert j.body.checked_type.ndim == 2
     check_shape(j.body, ("n", "n"))
 
     # check tuple type/shape
@@ -709,7 +711,7 @@ def test_class_irmodule():
     isinstance(gv1_bind.value, relax.Tuple)
     isinstance(gv1_bind.value.checked_type, relax.TupleType)
     isinstance(gv1_bind.var.checked_type, relax.TupleType)
-    assert gv1_bind.var.checked_type.fields[0].rank == 2
+    assert gv1_bind.var.checked_type.fields[0].ndim == 2
     assert gv1_bind.var.checked_type.fields[0].dtype == "float32"
     isinstance(gv1_bind.var.shape, relax.Tuple)
     isinstance(gv1_bind.value.shape, relax.Tuple)
@@ -721,9 +723,9 @@ def test_class_irmodule():
     # check TupleGetItem type/shape
     gv2_bind = j.body.blocks[0].bindings[2]
     isinstance(gv2_bind.value, relax.TupleGetItem)
-    assert gv2_bind.value.checked_type.rank == 2
+    assert gv2_bind.value.checked_type.ndim == 2
     assert gv2_bind.value.checked_type.dtype == "float32"
-    assert gv2_bind.var.checked_type.rank == 2
+    assert gv2_bind.var.checked_type.ndim == 2
     assert gv2_bind.var.checked_type.dtype == "float32"
     check_shape(gv2_bind.value.shape, ("n", "n"))
     check_shape(gv2_bind.var, ("n", "n"))

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -50,14 +50,15 @@ def test_annotations():
     check_roundtrip(foo)
 
 
-def test_rank_annotations():
+def test_ndim_annotations():
     @R.function
     def foo(
-        x: Tensor((2, 3, 5), "float32", rank=3),
-        y: Tensor(None, "float32", rank=-1),
-        z: Tensor(_, "float32", rank=2),
+        x: Tensor((2, 3, 5), "float32", ndim=3),
+        y: Tensor(_, "float32", ndim=-1),
+        z: Tensor(_, "float32", ndim=2),
     ):
-        return x
+        w: Tensor(None, "float32", ndim=-1) = x + x
+        return w
 
     check_roundtrip(foo)
 
@@ -317,8 +318,8 @@ def test_class_irmodule():
 
 
 def test_dyntensortype():
-    x = relax.DynTensorType(rank=3, dtype="float32")
-    assert x.__str__() == 'Tensor[rank=3, dtype="float32"]'
+    x = relax.DynTensorType(ndim=3, dtype="float32")
+    assert x.__str__() == 'Tensor[ndim=3, dtype="float32"]'
 
 
 def test_shapeexpr():

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -50,6 +50,18 @@ def test_annotations():
     check_roundtrip(foo)
 
 
+def test_rank_annotations():
+    @R.function
+    def foo(
+        x: Tensor((2, 3, 5), "float32", rank=3),
+        y: Tensor(None, "float32", rank=-1),
+        z: Tensor(_, "float32", rank=2),
+    ):
+        return x
+
+    check_roundtrip(foo)
+
+
 def test_match_shape():
     @R.function
     def foo(x: Tensor(_, "float32")):

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -316,7 +316,7 @@ def test_shapeexpr():
 
 def test_runtime_dep_shape():
     x = relax.RuntimeDepShape()
-    assert x.__str__() == '"RuntimeDepShape"'
+    assert x.__str__() == "_"
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_type.py
+++ b/tests/python/relax/test_type.py
@@ -28,9 +28,9 @@ def test_shape_type():
 
 def test_dyn_tensor_type():
     t0 = rx.DynTensorType()
-    assert t0.rank == -1
+    assert t0.ndim == -1
     t1 = rx.DynTensorType(3, "int32")
-    assert t1.rank == 3
+    assert t1.ndim == 3
     assert t1.dtype == "int32"
 
 


### PR DESCRIPTION
This PR make the following changes to Tensor annotation

* Use `_` to represent RuntimeDepShape and `None` to represent not yet deduced shape.
* Add ndim annotation to Tensor
* [NFC] Replace rank with ndim throughout Relax.

For example, 
* `Tensor(_, "float32", ndim=2)`: a 2D float tensor with runtime dependent shape
* `Tensor(None, "float32", ndim=3)`: a 3D float tensor with not yet deduced shape.
* `Tensor((2, 3), "float32")`: a 2D float tensor with shape (2, 3).

This is in accordance to what was agreed upon in https://github.com/tlc-pack/relax/issues/120#issuecomment-1097361527, except the use of `_` instead of "?" to denote `RuntimeDepShape`. It was necessary since "?" is not a valid type annotation.
