### PR TITLE
Add `relax.unique` operator in Relax.

### DIFF
--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -55,6 +55,39 @@ using FInferShape =
  */
 using FInferType = runtime::TypedPackedFunc<Type(const Call& call, DiagnosticContext diag_ctx)>;
 
+/*!
+ * \brief Packed function implementation for operators. The relax operator will be lowered to
+ * this packed function call during codegen.
+ */
+using FCallPacked = String;
+
+/*! \brief Attributes used in unique operator */
+struct UniqueAttrs : public tvm::AttrsNode<UniqueAttrs> {
+  bool sorted;
+  bool return_inverse;
+  bool return_counts;
+  int dim;
+  TVM_DECLARE_ATTRS(UniqueAttrs, "relax.attrs.UniqueAttrs") {
+    TVM_ATTR_FIELD(sorted)
+        .describe(
+            "Whether to sort the unique elements in ascending order before returning as output.")
+        .set_default(true);
+    TVM_ATTR_FIELD(return_inverse)
+        .describe(
+            "Whether to return an additional tensor with indices for where elements in the "
+            "original input ended up in the returned unique list.")
+        .set_default(false);
+    TVM_ATTR_FIELD(return_counts)
+        .describe("Whether to return an additional tensor with counts of each unique elements")
+        .set_default(false);
+    TVM_ATTR_FIELD(dim)
+        .describe(
+            "The dimension to apply unique. If negative, the unique of the flattened input is "
+            "returned.")
+        .set_default(-1);
+  }
+};  // struct UniqueAttrs
+
 }  // namespace relax
 }  // namespace tvm
 #endif  // TVM_RELAX_OP_ATTR_TYPES_H_

--- a/python/tvm/relax/op/tensor.py
+++ b/python/tvm/relax/op/tensor.py
@@ -14,15 +14,42 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 """Basic tensor operations."""
+import numpy as np
+import tvm
+
 from . import _ffi_api
 from ..expr import Expr
 
 
-def add(lhs: Expr,
-        rhs: Expr) -> Expr:
+def add(lhs: Expr, rhs: Expr) -> Expr:
     return _ffi_api.add(lhs, rhs)
 
 
-def multiply(lhs: Expr,
-             rhs: Expr) -> Expr:
+def multiply(lhs: Expr, rhs: Expr) -> Expr:
     return _ffi_api.multiply(lhs, rhs)
+
+
+@tvm.register_func("relax.run.unique")
+def unique(
+    a: tvm.nd.array,
+    sort: int,
+    return_inverse: int,
+    return_counts: int,
+    dim: int,
+) -> tvm.nd.array:
+    """Returns the unique elements of the input tensor.
+
+    Uses numpy.unique to compute unique elements.
+    """
+    # TODO(prakalp): add support for returning a tuple when return_inverse or return_counts is True
+    if bool(return_inverse) or bool(return_counts):
+        raise NotImplementedError("missing support return_inverse or return_counts set to true")
+    if dim < 0:
+        dim = None
+    a_numpy = a.numpy()
+    # TODO(prakalp): use torch.unique instead of numpy when torch is installed in ci.
+    output_sorted_numpy, indices = np.unique(a_numpy, return_index=True)
+    if sort:
+        return tvm.nd.array(output_sorted_numpy)
+    output_numpy = [a_numpy.flatten()[index] for index in sorted(indices, reverse=True)]
+    return tvm.nd.array(output_numpy)

