### PR TITLE
[Relay Translator] Use OpStrategy for lowering

### DIFF
--- a/python/tvm/meta_schedule/__init__.py
+++ b/python/tvm/meta_schedule/__init__.py
@@ -31,6 +31,7 @@ from . import (
 from .apply_history_best import ApplyHistoryBest
 from .extracted_task import ExtractedTask
 from .relay_integration import extract_task_from_relay
+from .relax_integration import extract_task_from_relax
 from .search_strategy import MeasureCandidate
 from .tune import (
     EvolutionarySearchConfig,

--- a/python/tvm/relax/testing/relay_translator.py
+++ b/python/tvm/relax/testing/relay_translator.py
@@ -61,7 +61,10 @@ def from_relay(
     if disabled_pass is None:
         disabled_pass = []
     if pass_config is None:
-        pass_config = {"relay.FuseOps.max_depth": 1, "relay.backend.use_meta_schedule": True}
+        pass_config = {
+            "relay.FuseOps.max_depth": 1,  # Disable relay fusion
+            "relay.backend.use_meta_schedule": True,
+        }
 
     if relay_params:
         func = relay.build_module.bind_params_by_name(func, relay_params)

--- a/python/tvm/relax/testing/relay_translator.py
+++ b/python/tvm/relax/testing/relay_translator.py
@@ -20,14 +20,13 @@
 from __future__ import annotations
 from typing import Any, Dict, List, Optional
 import tvm
-import numpy as np  # type: ignore
-from tvm import nd
 from tvm.ir.module import IRModule
 from tvm import relax, relay
 from tvm.relax.testing import nn
 from tvm.relay.backend.te_compiler import select_implementation
 from tvm.runtime import NDArray
 from tvm.target import Target
+from tvm.meta_schedule.utils import autotvm_silencer
 
 
 def from_relay(
@@ -68,17 +67,7 @@ def from_relay(
 
     if relay_params:
         func = relay.build_module.bind_params_by_name(func, relay_params)
-    mod = tvm.IRModule.from_expr(func)
 
-    # List of subset of relay->relay optimizations
-    # See src/relay/backend/utils.cc::GetPassPrefix() for full list
-    seq = tvm.get_global_func("relay.backend.GetPassPrefixSeq")(True, True)
-
-    with tvm.transform.PassContext(
-        opt_level=opt_level, config=pass_config, disabled_pass=disabled_pass
-    ):
-        mod = seq(mod)
-    func = mod["main"]
     params = []
 
     def visit_func(node):
@@ -103,24 +92,20 @@ def from_relay(
             op_name = node.op.name
             attrs = node.attrs
             out_type = node.checked_type
-            # @sunggg: its funny that we need this target context despite the target argument
-            # PassContext is also necessary for winograd-like lowerings
-            with target, tvm.transform.PassContext(
-                opt_level=opt_level, config=pass_config, disabled_pass=disabled_pass
-            ):
-                best_impl, outputs = select_implementation(
-                    node.op,
-                    attrs,
-                    te_inputs,
-                    out_type,
-                    target,
-                    use_autotvm=False,
-                )
-                compute_func = best_impl.compute
-                name_hint = op_name.split(".")[-1]
-                var = bb.emit_te(
-                    compute_func, attrs, new_args, node.checked_type, primfunc_name_hint=name_hint
-                )
+
+            best_impl, outputs = select_implementation(
+                node.op,
+                attrs,
+                te_inputs,
+                out_type,
+                target,
+                use_autotvm=False,
+            )
+            compute_func = best_impl.compute
+            name_hint = op_name.split(".")[-1]
+            var = bb.emit_te(
+                compute_func, attrs, new_args, node.checked_type, primfunc_name_hint=name_hint
+            )
             output_var = var
             var_map[node] = var
         elif isinstance(node, relay.Constant):
@@ -154,8 +139,19 @@ def from_relay(
         else:
             raise TypeError("{} is not supported yet.".format(str(type(node))))
 
-    bb = relax.BlockBuilder()
-    with bb.function("main"):
-        relay.analysis.post_order_visit(func, visit_func)
+    # List of subset of relay->relay optimizations
+    # See src/relay/backend/utils.cc::GetPassPrefix() for full list
+    seq = tvm.get_global_func("relay.backend.GetPassPrefixSeq")(True, True)
+
+    # Since optimization passes and OpStrategy are highly context-dependent,
+    # we match the exact same context with `extract_task_from_relay()` env
+    with autotvm_silencer(), target, tvm.transform.PassContext(
+        opt_level=opt_level, config=pass_config, disabled_pass=disabled_pass
+    ):
+        mod = tvm.IRModule.from_expr(func)
+        mod = seq(mod)
+        bb = relax.BlockBuilder()
+        with bb.function("main"):
+            relay.analysis.post_order_visit(mod["main"], visit_func)
 
     return bb.get()

--- a/python/tvm/relax/testing/relay_translator.py
+++ b/python/tvm/relax/testing/relay_translator.py
@@ -18,138 +18,27 @@
 """Relay to Relax translator."""
 
 from __future__ import annotations
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 import tvm
+import numpy as np  # type: ignore
+from tvm import nd
 from tvm.ir.module import IRModule
-from tvm import relax, relay, topi
+from tvm import relax, relay
 from tvm.relax.testing import nn
+from tvm.relay.backend.te_compiler import select_implementation
+from tvm.runtime import NDArray
+from tvm.target import Target
 
 
-class RelayOpConverter(object):
-    """A helper class for holding Relay op converters."""
-
-    @classmethod
-    def get_converter(cls):
-        """Get converter.
-
-        :return: converter, which should be `_impl`.
-        """
-
-        if hasattr(cls, "_impl"):
-            return getattr(cls, "_impl")
-        raise tvm.error.OpNotImplemented("Operator {} is not supported.".format(cls.__name__))
-
-
-class Dense(RelayOpConverter):
-    """Operator converter for nn.dense."""
-
-    @classmethod
-    def _impl(cls, inputs, attrs):
-        return nn.emit_te(topi.nn.dense, *inputs)
-
-
-class BatchNorm(RelayOpConverter):
-    """Operator converter for nn.batch_norm."""
-
-    @classmethod
-    def _impl(cls, inputs, attrs):
-        new_attrs = attr_convert(attrs)
-        return nn.emit_te(topi.nn.batch_norm, *inputs, **new_attrs)
-
-
-class Conv2D(RelayOpConverter):
-    """Operator converter for nn.conv2d."""
-
-    @classmethod
-    def _impl(cls, inputs, attrs):
-        new_inputs = [*inputs]
-        if attrs is not None:
-            new_inputs.append(attrs["strides"])
-            new_inputs.append(attrs["padding"])
-            new_inputs.append(attrs["dilation"])
-        else:
-            raise RuntimeError("attrs must be provided to conv2d op.")
-        return nn.emit_te(topi.nn.conv2d_nchw, *new_inputs)
-
-
-class BatchMatmul(RelayOpConverter):
-    """Operator converter for nn.batch_matmul."""
-
-    @classmethod
-    def _impl(cls, inputs, attrs):
-        new_attrs = attr_convert(attrs)
-        if "out_dtype" in new_attrs:
-            new_attrs["out_dtype"] = None
-        if "transpose_a" in new_attrs:
-            new_attrs["transpose_a"] = bool(new_attrs["transpose_a"])
-        if "transpose_b" in new_attrs:
-            new_attrs["transpose_b"] = bool(new_attrs["transpose_b"])
-        return nn.emit_te(topi.nn.batch_matmul, *inputs, **new_attrs)
-
-
-class Softmax(RelayOpConverter):
-    """Operator converter for softmax."""
-
-    @classmethod
-    def _impl(cls, inputs, attrs):
-        new_attrs = attr_convert(attrs)
-        return nn.emit_te(topi.nn.softmax, *inputs, **new_attrs)
-
-
-# convert_map defines maps of name to converter functor(callable)
-# use attr_convert if attributes need to be converted
-# for 1 to N mapping(composed), use custom callable functions
-# for N to 1 mapping (fusion), write custom topi func
-
-# Minimal set of ops for transformer
-def get_convert_map():
-    return {
-        "nn.dense": Dense.get_converter(),
-        "nn.batch_norm": BatchNorm.get_converter(),
-        "nn.conv2d": Conv2D.get_converter(),
-        "nn.batch_matmul": BatchMatmul.get_converter(),
-        "nn.softmax": Softmax.get_converter(),
-    }
-
-
-def convert_operator(op_type: str, inputs: List[relax.Expr], attrs: Dict = None):
-    """Convert from Relay operator to Relax operator/topi function.
-    The converter must specify conversions explicitly for incompatible name, and
-    apply handlers to operator attributes.
-
-    Parameters
-    ----------
-    op_type : str
-        Operator name, such as Convolution, FullyConnected
-    inputs : list of Expr
-        List of input inputs.
-    attrs : dict
-        Dict of operator attributes
-
-    Returns
-    -------
-    func : tvm.relay.function.Function
-        Converted relay function
-    """
-    convert_map = get_convert_map()
-    if op_type in convert_map:
-        func = convert_map[op_type](inputs, attrs)
-    else:
-        raise tvm.error.OpNotImplemented("Operator {} is not supported.".format(op_type))
-    return func
-
-
-def attr_convert(attrs: tvm.ir.Attrs) -> Dict:
-    """Convert attributes to a dict."""
-    attrs_dict = {}
-
-    for k in attrs.keys():
-        attrs_dict[k] = attrs[k]
-
-    return attrs_dict
-
-
-def from_relay(func: relay.Function) -> IRModule:
+def from_relay(
+    func: relay.Function,
+    target: Target,
+    relay_params: Optional[Dict[str, NDArray]] = None,
+    *,
+    opt_level: int = 3,
+    pass_config: Optional[Dict[str, Any]] = None,
+    disabled_pass: Optional[List[str]] = None,
+) -> IRModule:
     """Convert a Relay function into a Relax program.
 
     Parameters
@@ -166,8 +55,28 @@ def from_relay(func: relay.Function) -> IRModule:
     var_map = {}
     # The output of the function
     output_var = None
+
+    if not isinstance(target, Target):
+        target = Target(target)
+    if disabled_pass is None:
+        disabled_pass = []
+    if pass_config is None:
+        pass_config = {"relay.FuseOps.max_depth": 1, "relay.backend.use_meta_schedule": True}
+
+    if relay_params:
+        func = relay.build_module.bind_params_by_name(func, relay_params)
+    mod = tvm.IRModule.from_expr(func)
+
+    # List of subset of relay->relay optimizations
+    # See src/relay/backend/utils.cc::GetPassPrefix() for full list
+    seq = tvm.get_global_func("relay.backend.GetPassPrefixSeq")(True, True)
+
+    with tvm.transform.PassContext(
+        opt_level=opt_level, config=pass_config, disabled_pass=disabled_pass
+    ):
+        mod = seq(mod)
+    func = mod["main"]
     params = []
-    convert_map = get_convert_map()
 
     def visit_func(node):
         nonlocal output_var
@@ -182,25 +91,33 @@ def from_relay(func: relay.Function) -> IRModule:
         elif isinstance(node, relay.Call):
             args = node.args
             new_args = []
+            te_inputs = []
             for arg in args:
                 if arg in var_map:
                     new_args.append(var_map[arg])
+                    te_inputs.append(tvm.relax.expr.te_tensor(new_args[-1]))
 
             op_name = node.op.name
             attrs = node.attrs
-            compute_func = node.op.get_attr("FTVMCompute")
-            if compute_func is None:
-                if node.op.name not in convert_map:
-                    raise tvm.error.OpNotImplemented(
-                        "Operator {} is not supported.".format(op_name)
-                    )
-                var = convert_operator(op_name, new_args, attrs)
-            else:
+            out_type = node.checked_type
+            # @sunggg: its funny that we need this target context despite the target argument
+            # PassContext is also necessary for winograd-like lowerings
+            with target, tvm.transform.PassContext(
+                opt_level=opt_level, config=pass_config, disabled_pass=disabled_pass
+            ):
+                best_impl, outputs = select_implementation(
+                    node.op,
+                    attrs,
+                    te_inputs,
+                    out_type,
+                    target,
+                    use_autotvm=False,
+                )
+                compute_func = best_impl.compute
                 name_hint = op_name.split(".")[-1]
                 var = bb.emit_te(
                     compute_func, attrs, new_args, node.checked_type, primfunc_name_hint=name_hint
                 )
-
             output_var = var
             var_map[node] = var
         elif isinstance(node, relay.Constant):

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -356,7 +356,7 @@ void BindParamsInModule(IRModule mod, Map<String, runtime::NDArray> params) {
 }
 
 TVM_REGISTER_GLOBAL("relay.backend.GetPassPrefixSeq")
-    .set_body_typed([](bool is_homogeneous, bool is_vm){
+    .set_body_typed([](bool is_homogeneous, bool is_vm) {
       auto pass_seqs = GetPassPrefix(is_homogeneous, is_vm);
       transform::Sequential seq(pass_seqs);
       return seq;

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -355,6 +355,13 @@ void BindParamsInModule(IRModule mod, Map<String, runtime::NDArray> params) {
   BindParamsInModule(mod, params_tmp);
 }
 
+TVM_REGISTER_GLOBAL("relay.backend.GetPassPrefixSeq")
+    .set_body_typed([](bool is_homogeneous, bool is_vm){
+      auto pass_seqs = GetPassPrefix(is_homogeneous, is_vm);
+      transform::Sequential seq(pass_seqs);
+      return seq;
+    });
+
 }  // namespace backend
 }  // namespace relay
 }  // namespace tvm

--- a/tests/python/relax/test_relay_translator.py
+++ b/tests/python/relax/test_relay_translator.py
@@ -1,0 +1,191 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+from tvm.relay import testing
+from tvm import relax, relay
+from tvm.relax.testing import relay_translator
+from tvm import meta_schedule as ms
+from tvm.target import Target
+import numpy as np
+import pytest
+import os, shutil
+from tvm.meta_schedule.database import JSONDatabase
+import tempfile
+from tvm.meta_schedule.task_scheduler import RoundRobin
+
+
+def get_resnet(batch_size, dtype, layout, image_shape):
+    relay_mod, params = testing.resnet.get_workload(
+        num_layers=18,
+        batch_size=batch_size,
+        dtype=dtype,
+        layout=layout,
+        image_shape=image_shape,
+    )
+
+    return relay_mod, params
+
+
+def create_database(workload_file, tuning_record_file):
+    os.makedirs(os.path.dirname(workload_file), exist_ok=True)
+    database = JSONDatabase(
+        path_workload=workload_file,
+        path_tuning_record=tuning_record_file,
+    )
+    return database
+
+
+def relay_build_and_run(mod, target, dev, params, data):
+    dirpath = "relay_tmp"
+    db = create_database(f"{dirpath}/workload.json", f"{dirpath}/record.json")
+    with tempfile.TemporaryDirectory() as work_dir:
+        ex = ms.tune_relay(
+            mod=mod,
+            params=params,
+            target=target,
+            config=ms.EvolutionarySearchConfig(
+                num_trials_per_iter=32,
+                max_trials_per_task=3,
+                max_trials_global=300,
+            ),
+            # TODO: commented out for now due to the error
+            # task_scheduler=RoundRobin,
+            work_dir=work_dir,
+            database=db,
+        )
+
+    rt_mod = tvm.contrib.graph_executor.GraphModule(ex["default"](dev))
+    rt_mod.set_input("data", data)
+    rt_mod.run()
+    out = rt_mod.get_output(0).asnumpy()
+
+    # cleanup
+    shutil.rmtree(dirpath)
+    return ex, rt_mod, out
+
+
+def relax_build_and_run(mod, target, dev, params, data):
+    dirpath = "relax_tmp"
+    db = create_database(f"{dirpath}/workload.json", f"{dirpath}/record.json")
+    mod = relax.transform.BindParams("main", params)(mod)
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        ex = ms.tune_relax(
+            mod=mod,
+            target=target,
+            config=ms.EvolutionarySearchConfig(
+                num_trials_per_iter=32,
+                max_trials_per_task=3,
+                max_trials_global=300,
+            ),
+            # TODO: commented out for now due to the error
+            # task_scheduler=RoundRobin,
+            work_dir=work_dir,
+            database=db,
+        )
+    vm = relax.VirtualMachine(ex, dev)
+    res = vm["main"](data)
+    out = res.numpy()
+    # cleanup
+    shutil.rmtree(dirpath)
+    return ex, vm, out
+
+
+def verify_e2e_translation(target_str, layout, batch_size, image_shape):
+    target = Target(target_str)
+    dev = tvm.device(str(target), dev_id=0)
+    relay_mod, params = get_resnet(batch_size, "float32", layout, image_shape)
+    input_shape = (1, *image_shape)
+    data = tvm.nd.array(np.random.rand(*input_shape).astype(np.float32), dev)
+
+    relax_mod = relay_translator.from_relay(relay_mod["main"], target, params)
+
+    relay_ex, relay_rt_mod, relay_out = relay_build_and_run(relay_mod, target, dev, params, data)
+    relax_ex, relax_rt_mod, relax_out = relax_build_and_run(relax_mod, target, dev, params, data)
+
+    tvm.testing.assert_allclose(relay_out, relax_out, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.skip(reason="take too much time")
+@pytest.mark.parametrize(
+    "layout, batch_size, image_shape", [("NCHW", 1, (3, 224, 224)), ("NHWC", 1, (224, 224, 3))]
+)
+def test_verify_e2e_translation_cpu(layout, batch_size, image_shape):
+    verify_e2e_translation("llvm --num-cores=16", layout, batch_size, image_shape)
+
+
+@pytest.mark.skip(reason="take too much time")
+@tvm.testing.requires_gpu
+@pytest.mark.parametrize(
+    "layout, batch_size, image_shape", [("NCHW", 1, (3, 224, 224)), ("NHWC", 1, (224, 224, 3))]
+)
+def test_verify_e2e_translation_gpu(layout, batch_size, image_shape):
+    verify_e2e_translation("nvidia/geforce-rtx-3070", layout, batch_size, image_shape)
+
+
+def verify_extracted_tasks(target_str, layout, batch_size, image_shape):
+    target = Target(target_str)
+    relay_mod, params = get_resnet(batch_size, "float32", layout, image_shape)
+
+    relax_mod = relay_translator.from_relay(
+        relay_mod["main"],
+        target,
+        params,
+        pass_config={
+            "relay.backend.use_meta_schedule": True,
+            "relay.FuseOps.max_depth": 1,  # Disable relay fusion
+        },
+    )
+
+    relay_tasks = ms.extract_task_from_relay(
+        relay_mod,
+        target=target,
+        params=params,
+        pass_config={
+            "relay.backend.use_meta_schedule": True,
+            "relay.FuseOps.max_depth": 1,  # Disable relay fusion
+        },
+    )
+    relax_tasks = ms.extract_task_from_relax(relax_mod, target=target, params=params)
+    assert len(relay_tasks) == len(relax_tasks)
+    # TODO: Can we compare extracted tasks as well?
+
+
+@pytest.mark.parametrize(
+    "layout, batch_size, image_shape",
+    [
+        # TODO: This test fails due to the different number of extracted tasks
+        # ("NCHW", 1, (3, 224, 224)),
+        ("NHWC", 1, (224, 224, 3)),
+    ],
+)
+def test_verify_extracted_tasks_cpu(layout, batch_size, image_shape):
+    verify_extracted_tasks("llvm --num-cores=16", layout, batch_size, image_shape)
+
+
+@tvm.testing.requires_gpu
+@pytest.mark.parametrize(
+    "layout, batch_size, image_shape", [("NCHW", 1, (3, 224, 224)), ("NHWC", 1, (224, 224, 3))]
+)
+def test_verify_extracted_tasks_gpu(layout, batch_size, image_shape):
+    verify_extracted_tasks("nvidia/geforce-rtx-3070", layout, batch_size, image_shape)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/relax/test_relay_translator.py
+++ b/tests/python/relax/test_relay_translator.py
@@ -136,7 +136,7 @@ def test_verify_e2e_translation_cpu(layout, batch_size, image_shape):
     "layout, batch_size, image_shape", [("NCHW", 1, (3, 224, 224)), ("NHWC", 1, (224, 224, 3))]
 )
 def test_verify_e2e_translation_gpu(layout, batch_size, image_shape):
-    verify_e2e_translation("nvidia/geforce-rtx-3070", layout, batch_size, image_shape)
+    verify_e2e_translation("cuda", layout, batch_size, image_shape)
 
 
 def verify_extracted_tasks(target_str, layout, batch_size, image_shape):
@@ -184,7 +184,7 @@ def test_verify_extracted_tasks_cpu(layout, batch_size, image_shape):
     "layout, batch_size, image_shape", [("NCHW", 1, (3, 224, 224)), ("NHWC", 1, (224, 224, 3))]
 )
 def test_verify_extracted_tasks_gpu(layout, batch_size, image_shape):
-    verify_extracted_tasks("nvidia/geforce-rtx-3070", layout, batch_size, image_shape)
+    verify_extracted_tasks("cuda", layout, batch_size, image_shape)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_relay_translator.py
+++ b/tests/python/relax/test_relay_translator.py
@@ -162,6 +162,7 @@ def verify_extracted_tasks(target_str, layout, batch_size, image_shape):
             "relay.FuseOps.max_depth": 1,  # Disable relay fusion
         },
     )
+
     relax_tasks = ms.extract_task_from_relax(relax_mod, target=target, params=params)
     assert len(relay_tasks) == len(relax_tasks)
     # TODO: Can we compare extracted tasks as well?
@@ -170,8 +171,7 @@ def verify_extracted_tasks(target_str, layout, batch_size, image_shape):
 @pytest.mark.parametrize(
     "layout, batch_size, image_shape",
     [
-        # TODO: This test fails due to the different number of extracted tasks
-        # ("NCHW", 1, (3, 224, 224)),
+        ("NCHW", 1, (3, 224, 224)),
         ("NHWC", 1, (224, 224, 3)),
     ],
 )


### PR DESCRIPTION
Currently, Relay translator relies on the hand-written conversion rule for lowering. 
To make this process automatic and robust, this PR uses `OpStrategy` as Relay pipeline does. 
Also, for the fair comparison with Relay side, it applies several default Relay->Relay transformation passes before the translation. 

Then we can emulate Relay pipeline in the Relax world: 
Relay pipeline: 
* Relay->Relay transformation. (RelayTranslator before the conversion)  
* Relay->TIR lowering w/ `OpStrategy` (Relay translator during the conversion)
* TIR->TIR transformation (`tvm.build` invoked in `relax.vm.build`)
* TIR->Binary w/ codegen (`tvm.build` invoked in `relax.vm.build`)

TODO (Any help or suggestion would be very appreciated): 
1. Verify the sanity of lowering outputs (e.g., Winograd)
2. Compare Relay ExtractedTasks and Relax ExtractedTasks. - Can we automate this process?

cc @Hzfengsy @YuchenJin @yongwww @junrushao1994 