### PR TITLE
[Relax][MS] Task extraction with proper weights

### DIFF
--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -17,7 +17,6 @@
 """Meta schedule integration with high-level IR"""
 from typing import List, Union, Dict, Optional
 
-import tvm
 from tvm import relax
 from tvm._ffi import get_global_func
 from tvm.ir import IRModule

--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -15,58 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """Meta schedule integration with high-level IR"""
-from typing import Any, List, Union, Tuple, Dict, Optional
+from typing import Any, List, Union, Dict, Optional
 
 import tvm
-from tvm.ir import IRModule, structural_hash, structural_equal
+from tvm._ffi import get_global_func
+from tvm.ir import IRModule
 from tvm.meta_schedule import ExtractedTask
 from tvm.target import Target
 from tvm.relax.expr import Function as RelaxFunc
-from tvm.relax.utils import tir_partitioner
 from tvm.runtime import NDArray
-
-
-def deduplicate_extracted_tasks(
-    mods: List[IRModule],
-) -> Tuple[List[IRModule], List[int]]:
-    """Remove duplicate modules.
-    Parameters
-    ----------
-    mods : List[IRModule]
-        The list of IRModule.
-    Returns
-    -------
-    tasks : Tuple[List[IRModule], List[int]]
-        A tuple containing the deduplicated modules and the count for each module.
-    """
-    hash2modules: Dict[int, List[IRModule]] = {}
-    hash2counts: Dict[int, List[int]] = {}
-    for mod in mods:
-        shash = structural_hash(mod)
-        if shash in hash2modules:
-            is_dup = False
-            for i, relax_mod in enumerate(hash2modules[shash]):
-                # duplicate module was found
-                if structural_equal(mod, relax_mod):
-                    hash2counts[shash][i] += 1
-                    is_dup = True
-                    break
-            if is_dup is False:
-                # hash conflict but actually different modules
-                hash2modules[shash].append(mod)
-                hash2counts[shash].append(1)
-
-        else:
-            hash2modules[shash] = [mod]
-            hash2counts[shash] = [1]
-
-    dedup: List[IRModule] = []
-    count: List[int] = []
-    for shash, relax_mods in hash2modules.items():
-        for i, mod in enumerate(relax_mods):
-            dedup.append(mod)
-            count.append(hash2counts[shash][i])
-    return dedup, count
 
 
 def extract_task_from_relax(
@@ -92,10 +49,14 @@ def extract_task_from_relax(
     tasks: List[ExtractedTask]
         The tasks extracted from this module
     """
+
+    extract_task_func = get_global_func(
+        "relax.backend.MetaScheduleExtractTask",
+        allow_missing=False,
+    )
+
     if isinstance(mod, RelaxFunc):
         mod = IRModule.from_expr(mod)
-    if not isinstance(target, Target):
-        target = Target(target)
 
     if disabled_pass is None:
         disabled_pass = []
@@ -105,17 +66,9 @@ def extract_task_from_relax(
     if params:
         mod = tvm.relax.transform.BindParams("main", params)(mod)
 
-    tir_partitions = tir_partitioner(mod)
-    tir_mods, tir_counts = deduplicate_extracted_tasks(tir_partitions)
-    tasks = []
     with target, tvm.transform.PassContext(
         opt_level=opt_level,
         config=pass_config,
         disabled_pass=disabled_pass,
     ):
-        for i, tir_mod in enumerate(tir_mods):
-            task_name = tir_mod.get_global_vars()[0].name_hint
-            # The second arg to ExtractedTask is supposed to be a high-level IRModule,
-            # passing tir_mod as a workaround.
-            tasks.append(ExtractedTask(task_name, tir_mod, target, [tir_mod], tir_counts[i]))
-    return tasks
+        return list(extract_task_func(mod, target))

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -16,30 +16,6 @@
 # under the License.
 """Utility functions for Relax"""
 from typing import List
-from tvm.tir import PrimFunc
-from tvm import IRModule
-
-
-def tir_partitioner(mod: IRModule) -> List[IRModule]:
-    """Extracts tir PrimFuncs from the input IRModule.
-
-    Parameters
-    ----------
-    mod : IRModule
-        The input IRModule.
-
-    Returns
-    -------
-    output : List[IRModule]
-        The result tir PrimFuncs.
-    """
-    partitions = []
-    for gvar in mod.get_global_vars():
-        if isinstance(mod[gvar], PrimFunc):
-            tir_mod = IRModule({})
-            tir_mod[gvar] = mod[gvar]
-            partitions.append(tir_mod)
-    return partitions
 
 
 def metadata_partitioner(rx_txt: str) -> List[str]:

--- a/src/relax/backend/task_extraction.cc
+++ b/src/relax/backend/task_extraction.cc
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <tvm/meta_schedule/extracted_task.h>
+#include <tvm/relax/expr.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/target/target.h>
+#include <tvm/tir/function.h>
+
+namespace tvm {
+namespace relax {
+namespace backend {
+
+// TODO(ruihang): need integration unit test
+
+using tvm::meta_schedule::ExtractedTask;
+
+/*!
+ * \brief Extract the Meta-Schedule tuning task from a given IRModule.
+ * \note
+ *   1. The task extractor is responsible for task deduplication. The
+ *   deduplication is achieved by comparing structural hashes of PrimFuncs.
+ *   2. For a PrimFunc, the weight of its corresponding task is the number
+ *   of times it called by op Call-TIR. Say in an IRModule there are three
+ *   PrimFuncs `fn1`, `fn2` and `fn3` sharing the same structural hash.
+ *   Suppose `fn1` is called by 5 Call-TIR ops among all Relax function,
+ *   `fn2` is called by 3 Call-TIR and `fn3` is called by 5 Call-TIR.
+ *   Then we will have a ExtractedTask for all three functions, whose weight
+ *   is 5 + 3 + 2 = 10.
+ */
+class TaskExtractor : public ExprVisitor {
+ public:
+  static Array<ExtractedTask> ExtractTask(IRModule mod, Target target) {
+    TaskExtractor extracor(mod, target);
+    // We go through each Relax function in the module.
+    for (const auto& kv : mod->functions) {
+      if (const auto* func = kv.second.as<FunctionNode>()) {
+        extracor(GetRef<Function>(func));
+      }
+    }
+    return std::move(extracor.tasks_);
+  }
+
+ private:
+  explicit TaskExtractor(IRModule mod, Target target)
+      : mod_(std::move(mod)), target_(std::move(target)) {}
+
+  void VisitExpr_(const CallNode* call) final {
+    static const Op& call_tir_op = Op::Get("relax.call_tir");
+    if (!call->op.same_as(call_tir_op)) {
+      // Since the Relax function is of A-normal form, the arguments of this call cannot be another
+      // Calls. And hence we do not need to recurse into this Call.
+      return;
+    }
+
+    const GlobalVar& global_var = Downcast<GlobalVar>(call->args[0]);
+    const tir::PrimFunc& func = Downcast<tir::PrimFunc>(mod_->Lookup(global_var));
+    size_t shash = StructuralHash()(func);
+
+    auto it = hash2task_.find(shash);
+    if (it != hash2task_.end()) {
+      it->second->weight += 1;
+      return;
+    }
+
+    IRModule tir_mod({{global_var, func}});
+    ExtractedTask task(/*task_name=*/global_var->name_hint,  //
+                       /*mod=*/tir_mod,                      //
+                       /*target=*/target_,                   //
+                       /*dispatched=*/{tir_mod},             //
+                       /*weight=*/1);
+    tasks_.push_back(task);
+    hash2task_.emplace(shash, task);
+  }
+
+  IRModule mod_;
+  Target target_;
+  Array<ExtractedTask> tasks_;
+  std::unordered_map<size_t, ExtractedTask> hash2task_;
+};
+
+TVM_REGISTER_GLOBAL("relax.backend.MetaScheduleExtractTask")
+    .set_body_typed([](IRModule mod, Target target) {
+      return TaskExtractor::ExtractTask(std::move(mod), std::move(target));
+    });
+
+}  // namespace backend
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/backend/task_extraction.cc
+++ b/src/relax/backend/task_extraction.cc
@@ -27,8 +27,6 @@ namespace tvm {
 namespace relax {
 namespace backend {
 
-// TODO(ruihang): need integration unit test
-
 using tvm::meta_schedule::ExtractedTask;
 
 /*!

--- a/src/relax/backend/task_extraction.cc
+++ b/src/relax/backend/task_extraction.cc
@@ -69,10 +69,9 @@ class TaskExtractor : public ExprVisitor {
 
     const GlobalVar& global_var = Downcast<GlobalVar>(call->args[0]);
     const tir::PrimFunc& func = Downcast<tir::PrimFunc>(mod_->Lookup(global_var));
-    size_t shash = StructuralHash()(func);
 
-    auto it = hash2task_.find(shash);
-    if (it != hash2task_.end()) {
+    auto it = func2task_.find(func);
+    if (it != func2task_.end()) {
       it->second->weight += 1;
       return;
     }
@@ -84,13 +83,13 @@ class TaskExtractor : public ExprVisitor {
                        /*dispatched=*/{tir_mod},             //
                        /*weight=*/1);
     tasks_.push_back(task);
-    hash2task_.emplace(shash, task);
+    func2task_.emplace(func, task);
   }
 
   IRModule mod_;
   Target target_;
   Array<ExtractedTask> tasks_;
-  std::unordered_map<size_t, ExtractedTask> hash2task_;
+  std::unordered_map<tir::PrimFunc, ExtractedTask, StructuralHash, StructuralEqual> func2task_;
 };
 
 TVM_REGISTER_GLOBAL("relax.backend.MetaScheduleExtractTask")


### PR DESCRIPTION
This PR improves our Meta-Schedule task extraction by setting proper weights for the tasks.

Prior to this PR, our task extraction will create a task for each PrimFunc in the IRModule. After that we have a step of task deduplication, and will adjust the task weights according to the deduplication results.

But this way has a flaw. Take the follow IRModule (which serves as the unit test of this PR) as an example.
```python
@tvm.script.ir_module
class Module:
    @T.prim_func
    def add1(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"]):
        T.func_attr({"global_symbol": "add1"})
        # B[i, j] = A[i, j] + 1.0

    @T.prim_func
    def add2(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"]):
        T.func_attr({"global_symbol": "add2"})
        # B[i, j] = A[i, j] + 2.0

    @T.prim_func
    def multiply1(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"]):
        T.func_attr({"global_symbol": "multiply1"})
        # B[i, j] = A[i, j] * 2.0

    @R.function
    def main(x: Tensor((128, 128), "float32")) -> Tensor(_, "float32"):
        with R.dataflow():
            lv0 = R.call_tir(add1, (x,), (128, 128), dtype="float32")
            lv1 = R.call_tir(multiply1, (lv0,), (128, 128), dtype="float32")
            lv2 = R.call_tir(add2, (lv1,), (128, 128), dtype="float32")
            lv3 = R.call_tir(multiply1, (lv2,), (128, 128), dtype="float32")
            gv = R.call_tir(add1, (lv3,), (128, 128), dtype="float32")
            relax.output(gv)
        return gv
```
Note that in the main function, `add1` and `multiply1` are called for both twice. In our previous task extraction, the task for `add1` and the task for `multiply1` both have weight 1, which doesn’t match the actual situation. Instead, we should set their weight to 2, so that the gradient-based task scheduler can make better task scheduling decision. And this PR exactly improves this point.

---

Another thing is about the deduplication. I moved the task deduplication stage into the task extractor, which still uses the structural hash values of PrimFuncs. But I suppose that in an IRModule, most of the time no two PrimFuncs share a same hash value. This is because two PrimFuncs in an IRModule usually have different function attributes at the `global_symbol` field, whose value is usually the name of the PrimFunc.

Given that the function attribute is taken into account of the function hash value, two PrimFuncs with different `global_symbol` value don’t share a same hash value. And that’s why I think the deduplication rarely plays a practical role. But anyway it’s not bad to have a deduplication 🤔 .

You might wonder why we don’t do the deduplication on Python side: after this weight improvement, we can utilize the function `deduplicate_extracted_tasks(...)` on Python side. But after sync with @junrushao1994, I learned that this utility function is to be removed in https://github.com/apache/tvm/pull/10986. And thus we decide to make the deduplication a job of the task extraction.

---

cc @yongwww @junrushao1994 @sunggg @YuchenJin 