### PR TITLE
[AST][Type] Introduce ObjectType; Infer the type of call_packed by type_args; Refactor InferType/InferShape.

### DIFF
--- a/include/tvm/ir/type_functor.h
+++ b/include/tvm/ir/type_functor.h
@@ -91,6 +91,7 @@ class TypeFunctor<R(const Type& n, Args...)> {
   virtual R VisitType_(const PrimTypeNode* op, Args... args) TYPE_FUNCTOR_DEFAULT;
   virtual R VisitType_(const PointerTypeNode* op, Args... args) TYPE_FUNCTOR_DEFAULT;
   virtual R VisitType_(const relax::ShapeTypeNode* op, Args... args) TYPE_FUNCTOR_DEFAULT;
+  virtual R VisitType_(const relax::ObjectTypeNode* op, Args... args) TYPE_FUNCTOR_DEFAULT;
   virtual R VisitType_(const relax::DynTensorTypeNode* op, Args... args) TYPE_FUNCTOR_DEFAULT;
   virtual R VisitType_(const relax::DimTypeNode* op, Args... args) TYPE_FUNCTOR_DEFAULT;
   virtual R VisitTypeDefault_(const Object* op, Args...) {
@@ -117,6 +118,7 @@ class TypeFunctor<R(const Type& n, Args...)> {
     TVM_TYPE_FUNCTOR_DISPATCH(PrimTypeNode);
     TVM_TYPE_FUNCTOR_DISPATCH(PointerTypeNode);
     TVM_TYPE_FUNCTOR_DISPATCH(relax::ShapeTypeNode);
+    TVM_TYPE_FUNCTOR_DISPATCH(relax::ObjectTypeNode);
     TVM_TYPE_FUNCTOR_DISPATCH(relax::DynTensorTypeNode);
     TVM_TYPE_FUNCTOR_DISPATCH(relax::DimTypeNode);
     return vtable;

--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -56,6 +56,25 @@ class ShapeType : public Type {
   TVM_DEFINE_OBJECT_REF_METHODS(ShapeType, Type, ShapeTypeNode);
 };
 
+class ObjectTypeNode : public TypeNode {
+ public:
+  void VisitAttrs(tvm::AttrVisitor* v) { v->Visit("span", &span); }
+
+  bool SEqualReduce(const ObjectTypeNode* other, SEqualReducer equal) const { return true; }
+
+  void SHashReduce(SHashReducer hash_reduce) const { hash_reduce(0); }
+
+  static constexpr const char* _type_key = "relax.ObjectType";
+  TVM_DECLARE_FINAL_OBJECT_INFO(ObjectTypeNode, TypeNode);
+};
+
+class ObjectType : public Type {
+ public:
+  TVM_DLL ObjectType(Span span = Span());
+
+  TVM_DEFINE_OBJECT_REF_METHODS(ObjectType, Type, ObjectTypeNode);
+};
+
 class DynTensorTypeNode : public BaseTensorTypeNode {
  public:
   /*!

--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -121,6 +121,11 @@ class DynTensorType : public Type {
    */
   TVM_DLL DynTensorType(int ndim, DataType dtype, Span span = Span());
 
+  /*!
+   * \brief Create a DynTensorType with unknown ndim.
+   */
+  TVM_DLL static DynTensorType CreateUnknownNDim(DataType dtype, Span span = Span());
+
   TVM_DEFINE_OBJECT_REF_METHODS(DynTensorType, Type, DynTensorTypeNode);
 };
 

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -58,6 +58,7 @@ te_tensor = expr.te_tensor
 # Type
 Type = ty.Type
 ShapeType = ty.ShapeType
+ObjectType = ty.ObjectType
 DynTensorType = ty.DynTensorType
 DimType = ty.DimType
 TupleType = ty.TupleType

--- a/python/tvm/relax/ty.py
+++ b/python/tvm/relax/ty.py
@@ -32,7 +32,8 @@ class ShapeType(Type):
 
 @tvm._ffi.register_object("relax.ObjectType")
 class ObjectType(Type):
-    """A type that corresponds to tvm::runtime::Object, is base of all possible object values in TVM."""
+    """A type that corresponds to tvm::runtime::Object, is base of all possible object
+    values in TVM."""
 
     def __init__(self, span: Span = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.ObjectType, span)

--- a/python/tvm/relax/ty.py
+++ b/python/tvm/relax/ty.py
@@ -32,11 +32,7 @@ class ShapeType(Type):
 
 @tvm._ffi.register_object("relax.ObjectType")
 class ObjectType(Type):
-    """A general type in Relax.
-
-    Its runtime types can be tvm::runtime::Object such as String, Array, Integer, etc.
-
-    """
+    """A type that corresponds to tvm::runtime::Object, is base of all possible object values in TVM."""
 
     def __init__(self, span: Span = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.ObjectType, span)
@@ -57,7 +53,7 @@ class DynTensorType(Type):
         The content data type.
     """
 
-    def __init__(self, ndim=-1, dtype="float32", span: Span = None):
+    def __init__(self, ndim=-1, dtype="float32", span: Span = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.DynTensorType, ndim, dtype, span)
 
 

--- a/python/tvm/relax/ty.py
+++ b/python/tvm/relax/ty.py
@@ -24,8 +24,22 @@ from . import _ffi_api
 
 @tvm._ffi.register_object("relax.ShapeType")
 class ShapeType(Type):
-    def __init__(self, span: Span = None):
+    """The type of shape in Relax."""
+
+    def __init__(self, span: Span = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.ShapeType, span)
+
+
+@tvm._ffi.register_object("relax.ObjectType")
+class ObjectType(Type):
+    """A general type in Relax.
+
+    Its runtime types can be tvm::runtime::Object such as String, Array, Integer, etc.
+
+    """
+
+    def __init__(self, span: Span = None) -> None:
+        self.__init_handle_by_constructor__(_ffi_api.ObjectType, span)
 
 
 @tvm._ffi.register_object("relax.DynTensorType")
@@ -51,7 +65,7 @@ class DynTensorType(Type):
 class DimType(Type):
     """The type of indices/shape dimensions in Relax."""
 
-    def __init__(self, span: Span = None):
+    def __init__(self, span: Span = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.DimType, span)
 
 

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -1008,52 +1008,62 @@ class RelaxTransformer(Transformer):
         const_values = _get_values(expr, [])
         return relax.const(const_values)
 
-    def parse_call_type_args(self, expr: ast.Call) -> Union[relax.Type, List[relax.Type], None]:
-        """Parses the keyword parameters with the keyword "type_args" as the type_args of the call.
+    # TODO(@tvm-team): Currenly the synr is over-specialized, unify with transform_type
+    # to parse types in the future
+    def parse_type_from_value(self, val: ast.Expr) -> relax.Type:
+        """Parses the type_args value of a call to a Relax type.
 
         Parameters
         ----------
-        expr : ast.Call
-            The synr Call to be parsed.
+        val : ast.Expr
+            The type_args value to be parsed.
 
         Returns
         -------
-        Union[relax.Type, List[relax.Type], None]
-            The parsed call type_args.
+        relax.Type
+            The parsed Relax type.
         """
-        for key, val in expr.keyword_params.items():
-            if key.value == "type_args":
-                if isinstance(val, ast.Call):
-                    if val.func_name.id.name != "Tensor":
-                        self.report_error(
-                            f"type_args elements must be Tensor, Object, or Shape", val.span
-                        )
+        if isinstance(val, ast.Var):
+            if val.id.name == "Tensor":
+                return relax.DynTensorType(ndim=-1, dtype=None, span=self.to_tvm_span(val.span))
+            elif val.id.name == "Object":
+                return relax.ObjectType(self.to_tvm_span(val.span))
+            elif val.id.name == "Shape":
+                return relax.ShapeType(self.to_tvm_span(val.span))
+            elif val.id.name == "Void":
+                return relay.TupleType(None, self.to_tvm_span(val.span))
+            else:
+                self.report_error(
+                    f"type_args value must be Tensor, Object, Shape, Void, or Tuple()", val.span
+                )
+        elif isinstance(val, ast.Call):
+            if val.func_name.id.name == "Tensor":
+                ndim = -1
+                dtype = None
+                for k, v in val.keyword_params.items():
+                    if k.value == "ndim":
+                        ndim = v.value
+                    if k.value == "dtype":
+                        dtype = v.value
+                return relax.DynTensorType(ndim, dtype, self.to_tvm_span(val.span))
+            elif val.func_name.id.name == "Tuple":
+                field_types = []
+                for field in val.params:
+                    fty = self.parse_type_from_value(field)
+                    field_types.append(fty)
+                return relax.TupleType(field_types, self.to_tvm_span(val.span))
+            else:
+                self.report_error(
+                    f"type_args elements must be Tensor or Tuple when having arguments, but meet {val.func_name.id.name}",
+                    val.span,
+                )
+        else:
+            self.report_error(
+                f"cannot parse {val} as the type_args value",
+                val.span,
+            )
 
-                    ndim = -1
-                    dtype = None
-                    for k, v in val.keyword_params.items():
-                        if k.value == "ndim":
-                            ndim = v.value
-                        if k.value == "dtype":
-                            dtype = v.value
-                    return relax.DynTensorType(ndim, dtype, self.to_tvm_span(val.span))
-                elif isinstance(val, ast.Var):
-                    if val.id.name == "Object":
-                        return relax.ObjectType(self.to_tvm_span(val.span))
-                    elif val.id.name == "Shape":
-                        return relax.ShapeType(self.to_tvm_span(val.span))
-                    else:
-                        self.report_error(
-                            f"type_args elements must be Tensor, Object, or Shape", val.span
-                        )
-                elif isinstance(val, ast.Tuple):
-                    fields = [self.parse_call_type_args(field) for field in val.values]
-                    return fields
-                else:
-                    self.report_error(f"unsupported expression: {expr}", expr.span)
-        return None
-
-    def parse_call_attr(self, expr: ast.Call) -> Union[tvm.ir.Attrs, None]:
+    def parse_call_attr(self, expr: ast.Call) -> Tuple(tvm.ir.Attrs, List[relax.Type]):
         """Parses keyword parameters as call attributes.
 
         Parameters
@@ -1063,13 +1073,18 @@ class RelaxTransformer(Transformer):
 
         Returns
         -------
-        Union[tvm.ir.Attrs, None]
-            The parsed call attributes.
+        Tuple(tvm.ir.Attrs, List[relax.Type])
+            The parsed call attributes and type_args.
         """
         op = self.transform_expr(expr.func_name)
         kwargs = {}
+        type_args = None
         for key, val in expr.keyword_params.items():
-            if key.value != "type_args":
+            if key.value == "type_args":
+                type_args = self.parse_type_from_value(val)
+                if type_args:
+                    type_args = [type_args]
+            else:
                 assert isinstance(key, ast.Constant) and isinstance(key.value, str)
                 # TODO(@altanh): might need separate attribute parsing eventually
                 kwargs[key.value] = self.transform_expr(val)
@@ -1087,7 +1102,7 @@ class RelaxTransformer(Transformer):
         attrs = None
         if kwargs or not is_default:
             attrs = tvm.ir.attrs.make_node(attrs_type_key, **kwargs)
-        return attrs
+        return (attrs, type_args)
 
     def parse_call(self, expr: ast.Call) -> Union[tir.PrimExpr, relax.Expr]:
         """Parses the given synr Call node to a Relax expression or PrimExpr.
@@ -1138,10 +1153,7 @@ class RelaxTransformer(Transformer):
                 return self.transform_Subscript(expr)
 
         op = self.transform_expr(expr.func_name)
-
-        type_args = self.parse_call_type_args(expr)
-        if type_args and not isinstance(type_args, list):
-            type_args = [type_args]
+        type_args = None
 
         if op == SpecialOp.CALL_PACKED:
             extern_func = expr.params[0]
@@ -1262,7 +1274,10 @@ class RelaxTransformer(Transformer):
         if isinstance(op, tvm.ir.Op) and op.name == "relax.call_tir":
             attrs = None
         else:
-            attrs = self.parse_call_attr(expr)
+            attrs, type_args = self.parse_call_attr(expr)
+
+        if isinstance(op, relax.ExternFunc) and type_args == None:
+            self.report_error(f"call_packed is required to have type_args", expr.span)
 
         return relax.Call(
             op, args, attrs=attrs, type_args=type_args, span=self.to_tvm_span(expr.span)

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -1029,14 +1029,14 @@ class RelaxTransformer(Transformer):
                             f"type_args elements must be Tensor, Object, or Shape", val.span
                         )
 
-                    rank = -1
+                    ndim = -1
                     dtype = None
                     for k, v in val.keyword_params.items():
-                        if k.value == "rank":
-                            rank = v.value
+                        if k.value == "ndim":
+                            ndim = v.value
                         if k.value == "dtype":
                             dtype = v.value
-                    return relax.DynTensorType(rank, dtype, self.to_tvm_span(val.span))
+                    return relax.DynTensorType(ndim, dtype, self.to_tvm_span(val.span))
                 elif isinstance(val, ast.Var):
                     if val.id.name == "Object":
                         return relax.ObjectType(self.to_tvm_span(val.span))

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -334,6 +334,8 @@ class RelaxTransformer(Transformer):
                 return (relax.DynTensorType(ndim=-1, dtype=None, span=span), None)
             elif ty.id.name == "Shape":
                 return (relax.ShapeType(span), None)
+            elif ty.id.name == "Object":
+                return (relax.ObjectType(span), None)
             elif ty.id.name == "Dim":
                 return (relax.DimType(span), None)
             self.report_error("unknown type in annotation", ty.span)

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -1054,7 +1054,8 @@ class RelaxTransformer(Transformer):
                 return relax.TupleType(field_types, self.to_tvm_span(val.span))
             else:
                 self.report_error(
-                    f"type_args elements must be Tensor or Tuple when having arguments, but meet {val.func_name.id.name}",
+                    f"""type_args elements must be Tensor or Tuple when having arguments,
+                    but meet {val.func_name.id.name}""",
                     val.span,
                 )
         else:
@@ -1276,7 +1277,7 @@ class RelaxTransformer(Transformer):
         else:
             attrs, type_args = self.parse_call_attr(expr)
 
-        if isinstance(op, relax.ExternFunc) and type_args == None:
+        if isinstance(op, relax.ExternFunc) and type_args is None:
             self.report_error(f"call_packed is required to have type_args", expr.span)
 
         return relax.Call(

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -422,7 +422,7 @@ std::vector<Doc> RelaxScriptPrinter::PrintTypeArgs(const Array<tvm::Type>& type_
     for (const auto& type : type_args) {
       if (const auto* tensor = type.as<DynTensorTypeNode>()) {
         Doc doc;
-        doc << "Tensor(rank=" << tensor->rank << ", dtype=" << PrintDType(tensor->dtype) << ")";
+        doc << "Tensor(ndim=" << tensor->ndim << ", dtype=" << PrintDType(tensor->dtype) << ")";
         type_args_doc.push_back(doc);
       } else {
         type_args_doc.push_back(this->VisitType(type));

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -35,6 +35,8 @@
 namespace tvm {
 namespace relax {
 
+Doc PrintDType(DataType dtype) { return Doc::StrLiteral(runtime::DLDataType2String(dtype)); }
+
 Doc RelaxScriptPrinter::Print(const ObjectRef& node) {
   if (node->IsInstance<IRModuleNode>()) {
     return PrintIRModule(Downcast<IRModule>(node));
@@ -90,13 +92,13 @@ Doc RelaxScriptPrinter::VisitNode_(const relay::CallNode* op) {
 
     Type output_type = op->type_args[0];
     if (const auto* out_type = output_type.as<DynTensorTypeNode>()) {
-      doc << ", dtype=" << Doc::StrLiteral(runtime::DLDataType2String(out_type->dtype)) << ")";
+      doc << ", dtype=" << PrintDType(out_type->dtype) << ")";
     } else if (const auto* out_type = output_type.as<TupleTypeNode>()) {
       std::vector<Doc> dtypes;
       for (auto field : out_type->fields) {
         if (const auto* field_type = field.as<DynTensorTypeNode>()) {
           Doc dtype;
-          dtype << Doc::StrLiteral(runtime::DLDataType2String(field_type->dtype));
+          dtype << PrintDType(field_type->dtype);
           dtypes.push_back(dtype);
         } else {
           LOG(FATAL) << "TypeError: Invalid type: " << field_type->GetTypeKey();
@@ -127,6 +129,13 @@ Doc RelaxScriptPrinter::VisitNode_(const relay::CallNode* op) {
   }
   if (!attrs.empty()) {
     doc << ", " << Doc::Concat(attrs);
+  }
+
+  if (!op->type_args.empty()) {
+    doc << ", type_args=(";
+    std::vector<Doc> type_args = PrintTypeArgs(op->type_args);
+    doc << Doc::Concat(type_args);
+    doc << ")";
   }
 
   doc << ")";
@@ -355,6 +364,10 @@ TVM_DEFINE_RELAX_PRINTER_PRIMEXPR_BINOP(tir::FloorDivNode, " // ");
 
 Doc RelaxScriptPrinter::VisitType_(const relax::ShapeTypeNode* node) { return Doc::Text("Shape"); }
 
+Doc RelaxScriptPrinter::VisitType_(const relax::ObjectTypeNode* node) {
+  return Doc::Text("Object");
+}
+
 Doc RelaxScriptPrinter::VisitType_(const relax::DynTensorTypeNode* node) {
   // NOTE: to print shape information, use PrintTensorAnnotation
   return PrintTensorAnnotation(GetRef<DynTensorType>(node), NullOpt);
@@ -401,6 +414,22 @@ std::vector<Doc> RelaxScriptPrinter::PrintAttrs(const Attrs& attrs) {
     const_cast<BaseAttrsNode*>(attrs.operator->())->VisitAttrs(&attr_printer);
   }
   return kwargs;
+}
+
+std::vector<Doc> RelaxScriptPrinter::PrintTypeArgs(const Array<tvm::Type>& type_args) {
+  std::vector<Doc> type_args_doc;
+  if (!type_args.empty()) {
+    for (const auto& type : type_args) {
+      if (const auto* tensor = type.as<DynTensorTypeNode>()) {
+        Doc doc;
+        doc << "Tensor(rank=" << tensor->rank << ", dtype=" << PrintDType(tensor->dtype) << ")";
+        type_args_doc.push_back(doc);
+      } else {
+        type_args_doc.push_back(this->VisitType(type));
+      }
+    }
+  }
+  return type_args_doc;
 }
 
 Doc RelaxScriptPrinter::VisitAttrDefault_(const Object* op) {
@@ -534,7 +563,7 @@ Doc RelaxScriptPrinter::PrintTensorAnnotation(const relax::DynTensorType& ty,
   if (ty->dtype.is_void()) {
     doc << "_";
   } else {
-    doc << Doc::StrLiteral(runtime::DLDataType2String(ty->dtype));
+    doc << PrintDType(ty->dtype);
   }
   // Print ndim annotation only when it cannot be inferred from shape itself.
   if (!shape.defined() || shape->IsInstance<relax::RuntimeDepShapeNode>()) {

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -782,6 +782,12 @@ Doc RelayTextPrinter::VisitType_(const relax::DynTensorTypeNode* node) {
   return doc;
 }
 
+Doc RelayTextPrinter::VisitType_(const relax::ObjectTypeNode* node) {
+  Doc doc;
+  doc << "Object";
+  return doc;
+}
+
 //------------------------------------
 // Overload of Attr printing functions
 //------------------------------------

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -195,6 +195,7 @@ class RelayTextPrinter : public ExprFunctor<Doc(const Expr&)>,
   Doc VisitType_(const RelayRefTypeNode* node) final;
   Doc VisitType_(const TypeDataNode* node) final;
   Doc VisitType_(const relax::DynTensorTypeNode* node) final;
+  Doc VisitType_(const relax::ObjectTypeNode* node) final;
   //------------------------------------
   // Overload of Attr printing functions
   //------------------------------------

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -306,11 +306,13 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   Doc PrintTupleAnnotation(const TupleType& ty, const Optional<ObjectRef>& shape);
 
   Doc VisitType_(const relax::ShapeTypeNode* node) override;
+  Doc VisitType_(const relax::ObjectTypeNode* node) override;
   Doc VisitType_(const relax::DynTensorTypeNode* node) override;
   Doc VisitType_(const relay::TupleTypeNode* node) override;
 
   Doc PrintAttr(const ObjectRef& attr);
   std::vector<Doc> PrintAttrs(const Attrs& attrs);
+  std::vector<Doc> PrintTypeArgs(const Array<tvm::Type>& type_args);
   Doc VisitAttrDefault_(const Object* op) override;
   Doc PrintExpr(const Expr& expr, bool meta, bool try_inline, bool optional_info = true);
   Doc VisitAttr_(const ArrayNode* op) override;

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -102,7 +102,6 @@ class VMShapeLowerMutator : public ExprMutator {
         }
       }
     }
-    Type ret_type = this->VisitType(node->ret_type);
     Expr new_body = this->VisitExpr(node->body);
 
     Array<BindingBlock> blocks;
@@ -119,6 +118,11 @@ class VMShapeLowerMutator : public ExprMutator {
     // builder_->Emit(Call(ExternFunc("vm.builtin.free_shape_heap"), {shape_heap_}), "gv");
     new_body = builder_->Normalize(SeqExpr(blocks, new_body));
 
+    Type ret_type = this->VisitType(node->ret_type);
+    // weaken the ret_type given this pass is the last stage of build.
+    if (const DynTensorTypeNode* temp = ret_type.as<DynTensorTypeNode>()) {
+      ret_type = DynTensorType(-1, temp->dtype);
+    }
     return Function(node->name, node->params, new_body, ret_type);
   }
 

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -121,7 +121,7 @@ class VMShapeLowerMutator : public ExprMutator {
     Type ret_type = this->VisitType(node->ret_type);
     // weaken the ret_type given this pass is the last stage of build.
     if (const DynTensorTypeNode* temp = ret_type.as<DynTensorTypeNode>()) {
-      ret_type = DynTensorType(-1, temp->dtype);
+      ret_type = DynTensorType::CreateUnknownNDim(temp->dtype, Span());
     }
     return Function(node->name, node->params, new_body, ret_type);
   }

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -119,10 +119,14 @@ class VMShapeLowerMutator : public ExprMutator {
     new_body = builder_->Normalize(SeqExpr(blocks, new_body));
 
     Type ret_type = this->VisitType(node->ret_type);
-    // weaken the ret_type given this pass is the last stage of build.
+
+    // Because this pass is the last stage of build, ndim info is no longer needed for tensors.
+    // The ret_type is weakened to unknown-dimensional DynTensorType.
+    // TODO(@yuchen): change all tensor types in the function to unknown ndim
     if (const DynTensorTypeNode* temp = ret_type.as<DynTensorTypeNode>()) {
       ret_type = DynTensorType::CreateUnknownNDim(temp->dtype, Span());
     }
+
     return Function(node->name, node->params, new_body, ret_type);
   }
 

--- a/src/relax/ir/type.cc
+++ b/src/relax/ir/type.cc
@@ -102,11 +102,11 @@ bool IsBaseOf(const Type& base, const Type& derived) {
       return true;
     }
     return false;
+  } else if (base.as<ObjectTypeNode>()) {
+    return true;
   } else {
     LOG(FATAL) << "TypeError: cannot handle base type: " << base->GetTypeKey();
   }
-
-  // TODO(@yuchen): consider ObjectType relation after the pr's merged.
 
   return false;
 }

--- a/src/relax/ir/type.cc
+++ b/src/relax/ir/type.cc
@@ -55,6 +55,14 @@ DynTensorType::DynTensorType(int ndim, DataType dtype, Span span) {
   data_ = std::move(n);
 }
 
+DynTensorType DynTensorType::CreateUnknownNDim(DataType dtype, Span span) {
+  ObjectPtr<DynTensorTypeNode> n = make_object<DynTensorTypeNode>();
+  n->ndim = -1;
+  n->dtype = std::move(dtype);
+  n->span = std::move(span);
+  return DynTensorType(std::move(n));
+}
+
 TVM_REGISTER_NODE_TYPE(DynTensorTypeNode);
 
 TVM_REGISTER_GLOBAL("relax.DynTensorType").set_body_typed([](int ndim, DataType dtype, Span span) {

--- a/src/relax/ir/type.cc
+++ b/src/relax/ir/type.cc
@@ -37,6 +37,16 @@ ShapeType::ShapeType(Span span) {
 
 TVM_REGISTER_GLOBAL("relax.ShapeType").set_body_typed([](Span span) { return ShapeType(span); });
 
+ObjectType::ObjectType(Span span) {
+  ObjectPtr<ObjectTypeNode> n = make_object<ObjectTypeNode>();
+  n->span = span;
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(ObjectTypeNode);
+
+TVM_REGISTER_GLOBAL("relax.ObjectType").set_body_typed([](Span span) { return ObjectType(span); });
+
 DynTensorType::DynTensorType(int ndim, DataType dtype, Span span) {
   ObjectPtr<DynTensorTypeNode> n = make_object<DynTensorTypeNode>();
   n->ndim = std::move(ndim);

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -168,7 +168,7 @@ Type InferTypeVMAllocTensor(const Call& call, DiagnosticContext diag_ctx) {
   if (const auto* output_shape = call->args[1].as<ShapeExprNode>()) {
     return DynTensorType(output_shape->values.size(), attrs->dtype);
   }
-  return DynTensorType(-1, attrs->dtype);
+  return DynTensorType::CreateUnknownNDim(attrs->dtype, Span());
 }
 
 RELAY_REGISTER_OP("relax.vm.builtin.alloc_tensor")

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -51,6 +51,12 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs) {
   return false;
 }
 
+Type InferTypeVoid(const Call& call, DiagnosticContext diag_ctx) { return VoidType(); }
+
+Type InferTypeObject(const Call& call, DiagnosticContext diag_ctx) { return ObjectType(Span()); }
+
+Type InferTypeShape(const Call& call, DiagnosticContext diag_ctx) { return ShapeType(Span()); }
+
 // call_tir
 
 Optional<Expr> InferShapeCallTIR(const Call& call, DiagnosticContext diag_ctx) {
@@ -97,7 +103,8 @@ TVM_REGISTER_GLOBAL("relax.op.call_tir").set_body_typed(MakeCallTIR);
 
 RELAY_REGISTER_OP("relax.shape_of")
     .set_num_inputs(1)
-    .add_argument("input", "Expr", "The input expression");
+    .add_argument("input", "Expr", "The input expression")
+    .set_attr<FInferType>("FInferType", InferTypeShape);
 
 Expr MakeShapeOf(Expr expr) {
   static const Op& op = Op::Get("relax.shape_of");
@@ -108,10 +115,24 @@ TVM_REGISTER_GLOBAL("relax.op.shape_of").set_body_typed(MakeShapeOf);
 
 // alloc_tensor
 
+Optional<Expr> InferShapeAllocTensor(const Call& call, DiagnosticContext diag_ctx) {
+  return call->args[0];
+}
+
+Type InferTypeAllocTensor(const Call& call, DiagnosticContext diag_ctx) {
+  auto attrs = call->attrs.as<AllocTensorAttrs>();
+  ICHECK(attrs != nullptr) << "must be AllocTensorAttrs, but got " << call->attrs->GetTypeKey();
+  auto output_shape = call->args[0].as<ShapeExprNode>();
+  ICHECK(output_shape != nullptr) << "must be ShapeExpr, but got " << call->args[0]->GetTypeKey();
+  return DynTensorType(output_shape->values.size(), attrs->dtype);
+}
+
 RELAY_REGISTER_OP("relax.builtin.alloc_tensor")
     .set_attrs_type<AllocTensorAttrs>()
     .set_num_inputs(1)
-    .add_argument("shape", "Expr", "The shape of the tensor to allocate.");
+    .add_argument("shape", "Expr", "The shape of the tensor to allocate.")
+    .set_attr<FInferShape>("FInferShape", InferShapeAllocTensor)
+    .set_attr<FInferType>("FInferType", InferTypeAllocTensor);
 
 Expr MakeAllocTensor(Expr shape) {
   static const Op& op = Op::Get("relax.builtin.alloc_tensor");
@@ -125,7 +146,8 @@ TVM_REGISTER_GLOBAL("relax.op.builtin.alloc_tensor").set_body_typed(MakeAllocTen
 RELAY_REGISTER_OP("relax.vm.builtin.alloc_storage")
     .set_attrs_type<VMAllocStorageAttrs>()
     .set_num_inputs(1)
-    .add_argument("size", "Expr", "The size of the storage to allocate.");
+    .add_argument("size", "Expr", "The size of the storage to allocate.")
+    .set_attr<FInferType>("FInferType", InferTypeObject);
 
 Expr MakeVMAllocStorage(Expr size) {
   static const Op& op = Op::Get("relax.vm.builtin.alloc_storage");
@@ -136,14 +158,30 @@ TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_storage").set_body_typed(MakeVMAl
 
 // vm alloc_tensor
 
+Optional<Expr> InferShapeVMAllocTensor(const Call& call, DiagnosticContext diag_ctx) {
+  return call->args[1];
+}
+
+Type InferTypeVMAllocTensor(const Call& call, DiagnosticContext diag_ctx) {
+  auto attrs = call->attrs.as<VMAllocTensorAttrs>();
+  ICHECK(attrs != nullptr) << "must be VMAllocTensorAttrs , but got " << call->attrs->GetTypeKey();
+  if (const auto* output_shape = call->args[1].as<ShapeExprNode>()) {
+    return DynTensorType(output_shape->values.size(), attrs->dtype);
+  }
+  return DynTensorType(-1, attrs->dtype);
+}
+
 RELAY_REGISTER_OP("relax.vm.builtin.alloc_tensor")
     .set_attrs_type<VMAllocTensorAttrs>()
-    .set_num_inputs(1)
-    .add_argument("shape", "Expr", "The shape of the tensor to allocate.");
+    .set_num_inputs(2)
+    .add_argument("storage", "Expr", "The storage to allocate the tensor to.")
+    .add_argument("shape", "Expr", "The shape of the tensor to allocate.")
+    .set_attr<FInferShape>("FInferShape", InferShapeVMAllocTensor)
+    .set_attr<FInferType>("FInferType", InferTypeVMAllocTensor);
 
-Expr MakeVMAllocTensor(Expr shape) {
+Expr MakeVMAllocTensor(Expr storage, Expr shape) {
   static const Op& op = Op::Get("relax.vm.builtin.alloc_tensor");
-  return Call(op, {shape}, {}, {});
+  return Call(op, {storage, shape}, {}, {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_tensor").set_body_typed(MakeVMAllocTensor);
@@ -154,7 +192,8 @@ RELAY_REGISTER_OP("relax.vm.builtin.store_shape")
     .set_attrs_type<ShapeHeapAttrs>()
     .set_num_inputs(2)
     .add_argument("shape", "Expr", "The shape to be stored.")
-    .add_argument("heap", "Expr", "The heap to store the shape.");
+    .add_argument("heap", "Expr", "The heap to store the shape.")
+    .set_attr<FInferType>("FInferType", InferTypeVoid);
 
 Expr MakeStoreShape(Expr shape, Expr heap) {
   static const Op& op = Op::Get("relax.vm.builtin.store_shape");
@@ -168,7 +207,8 @@ TVM_REGISTER_GLOBAL("relax.op.vm.builtin.store_shape").set_body_typed(MakeStoreS
 RELAY_REGISTER_OP("relax.vm.builtin.load_shape")
     .set_attrs_type<ShapeHeapAttrs>()
     .set_num_inputs(1)
-    .add_argument("heap", "Expr", "The heap to load the shape from.");
+    .add_argument("heap", "Expr", "The heap to load the shape from.")
+    .set_attr<FInferType>("FInferType", InferTypeShape);
 
 Expr MakeLoadShape(Expr heap) {
   static const Op& op = Op::Get("relax.vm.builtin.load_shape");
@@ -178,11 +218,13 @@ Expr MakeLoadShape(Expr heap) {
 TVM_REGISTER_GLOBAL("relax.op.vm.builtin.load_shape").set_body_typed(MakeLoadShape);
 
 // vm call_tir_dyn
+
 RELAY_REGISTER_OP("relax.vm.call_tir_dyn")
     .set_num_inputs(2)
     .add_argument("func", "Expr", "The destination-passing-style function.")
     .add_argument("args", "Tuple",
-                  "The input arguments (list of tensors and last argument is ShapeExpr)");
+                  "The input arguments (list of tensors and last argument is ShapeExpr)")
+    .set_attr<FInferType>("FInferType", InferTypeVoid);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -51,11 +51,11 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs) {
   return false;
 }
 
-Type InferTypeVoid(const Call& call, DiagnosticContext diag_ctx) { return VoidType(); }
+Type ReturnVoidType(const Call& call, DiagnosticContext diag_ctx) { return VoidType(); }
 
-Type InferTypeObject(const Call& call, DiagnosticContext diag_ctx) { return ObjectType(Span()); }
+Type ReturnObjectType(const Call& call, DiagnosticContext diag_ctx) { return ObjectType(Span()); }
 
-Type InferTypeShape(const Call& call, DiagnosticContext diag_ctx) { return ShapeType(Span()); }
+Type ReturnShapeType(const Call& call, DiagnosticContext diag_ctx) { return ShapeType(Span()); }
 
 // call_tir
 
@@ -104,7 +104,7 @@ TVM_REGISTER_GLOBAL("relax.op.call_tir").set_body_typed(MakeCallTIR);
 RELAY_REGISTER_OP("relax.shape_of")
     .set_num_inputs(1)
     .add_argument("input", "Expr", "The input expression")
-    .set_attr<FInferType>("FInferType", InferTypeShape);
+    .set_attr<FInferType>("FInferType", ReturnShapeType);
 
 Expr MakeShapeOf(Expr expr) {
   static const Op& op = Op::Get("relax.shape_of");
@@ -147,7 +147,7 @@ RELAY_REGISTER_OP("relax.vm.builtin.alloc_storage")
     .set_attrs_type<VMAllocStorageAttrs>()
     .set_num_inputs(1)
     .add_argument("size", "Expr", "The size of the storage to allocate.")
-    .set_attr<FInferType>("FInferType", InferTypeObject);
+    .set_attr<FInferType>("FInferType", ReturnObjectType);
 
 Expr MakeVMAllocStorage(Expr size) {
   static const Op& op = Op::Get("relax.vm.builtin.alloc_storage");
@@ -193,7 +193,7 @@ RELAY_REGISTER_OP("relax.vm.builtin.store_shape")
     .set_num_inputs(2)
     .add_argument("shape", "Expr", "The shape to be stored.")
     .add_argument("heap", "Expr", "The heap to store the shape.")
-    .set_attr<FInferType>("FInferType", InferTypeVoid);
+    .set_attr<FInferType>("FInferType", ReturnVoidType);
 
 Expr MakeStoreShape(Expr shape, Expr heap) {
   static const Op& op = Op::Get("relax.vm.builtin.store_shape");
@@ -208,7 +208,7 @@ RELAY_REGISTER_OP("relax.vm.builtin.load_shape")
     .set_attrs_type<ShapeHeapAttrs>()
     .set_num_inputs(1)
     .add_argument("heap", "Expr", "The heap to load the shape from.")
-    .set_attr<FInferType>("FInferType", InferTypeShape);
+    .set_attr<FInferType>("FInferType", ReturnShapeType);
 
 Expr MakeLoadShape(Expr heap) {
   static const Op& op = Op::Get("relax.vm.builtin.load_shape");
@@ -224,7 +224,7 @@ RELAY_REGISTER_OP("relax.vm.call_tir_dyn")
     .add_argument("func", "Expr", "The destination-passing-style function.")
     .add_argument("args", "Tuple",
                   "The input arguments (list of tensors and last argument is ShapeExpr)")
-    .set_attr<FInferType>("FInferType", InferTypeVoid);
+    .set_attr<FInferType>("FInferType", ReturnVoidType);
 
 }  // namespace relax
 }  // namespace tvm

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -79,7 +79,7 @@ def test_annotations():
         x: Tensor((32, m), "float32"),
         y: Tensor((m, k), "float32"),
         r: Tensor(_, "int64"),
-    ) -> Tensor:
+    ) -> Object:
         z: Tensor((32, k), "float32") = nn.matmul(x, y, units=None)
         w: Tensor(None, _) = multiply(z, z)
         q: Tensor(None, _, ndim=2) = add(w, w)
@@ -570,7 +570,7 @@ def test_call_packed():
             x,
             x,
             mp=False,
-            type_args=(Tensor(rank=2, dtype="float32")),
+            type_args=(Tensor(ndim=2, dtype="float32")),
         )
         w = relax.call_packed(
             "contrib.my_shape_of",
@@ -629,7 +629,7 @@ def test_primexpr_arithmetic():
     @R.function
     def f(x: Tensor((n, m), "float32")):
         z: Tensor((n * m,), "float32") = relax.call_packed(
-            "my_flatten", (x,), type_args=(Tensor(rank=2, dtype="float32"))
+            "my_flatten", (x,), type_args=(Tensor(ndim=2, dtype="float32"))
         )
         sh: Shape = (n + m, n // m)
         return z
@@ -703,7 +703,7 @@ def test_class_irmodule():
         @R.function
         def k(x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")) -> Tensor:
             gv0 = relax.call_packed(
-                "test.vm.mul", x, w, type_args=(Tensor(rank=2, dtype="float32"))
+                "test.vm.mul", x, w, type_args=(Tensor(ndim=2, dtype="float32"))
             )
             return gv0
 
@@ -736,9 +736,9 @@ def test_class_irmodule():
     # check call_packed checked_type_
     gv0_bind = k.body.blocks[0].bindings[0]
     assert gv0_bind.value.checked_type.dtype == "float32"
-    assert gv0_bind.value.checked_type.rank == 2
+    assert gv0_bind.value.checked_type.ndim == 2
     assert gv0_bind.var.checked_type.dtype == "float32"
-    assert gv0_bind.var.checked_type.rank == 2
+    assert gv0_bind.var.checked_type.ndim == 2
 
     # check function type
     j_type = j.checked_type

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -183,7 +183,7 @@ def test_call_packed():
     def foo(x: Tensor((3, 3), "float32")):
         # test that we can intro dim vars
         z: Tensor((n, m), "float32") = relax.call_packed(
-            "contrib.my_matmul", x, x, mp=False, type_args=(Tensor(rank=2, dtype="float32"))
+            "contrib.my_matmul", x, x, mp=False, type_args=(Tensor(ndim=2, dtype="float32"))
         )
         w = relax.call_packed(
             "contrib.my_shape_of",
@@ -202,7 +202,7 @@ def test_primexpr_arithmetic():
     @R.function
     def foo(x: Tensor((n, m), "float32")):
         z: Tensor((n * m,), "float32") = relax.call_packed(
-            "my_flatten", (x,), type_args=(Tensor(rank=2, dtype="float32"))
+            "my_flatten", (x,), type_args=(Tensor(ndim=2, dtype="float32"))
         )
         sh: Shape = (n + m, n // m)
         return z

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -182,9 +182,15 @@ def test_call_packed():
     @R.function
     def foo(x: Tensor((3, 3), "float32")):
         # test that we can intro dim vars
-        z: Tensor((n, m), "float32") = relax.call_packed("contrib.my_matmul", x, x, mp=False)
+        z: Tensor((n, m), "float32") = relax.call_packed(
+            "contrib.my_matmul", x, x, mp=False, type_args=(Tensor(rank=2, dtype="float32"))
+        )
         w = relax.call_packed(
-            "contrib.my_shape_of", x, dtype="int32", attrs_type_key="relay.attrs.ShapeOfAttrs"
+            "contrib.my_shape_of",
+            x,
+            dtype="int32",
+            attrs_type_key="relay.attrs.ShapeOfAttrs",
+            type_args=(Shape),
         )
         return z
 
@@ -194,7 +200,9 @@ def test_call_packed():
 def test_primexpr_arithmetic():
     @R.function
     def foo(x: Tensor((n, m), "float32")):
-        z: Tensor((n * m,), "float32") = relax.call_packed("my_flatten", (x,))
+        z: Tensor((n * m,), "float32") = relax.call_packed(
+            "my_flatten", (x,), type_args=(Tensor(rank=2, dtype="float32"))
+        )
         sh: Shape = (n + m, n // m)
         return z
 

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -192,6 +192,7 @@ def test_call_packed():
             attrs_type_key="relay.attrs.ShapeOfAttrs",
             type_args=(Shape),
         )
+        o = relax.call_packed("contrib.tensor_array_stack", x, z, type_args=(Object))
         return z
 
     check_roundtrip(foo)
@@ -325,12 +326,17 @@ def test_class_irmodule():
     check_roundtrip(my_module)
 
 
-def test_dyntensortype():
+def test_dyntensor_type():
     x = relax.DynTensorType(ndim=3, dtype="float32")
     assert x.__str__() == 'Tensor[ndim=3, dtype="float32"]'
 
 
-def test_shapeexpr():
+def test_object_type():
+    x = relax.ObjectType()
+    assert x.__str__() == "Object"
+
+
+def test_shape_expr():
     x = relax.ShapeExpr([tir.IntImm("int64", 10), tir.IntImm("int64", 5)])
     assert x.__str__() == "(10, 5)"
 

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -228,7 +228,9 @@ def test_vm_memory_lower():
         @R.function
         def foo(x: Tensor((m, n), "float32")) -> Tensor:
             alloc = relax.builtin.alloc_tensor((m, n), runtime_device_index=0, dtype="float32")
-            _ = relax.call_packed("test.op.identity", (x,), alloc)
+            _ = relax.call_packed(
+                "test.op.identity", x, alloc, type_args=[Tensor(rank=2, dtype="float32")]
+            )
             gv0 = alloc
             return gv0
 
@@ -401,4 +403,5 @@ def test_to_anf_no_op():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    # pytest.main([__file__])
+    test_vm_memory_lower()

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -229,7 +229,7 @@ def test_vm_memory_lower():
         def foo(x: Tensor((m, n), "float32")) -> Tensor:
             alloc = relax.builtin.alloc_tensor((m, n), runtime_device_index=0, dtype="float32")
             _ = relax.call_packed(
-                "test.op.identity", x, alloc, type_args=[Tensor(rank=2, dtype="float32")]
+                "test.op.identity", x, alloc, type_args=(Tensor(rank=2, dtype="float32"))
             )
             gv0 = alloc
             return gv0
@@ -403,5 +403,4 @@ def test_to_anf_no_op():
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_vm_memory_lower()
+    pytest.main([__file__])

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -137,8 +137,8 @@ def test_vm_exec_serialize_export_library():
     @tvm.script.ir_module
     class TestVMMove:
         @R.function
-        def foo(x: Tensor((3, 4), "float32")) -> Tensor:
-            z = R.call_packed("vm.builtin.copy", x)
+        def foo(x: Tensor((3, 4), "float32")):
+            z = R.call_packed("vm.builtin.copy", x, type_args=(Tensor(ndim=2, dtype="float32")))
             return z
 
     mod = TestVMMove
@@ -271,8 +271,8 @@ def test_vm_copy():
     @tvm.script.ir_module
     class TestVMMove:
         @R.function
-        def foo(x: Tensor((3, 4), "float32")) -> Tensor:
-            z = R.call_packed("vm.builtin.copy", x)
+        def foo(x: Tensor((3, 4), "float32")):
+            z = R.call_packed("vm.builtin.copy", x, type_args=(Tensor(ndim=2, dtype="float32")))
             return z
 
     mod = TestVMMove
@@ -393,7 +393,7 @@ def test_vm_compile_stage1():
             H[3] = H[1] * T.int64(3)
 
         @R.function
-        def foo(x: Tensor(_, "float32")) -> Shape:
+        def foo(x: Tensor(_, "float32")):
             shape_heap: Tensor((4,), "int64") = relax.call_packed(
                 "vm.builtin.alloc_shape_heap", (4,)
             )
@@ -794,11 +794,11 @@ def test_vm_tuplegetitem():
     @tvm.script.ir_module
     class TestVMTupleGetItem:
         @R.function
-        def tuple_get_item(x: Tensor((_, _), "float32"), y: Tensor((_, _), "float32")) -> Tensor:
-            t = relax.Tuple((x, y))
-            a = relax.TupleGetItem(t, 0)
-            b = relax.TupleGetItem(t, 1)
-            c = relax.call_packed("test.vm.add", a, b)
+        def tuple_get_item(x: Tensor((_, _), "float32"), y: Tensor((_, _), "float32")):
+            t = (x, y)
+            a = t[0]
+            b = t[1]
+            c = relax.call_packed("test.vm.add", a, b, type_args=(Tensor(ndim=2, dtype="float32")))
             return c
 
     mod = TestVMTupleGetItem
@@ -843,12 +843,12 @@ def test_sub_func_call():
         @R.function
         def relax_matmul_packed(
             x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")
-        ) -> Tensor:
+        ) -> Object:
             gv0 = relax.call_packed("test.vm.mul", x, w)
             return gv0
 
         @R.function
-        def main(x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")) -> Tensor:
+        def main(x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")) -> Object:
             gv0 = relax_matmul_tir(x, w)
             gv1 = relax_matmul_packed(gv0, gv0)
             return gv1

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -339,9 +339,9 @@ def test_vm_compile_if():
         @R.function
         def ife(cond: Tensor((), "bool"), x: Tensor((3, 4), "float32")) -> Tensor:
             if cond:
-                w = relax.call_packed("test.vm.add", x, x)
+                w = relax.call_packed("test.vm.add", x, x, type_args=(Tensor))
             else:
-                w = relax.call_packed("test.vm.mul", x, x)
+                w = relax.call_packed("test.vm.mul", x, x, type_args=(Tensor))
             return w
 
     mod = TestVMCompileIf
@@ -360,7 +360,7 @@ def test_vm_compile_stage0():
     class TestVMCompileStage0:
         @R.function
         def foo(x: Tensor((3, 4), "float32"), y: Tensor((3, 4), "float32")):
-            z = R.call_packed("test.vm.identity", x, y)
+            z = R.call_packed("test.vm.identity", x, y, type_args=(Tensor(ndim=2, dtype="float32")))
             return y
 
     mod = TestVMCompileStage0
@@ -395,12 +395,14 @@ def test_vm_compile_stage1():
         @R.function
         def foo(x: Tensor(_, "float32")):
             shape_heap: Tensor((4,), "int64") = relax.call_packed(
-                "vm.builtin.alloc_shape_heap", (4,)
+                "vm.builtin.alloc_shape_heap", (4,), type_args=(Tensor(ndim=2, dtype="float32"))
             )
-            gv0 = relax.call_packed("vm.builtin.shape_of", x)
-            gv1 = relax.call_packed("vm.builtin.store_shape", gv0, shape_heap, (0, 1))
+            gv0 = relax.call_packed("vm.builtin.shape_of", x, type_args=(Shape))
+            gv1 = relax.call_packed(
+                "vm.builtin.store_shape", gv0, shape_heap, (0, 1), type_args=(Void)
+            )
             gv2 = shape_func0(shape_heap)
-            gv3 = relax.call_packed("vm.builtin.load_shape", shape_heap, (2, 3))
+            gv3 = relax.call_packed("vm.builtin.load_shape", shape_heap, (2, 3), type_args=(Shape))
             return gv3
 
     mod = TestVMCompileStage1
@@ -844,13 +846,15 @@ def test_sub_func_call():
         def relax_matmul_packed(
             x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")
         ) -> Object:
-            gv0 = relax.call_packed("test.vm.mul", x, w)
+            gv0 = relax.call_packed(
+                "test.vm.mul", x, w, type_args=(Tensor(ndim=2, dtype="float32"))
+            )
             return gv0
 
         @R.function
         def main(x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")) -> Object:
             gv0 = relax_matmul_tir(x, w)
-            gv1 = relax_matmul_packed(gv0, gv0)
+            gv1 = relax_matmul_packed(gv0, gv0, type_args=(Tensor(ndim=2, dtype="float32")))
             return gv1
 
     target = tvm.target.Target("llvm", host="llvm")
@@ -869,12 +873,18 @@ def test_recursion():
     class TestVMRecursion:
         @R.function
         def recursion(n: Tensor((1,), "float32")) -> Tensor:
-            cond = relax.call_packed("test.vm.equal_zero", n)
+            cond = relax.call_packed(
+                "test.vm.equal_zero", n, type_args=(Tensor(ndim=1, dtype="float32"))
+            )
             if cond:
                 res = relax.const(1.0)
             else:
-                gv0 = relax.call_packed("test.vm.subtract_one", n)
-                res = relax.call_packed("test.vm.add", recursion(gv0), n)
+                gv0 = relax.call_packed(
+                    "test.vm.subtract_one", n, type_args=(Tensor(ndim=1, dtype="float32"))
+                )
+                res = relax.call_packed(
+                    "test.vm.add", recursion(gv0), n, type_args=(Tensor(ndim=1, dtype="float32"))
+                )
             return res
 
     target = tvm.target.Target("llvm", host="llvm")


### PR DESCRIPTION
As discussed in https://github.com/tlc-pack/relax/issues/122, we need to ensure the type invariant that "All Expr should have not null checked_type_ after type inference" always hold.

This PR introduces `ObjectType`, which serves as a general type, and its runtime representations can be `tvm::runtime::Object` such as `String`, `Array`, `Integer`, etc, and can be used when we support TensorArray.

For the return type of a `call_packed` node, in most cases we know the return type of a packed function. For example, if a packed function performs a tensor operation, the return value should be of DynTensorType. This PR annotates the return type by the CallNode's `type_args`,  and adds a general handling for `type_args` in the parser and printer.

In TVMScript, user can annotate the return type of a call_packed as:
```python
# return a tensor
x = relax.call_packed("test.vm.mul", x, y, type_args=(Tensor(rank=2, dtype="float32")))`

# return a shape
y = relax.call_packed("contrib.my_shape_of", x, type_args=(Shape))`

# return an object
z = relax.call_packed("contrib.tensor_array_concat", x, y, type_args=(Object))`
```
If `type_args` is not annotated, by default the return type of `call_packed` would be `ObjectType`.

This PR also refactors the `InferType` and `InferShape` functions in the Normalizer, and added the FInferType/FInferShape attributes to relax ops to make sure we can infer the types for all ops.