--- a/src/relax/op/tensor/unary.cc
+++ b/src/relax/op/tensor/unary.cc
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file unary.cc
+ * \brief unary operators.
+ */
+
+#include "unary.h"
+
+namespace tvm {
+namespace relax {
+
+TVM_REGISTER_NODE_TYPE(UniqueAttrs);
+
+RELAY_REGISTER_OP("relax.unique")
+    .describe(
+        "This operation returns the unique elements and the new index of each item in a given "
+        "tensor.")
+    .set_num_inputs(1)
+    .add_argument("data", "Tensor", "The input tensor")
+    .set_attrs_type<UniqueAttrs>()
+    .set_attr<FInferShape>("FInferShape", InferShapeUnique)
+    .set_attr<FInferType>("FInferType", InferTypeUnique)
+    .set_attr<FCallPacked>("FCallPacked", "relax.run.unique");
+
+Expr MakeUnique(Expr data, bool sorted, bool return_inverse, bool return_counts, int dim) {
+  auto attrs = make_object<UniqueAttrs>();
+  attrs->sorted = sorted;
+  attrs->return_inverse = return_inverse;
+  attrs->return_counts = return_counts;
+  attrs->dim = dim;
+  static const Op& op = Op::Get("unique");
+  return Call(op, {data}, Attrs(attrs));
+}
+
+TVM_REGISTER_GLOBAL("relax.op.unique").set_body_typed(MakeUnique);
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/op/tensor/unary.h
+++ b/src/relax/op/tensor/unary.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file unary.h
+ * \brief shape and type deduction for unary operators.
+ */
+
+#ifndef TVM_RELAX_OP_TENSOR_UNARY_H_
+#define TVM_RELAX_OP_TENSOR_UNARY_H_
+
+#include <tvm/relax/expr.h>
+#include <tvm/relax/type.h>
+
+#include <vector>
+
+#include "../op_common.h"
+
+namespace tvm {
+namespace relax {
+
+Optional<Expr> InferShapeUnique(const Call& call, DiagnosticContext diag_ctx) {
+  if (call->args.size() != 1) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "Unique op should have 1 argument");
+  }
+  auto unique_attrs = call->attrs.as<UniqueAttrs>();
+  // Only default values of these attributes are supported right now.
+  if (unique_attrs->return_counts || unique_attrs->return_inverse || unique_attrs->dim != -1)
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "support for return_inverse, return_counts, and dim is not implemented");
+  return relax::RuntimeDepShape(call->span);
+}
+
+Type InferTypeUnique(const Call& call, DiagnosticContext diag_ctx) {
+  if (call->args.size() != 1) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "Unique op should have 1 argument");
+  }
+  auto* input_ty = call->args[0]->checked_type().as<DynTensorTypeNode>();
+  if (!input_ty) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "Input should be DynTensor, but got "
+                       << call->args[0]->checked_type()->GetTypeKey());
+  }
+
+  // TODO(prakalp): Add support for return_inverse, return_counts and dim attributes. Only defaults
+  // are supported right now.
+  auto unique_attrs = call->attrs.as<UniqueAttrs>();
+  if (unique_attrs->return_counts || unique_attrs->return_inverse || unique_attrs->dim != -1)
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "support for return_inverse, return_counts, and dim is not implemented");
+  return DynTensorType(/*ndim=*/1, input_ty->dtype);
+}
+
+}  // namespace relax
+}  // namespace tvm
+
+#endif  // TVM_RELAX_OP_TENSOR_UNARY_H_

--- a/tests/python/relax/test_relax_operators.py
+++ b/tests/python/relax/test_relax_operators.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations  # must import to defer parsing of annotations
+import pytest
+import tvm
+from tvm import relax
+
+from tvm.script import relax as R
+
+import numpy as np
+
+
+@tvm.script.ir_module
+class InputModule:
+    @R.function
+    def foo(x: Tensor((m, n), "int64")):
+        y = relax.unique(x, sorted=False)
+        y_sorted = relax.unique(x)
+        return y, y_sorted
+
+
+def test_unique():
+
+    mod = InputModule
+    # TODO(prakalp): also add test for compiling and running on cuda device.
+    target = tvm.target.Target("llvm")
+    ex = relax.vm.build(mod, target)
+    vm = relax.VirtualMachine(ex, tvm.cpu())
+
+    data_numpy = np.random.randint(0, 16, (16, 16))
+    data = tvm.nd.array(data_numpy)
+    result, result_sorted = vm["foo"](data)
+
+    expected_output_sorted, indices = np.unique(data_numpy, return_index=True)
+    expected_output = [data_numpy.flatten()[index] for index in sorted(indices, reverse=True)]
+
+    np.testing.assert_array_equal(expected_output_sorted, result_sorted.numpy())
+    np.testing.assert_array_equal(expected_output, result.numpy())
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -160,6 +160,9 @@ def test_vm_constant_serialize():
     shape = (4, 6)
     inp = tvm.nd.array(np.random.rand(4, 6).astype(np.float32))
     ib = relax.ExecBuilder()
+    # add a few integer constants in constant pool
+    ib.emit_constant(2)
+    ib.emit_constant(5)
     with ib.function("main", num_inputs=1):
         ib.emit_call(
             "vm.builtin.alloc_storage", args=[ib.vm_state(), (24,), ib.imm(0), dtype], dst=ib.r(1)
@@ -172,6 +175,7 @@ def test_vm_constant_serialize():
     exec0 = ib.get()
     exec0.save_to_file("exec.tmp")
     exec1 = relax.load_exec_from_file("exec.tmp")
+    assert exec0.stats() == exec1.stats()
     assert exec0.as_text() == exec1.as_text()
     vm = relax.VirtualMachine(exec0, tvm.cpu())
     res = vm["main"](inp)


### PR DESCRIPTION
Add `relax.unique` operator in Relax. 

This adds the functionality to register a packed function implementation of
any operator using `FCallPacked` attribute. The relax operator would be
lowered to a call to the registered packed function during codegen.
For example, in this change `relax.unique` is lowered to
`relax.run.unique` packed function which uses torch.unique under the
hood.

Specifically the PR makes the following changes:
* Add support for integer constants in Relax VM.
* Add support for `FCallPacked` attribute to register a packed function during Relax op registration.
* Add `relax.unique` operator. It is similar to `torch.unique` in signature but currently only default values of `return_counts`, `return_inverse` and `dim` attributes are supported.
