### PR TITLE
Introduce Relax function attribute and drop name field in Relax function

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -409,11 +409,6 @@ class SeqExpr : public Expr {
 /*! \brief A Relax function, eventually to replace the current Relay function definition. */
 class FunctionNode : public BaseFuncNode {
  public:
-  /*!
-   * \brief Optionally attach the function's name for improved printing, and debugging.
-   * It need to be consistent with the GlobalVar in the IRModule.
-   */
-  runtime::Optional<GlobalVar> name;
   /*! \brief The parameters to the function. */
   Array<Var> params;
   /*! \brief The body of the function. */
@@ -422,7 +417,6 @@ class FunctionNode : public BaseFuncNode {
   Type ret_type;
 
   void VisitAttrs(AttrVisitor* v) {
-    v->Visit("name", &name);
     v->Visit("params", &params);
     v->Visit("body", &body);
     v->Visit("ret_type", &ret_type);
@@ -457,15 +451,13 @@ class FunctionNode : public BaseFuncNode {
 
 class Function : public BaseFunc {
  public:
-  TVM_DLL explicit Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
-                            Type ret_type, DictAttrs attrs = NullValue<DictAttrs>(),
-                            Span span = Span());
+  TVM_DLL explicit Function(Array<Var> params, Expr body, Type ret_type,
+                            DictAttrs attrs = NullValue<DictAttrs>(), Span span = Span());
 
   /*!
    * \brief Mimics the constructor but without type checking.
    */
-  TVM_DLL static Function CreateUnchecked(runtime::Optional<GlobalVar> name, Array<Var> params,
-                                          Expr body, Type ret_type,
+  TVM_DLL static Function CreateUnchecked(Array<Var> params, Expr body, Type ret_type,
                                           DictAttrs attrs = NullValue<DictAttrs>(),
                                           Span span = Span());
 
@@ -473,7 +465,8 @@ class Function : public BaseFunc {
   TVM_DEFINE_OBJECT_REF_COW_METHOD(FunctionNode);
 };
 
-// [TODO] Investigate the exact usage of kComposite, kPartitionedFromPattern, and kPrimitive.
+// TODO(@sunggg): Investigate the exact usage of kComposite, kPartitionedFromPattern, and
+// kPrimitive.
 namespace attr {
 /*! \brief Mark the function as a primitive function. */
 constexpr const char* kPrimitive = "Primitive";

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -429,13 +429,14 @@ class FunctionNode : public BaseFuncNode {
     v->Visit("_checked_type_", &checked_type_);
     v->Visit("shape_", &shape_);
     v->Visit("span", &span);
+    v->Visit("attrs", &attrs);
   }
 
   bool SEqualReduce(const FunctionNode* other, SEqualReducer equal) const {
     equal->MarkGraphNode();
     return equal.DefEqual(params, other->params) && equal(body, other->body) &&
            equal(ret_type, other->ret_type) && equal(checked_type_, other->checked_type_) &&
-           equal(shape_, other->shape_);
+           equal(shape_, other->shape_) && equal(attrs, other->attrs);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
@@ -445,6 +446,7 @@ class FunctionNode : public BaseFuncNode {
     hash_reduce(ret_type);
     hash_reduce(checked_type_);
     hash_reduce(shape_);
+    hash_reduce(attrs);
   }
 
   static constexpr const char* _type_key = "relax.expr.Function";
@@ -456,17 +458,35 @@ class FunctionNode : public BaseFuncNode {
 class Function : public BaseFunc {
  public:
   TVM_DLL explicit Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
-                            Type ret_type, Span span = Span());
+                            Type ret_type, DictAttrs attrs = NullValue<DictAttrs>(),
+                            Span span = Span());
 
   /*!
    * \brief Mimics the constructor but without type checking.
    */
   TVM_DLL static Function CreateUnchecked(runtime::Optional<GlobalVar> name, Array<Var> params,
-                                          Expr body, Type ret_type, Span span = Span());
+                                          Expr body, Type ret_type,
+                                          DictAttrs attrs = NullValue<DictAttrs>(),
+                                          Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Function, BaseFunc, FunctionNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(FunctionNode);
 };
+
+// [TODO] Investigate the exact usage of kComposite, kPartitionedFromPattern, and kPrimitive.
+namespace attr {
+/*! \brief Mark the function as a primitive function. */
+constexpr const char* kPrimitive = "Primitive";
+/*!
+ * \brief Indicate the codegen that should be used for building this function.
+ * When this is unset or set to "default", the default compilation pipeline will be used.
+ */
+constexpr const char* kCodegen = "Codegen";
+/*! \brief Treat the function as a composite operator. */
+constexpr const char* kComposite = "Composite";
+/*! \brief Indicate the function was created by the Pattern Partitioning Pass. */
+constexpr const char* kPartitionedFromPattern = "PartitionedFromPattern";
+}  // namespace attr
 
 /*! \brief The extern function, which can represent packed function. */
 class ExternFuncNode : public BaseFuncNode {

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -574,7 +574,8 @@ class BlockBuilder(Object):
 
         # The function's checked_type_ relies on the function body(seqe) to have deduced type
         # TODO(@yuchen): handle the case where the body's checked_type_ is null
-        func = rx.Function(self._func_params, seqe, None, rx.GlobalVar(self._func_name))
+        func = rx.Function(self._func_params, seqe, None)
+        func = func.with_attr("global_symbol", self._func_name)
         self.add_func(func, self._func_name)
 
     def normalize(self, expr: Expr) -> Expr:

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -181,15 +181,15 @@ class Function(BaseFunc):
     params: List[Var]
     body: Expr
     ret_type: Type
-    attrs: dict
+    attrs: Optional[tvm.ir.DictAttrs]
 
     def __init__(
         self,
         params: List[Var],
         body: Expr,
         ret_type: Type,
-        attrs: dict = None,
-        span: Span = None,
+        attrs: Optional[tvm.ir.DictAttrs] = None,
+        span: Optional[Span] = None,
     ) -> None:
         self.__init_handle_by_constructor__(_ffi_api.Function, params, body, ret_type, attrs, span)
 
@@ -198,8 +198,8 @@ class Function(BaseFunc):
         params: List[Var],
         body: Expr,
         ret_type: Type,
-        attrs: dict = None,
-        span: Span = None,
+        attrs: Optional[tvm.ir.DictAttrs] = None,
+        span: Optional[Span] = None,
     ):
         """Construct a relax.Function but without type checking."""
         return _ffi_api.Function_CreateUnchecked(params, body, ret_type, attrs, span)

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -178,7 +178,6 @@ class SeqExpr(Expr):
 class Function(BaseFunc):
     """A Relax function."""
 
-    name: Optional[GlobalVar]
     params: List[Var]
     body: Expr
     ret_type: Type
@@ -189,25 +188,21 @@ class Function(BaseFunc):
         params: List[Var],
         body: Expr,
         ret_type: Type,
-        name: Optional[GlobalVar] = None,
         attrs: dict = None,
         span: Span = None,
     ) -> None:
-        self.__init_handle_by_constructor__(
-            _ffi_api.Function, name, params, body, ret_type, attrs, span
-        )
+        self.__init_handle_by_constructor__(_ffi_api.Function, params, body, ret_type, attrs, span)
 
     @staticmethod
     def create_unchecked(
         params: List[Var],
         body: Expr,
         ret_type: Type,
-        name: Optional[GlobalVar] = None,
         attrs: dict = None,
         span: Span = None,
     ):
         """Construct a relax.Function but without type checking."""
-        return _ffi_api.Function_CreateUnchecked(name, params, body, ret_type, attrs, span)
+        return _ffi_api.Function_CreateUnchecked(params, body, ret_type, attrs, span)
 
 
 @tvm._ffi.register_object("relax.expr.ExternFunc")

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -182,6 +182,7 @@ class Function(BaseFunc):
     params: List[Var]
     body: Expr
     ret_type: Type
+    attrs: dict
 
     def __init__(
         self,
@@ -189,9 +190,12 @@ class Function(BaseFunc):
         body: Expr,
         ret_type: Type,
         name: Optional[GlobalVar] = None,
+        attrs: dict = None,
         span: Span = None,
     ) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.Function, name, params, body, ret_type, span)
+        self.__init_handle_by_constructor__(
+            _ffi_api.Function, name, params, body, ret_type, attrs, span
+        )
 
     @staticmethod
     def create_unchecked(
@@ -199,10 +203,11 @@ class Function(BaseFunc):
         body: Expr,
         ret_type: Type,
         name: Optional[GlobalVar] = None,
+        attrs: dict = None,
         span: Span = None,
     ):
-        """ Construct a relax.Function but without type checking. """
-        return _ffi_api.Function_CreateUnchecked(name, params, body, ret_type, span)
+        """Construct a relax.Function but without type checking."""
+        return _ffi_api.Function_CreateUnchecked(name, params, body, ret_type, attrs, span)
 
 
 @tvm._ffi.register_object("relax.expr.ExternFunc")

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -219,7 +219,7 @@ class ExprMutator(ExprFunctor):
     def visit_function(self, func: Function) -> Function:
         new_params = [self.visit(param) for param in func.params]
         new_body = self.visit(func.body)
-        return Function(new_params, new_body, func.ret_type, func.name, func.span)
+        return Function(new_params, new_body, func.ret_type, func.attrs, func.span)
 
     def visit_extern_func(self, op: ExternFunc) -> ExternFunc:
         return op

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -617,15 +617,17 @@ class RelaxTransformer(Transformer):
             new_body = self.transform_block(func.body)
             ret_type, _ = self.transform_type(func.ret_type, bind_free_vars=False)
 
-        func_name = relax.GlobalVar(func.name) if is_global else None
-        return relax.Function.create_unchecked(
+        relax_func = relax.Function.create_unchecked(
             params,
             new_body,
             ret_type,
-            name=func_name,
             attrs=None,
             span=self.to_tvm_span(func.span),
         )
+        if is_global:
+            relax_func = relax_func.with_attr("global_symbol", func.name)
+
+        return relax_func
 
     def is_match_shape(self, stmt: ast.Stmt) -> bool:
         """Returns whether or not the given statement is a MatchShape binding.

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -619,7 +619,12 @@ class RelaxTransformer(Transformer):
 
         func_name = relax.GlobalVar(func.name) if is_global else None
         return relax.Function.create_unchecked(
-            params, new_body, ret_type, name=func_name, span=self.to_tvm_span(func.span)
+            params,
+            new_body,
+            ret_type,
+            name=func_name,
+            attrs=None,
+            span=self.to_tvm_span(func.span),
         )
 
     def is_match_shape(self, stmt: ast.Stmt) -> bool:

--- a/src/ir/function.cc
+++ b/src/ir/function.cc
@@ -28,6 +28,7 @@
 // and are only used in minimum cases where they are clearly marked.
 //
 // Rationale: We calls into the type specific WithAttr function
+#include <tvm/relax/expr.h>
 #include <tvm/relay/function.h>
 #include <tvm/tir/function.h>
 
@@ -43,6 +44,8 @@ TVM_REGISTER_GLOBAL("ir.BaseFuncWithAttr")
         return WithAttr(Downcast<tir::PrimFunc>(std::move(func)), key, value);
       } else if (func->IsInstance<relay::FunctionNode>()) {
         return WithAttr(Downcast<relay::Function>(std::move(func)), key, value);
+      } else if (func->IsInstance<relax::FunctionNode>()) {
+        return WithAttr(Downcast<relax::Function>(std::move(func)), key, value);
       } else {
         LOG(FATAL) << "Do not support function type " << func->GetTypeKey();
         return func;

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -328,8 +328,9 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::SeqExprNode* op) {
 }
 
 Doc RelaxScriptPrinter::VisitNode_(const relax::FunctionNode* op) {
-  ICHECK(op->name.defined());
-  return PrintFunctionDef(Doc::Text(op->name.value()->name_hint), GetRef<relax::Function>(op));
+  Optional<String> gsymbol = op->GetAttr<String>(tvm::attr::kGlobalSymbol);
+  ICHECK(gsymbol.defined());
+  return PrintFunctionDef(Doc::Text(gsymbol.value()), GetRef<relax::Function>(op));
 }
 
 Doc RelaxScriptPrinter::VisitNode_(const relax::ExternFuncNode* op) {

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -53,8 +53,9 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   // TODO(@yuchen): when we support closure, this visitor should return a register that
   // contains the closure object.
   Instruction::Arg VisitExpr_(const FunctionNode* func_node) {
-    if (func_node->name.defined()) {
-      builder_->EmitFunction(func_node->name.value()->name_hint, func_node->params.size());
+    Optional<String> gsymbol = func_node->GetAttr<String>(tvm::attr::kGlobalSymbol);
+    if (gsymbol.defined()) {
+      builder_->EmitFunction(gsymbol.value(), func_node->params.size());
     } else {
       // TODO(@yuchen): handle local functions that capture local vars outside the func
       // TODO(@yuchen): a renaming pass to resolve name conflicts, e.g. the input module has a

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -127,7 +127,7 @@ class VMShapeLowerMutator : public ExprMutator {
       ret_type = DynTensorType::CreateUnknownNDim(temp->dtype, Span());
     }
 
-    return Function(node->name, node->params, new_body, ret_type, node->attrs);
+    return Function(node->params, new_body, ret_type, node->attrs);
   }
 
   tir::PrimFunc CalculateShape(ShapeExpr s) {

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -127,7 +127,7 @@ class VMShapeLowerMutator : public ExprMutator {
       ret_type = DynTensorType::CreateUnknownNDim(temp->dtype, Span());
     }
 
-    return Function(node->name, node->params, new_body, ret_type);
+    return Function(node->name, node->params, new_body, ret_type, node->attrs);
   }
 
   tir::PrimFunc CalculateShape(ShapeExpr s) {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -100,7 +100,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     if (new_body.same_as(op->body)) {
       func = GetRef<Function>(op);
     } else {
-      func = Function(op->name, op->params, new_body, op->ret_type, op->attrs);
+      func = Function(op->params, new_body, op->ret_type, op->attrs);
     }
 
     // NOTE: the shape_ of Function is left as null for now, to be consitent with

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -100,7 +100,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     if (new_body.same_as(op->body)) {
       func = GetRef<Function>(op);
     } else {
-      func = Function(op->name, op->params, new_body, op->ret_type);
+      func = Function(op->name, op->params, new_body, op->ret_type, op->attrs);
     }
 
     // NOTE: the shape_ of Function is left as null for now, to be consitent with

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -187,8 +187,7 @@ TVM_REGISTER_GLOBAL("relax.SeqExpr")
 
 TVM_REGISTER_NODE_TYPE(FunctionNode);
 
-Function::Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr body, Type ret_type,
-                   DictAttrs attrs, Span span) {
+Function::Function(Array<Var> params, Expr body, Type ret_type, DictAttrs attrs, Span span) {
   // Set the function type.
   // For function, we take a conservative approach and require the function type
   // to be known at construction time.
@@ -219,7 +218,6 @@ Function::Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr bo
 
   // set the fields
   ObjectPtr<FunctionNode> n = make_object<FunctionNode>();
-  n->name = std::move(name);
   n->params = std::move(params);
   n->body = std::move(body);
   n->ret_type = std::move(ret_type);
@@ -230,12 +228,12 @@ Function::Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr bo
 }
 
 TVM_REGISTER_GLOBAL("relax.Function")
-    .set_body_typed([](runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
-                       Type ret_type, DictAttrs attrs,
-                       Span span) { return Function(name, params, body, ret_type, attrs, span); });
+    .set_body_typed([](Array<Var> params, Expr body, Type ret_type, DictAttrs attrs, Span span) {
+      return Function(params, body, ret_type, attrs, span);
+    });
 
-Function Function::CreateUnchecked(runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
-                                   Type ret_type, DictAttrs attrs, Span span) {
+Function Function::CreateUnchecked(Array<Var> params, Expr body, Type ret_type, DictAttrs attrs,
+                                   Span span) {
   for (Var param : params) {
     ICHECK(param->checked_type_.defined())
         << "relax.Function requires params to contain checked_type_.";
@@ -243,7 +241,6 @@ Function Function::CreateUnchecked(runtime::Optional<GlobalVar> name, Array<Var>
 
   // set the fields
   ObjectPtr<FunctionNode> n = make_object<FunctionNode>();
-  n->name = std::move(name);
   n->params = std::move(params);
   n->body = std::move(body);
   n->ret_type = std::move(ret_type);
@@ -253,9 +250,8 @@ Function Function::CreateUnchecked(runtime::Optional<GlobalVar> name, Array<Var>
 }
 
 TVM_REGISTER_GLOBAL("relax.Function_CreateUnchecked")
-    .set_body_typed([](runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
-                       Type ret_type, DictAttrs attrs, Span span) {
-      return Function::CreateUnchecked(name, params, body, ret_type, attrs, span);
+    .set_body_typed([](Array<Var> params, Expr body, Type ret_type, DictAttrs attrs, Span span) {
+      return Function::CreateUnchecked(params, body, ret_type, attrs, span);
     });
 
 TVM_REGISTER_NODE_TYPE(ExternFuncNode);

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -188,7 +188,7 @@ TVM_REGISTER_GLOBAL("relax.SeqExpr")
 TVM_REGISTER_NODE_TYPE(FunctionNode);
 
 Function::Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr body, Type ret_type,
-                   Span span) {
+                   DictAttrs attrs, Span span) {
   // Set the function type.
   // For function, we take a conservative approach and require the function type
   // to be known at construction time.
@@ -224,17 +224,18 @@ Function::Function(runtime::Optional<GlobalVar> name, Array<Var> params, Expr bo
   n->body = std::move(body);
   n->ret_type = std::move(ret_type);
   n->checked_type_ = std::move(func_type);
+  n->attrs = std::move(attrs);
   n->span = std::move(span);
   data_ = std::move(n);
 }
 
 TVM_REGISTER_GLOBAL("relax.Function")
     .set_body_typed([](runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
-                       Type ret_type,
-                       Span span) { return Function(name, params, body, ret_type, span); });
+                       Type ret_type, DictAttrs attrs,
+                       Span span) { return Function(name, params, body, ret_type, attrs, span); });
 
 Function Function::CreateUnchecked(runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
-                                   Type ret_type, Span span) {
+                                   Type ret_type, DictAttrs attrs, Span span) {
   for (Var param : params) {
     ICHECK(param->checked_type_.defined())
         << "relax.Function requires params to contain checked_type_.";
@@ -246,14 +247,15 @@ Function Function::CreateUnchecked(runtime::Optional<GlobalVar> name, Array<Var>
   n->params = std::move(params);
   n->body = std::move(body);
   n->ret_type = std::move(ret_type);
+  n->attrs = std::move(attrs);
   n->span = std::move(span);
   return Function(std::move(n));
 }
 
 TVM_REGISTER_GLOBAL("relax.Function_CreateUnchecked")
     .set_body_typed([](runtime::Optional<GlobalVar> name, Array<Var> params, Expr body,
-                       Type ret_type, Span span) {
-      return Function::CreateUnchecked(name, params, body, ret_type, span);
+                       Type ret_type, DictAttrs attrs, Span span) {
+      return Function::CreateUnchecked(name, params, body, ret_type, attrs, span);
     });
 
 TVM_REGISTER_NODE_TYPE(ExternFuncNode);

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -275,7 +275,7 @@ Expr ExprMutator::VisitExpr_(const FunctionNode* op) {
   if (all_params_unchanged && ret_type.same_as(op->ret_type) && body.same_as(op->body)) {
     return GetRef<Expr>(op);
   } else {
-    return Function(op->name, params, body, ret_type);
+    return Function(op->name, params, body, ret_type, op->attrs);
   }
 }
 

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -275,7 +275,7 @@ Expr ExprMutator::VisitExpr_(const FunctionNode* op) {
   if (all_params_unchanged && ret_type.same_as(op->ret_type) && body.same_as(op->body)) {
     return GetRef<Expr>(op);
   } else {
-    return Function(op->name, params, body, ret_type, op->attrs);
+    return Function(params, body, ret_type, op->attrs);
   }
 }
 

--- a/src/relax/transform/bind_params.cc
+++ b/src/relax/transform/bind_params.cc
@@ -68,7 +68,7 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
       return expr;
     }
     // The checked_type_ of the new function is deduced from the function body
-    return Function(func->name, new_params, new_body, Type());
+    return Function(func->name, new_params, new_body, Type(), func->attrs);
   } else {
     return ExprBinder(args_map).VisitExpr(expr);
   }

--- a/src/relax/transform/bind_params.cc
+++ b/src/relax/transform/bind_params.cc
@@ -68,7 +68,7 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
       return expr;
     }
     // The checked_type_ of the new function is deduced from the function body
-    return Function(func->name, new_params, new_body, Type(), func->attrs);
+    return Function(new_params, new_body, Type(), func->attrs);
   } else {
     return ExprBinder(args_map).VisitExpr(expr);
   }
@@ -122,7 +122,8 @@ IRModule BindParam(IRModule m, String func_name, Map<String, runtime::NDArray> p
   Map<GlobalVar, BaseFunc> functions = m->functions;
   for (const auto& func_pr : functions) {
     if (const auto* relax_f = func_pr.second.as<FunctionNode>()) {
-      if (relax_f->name.value()->name_hint == func_name) {
+      Optional<String> gsymbol = relax_f->GetAttr<String>(tvm::attr::kGlobalSymbol);
+      if (gsymbol.defined() && gsymbol.value() == func_name) {
         Function f_after_bind = BindParamsByName(GetRef<Function>(relax_f), param);
         new_module->Update(func_pr.first, f_after_bind);
       }

--- a/src/relax/transform/fma_rewrite.cc
+++ b/src/relax/transform/fma_rewrite.cc
@@ -122,9 +122,9 @@ class EwiseFuseFMAMutator : public ExprMutator {
         Var z = Var("z", Downcast<Expr>(call->args[1]->shape_), call->args[1]->checked_type_);
         Expr body = Call(ewise_fma_op, {x, y, z});
 
-        // TODO(@yuchen): avoid creating the unnecessary global_var after #136 is merged
-        GlobalVar global_var = GlobalVar("ewise_fma_fused");
-        Expr ewise_fma_fused = Function(global_var, {x, y, z}, body, call->args[1]->checked_type_);
+        String func_name = "ewise_fma_fused";
+        Function func = Function({x, y, z}, body, call->args[1]->checked_type_);
+        Expr ewise_fma_fused = WithAttr(std::move(func), "global_symbol", func_name);
         Expr normalized = builder_->Normalize(ewise_fma_fused);
         GlobalVar global_var1 =
             builder_->AddFunction(Downcast<BaseFunc>(normalized), "ewise_fma_fused");

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -123,7 +123,7 @@ def test_function_multi_blocks():
     assert gv2.checked_type.dtype == "float16"
     assert func.params[0] == x
     assert func.params[1] == y
-    assert func.name.name_hint == "func"
+    assert func.attrs["global_symbol"] == "func"
     assert func.body.body == gv2
     assert len(func.body.blocks) == 3
     assert len(func.body.blocks[0].bindings) == 2
@@ -159,12 +159,12 @@ def test_multi_functions():
     func1 = mod["func1"]
     assert func1.params[0] == x
     assert func1.params[1] == y
-    assert func1.name.name_hint == "func1"
+    assert func1.attrs["global_symbol"] == "func1"
     assert len(func1.body.blocks) == 1
     func2 = mod["func2"]
     assert func2.params[0] == x
     assert func2.params[1] == y
-    assert func2.name.name_hint == "func2"
+    assert func2.attrs["global_symbol"] == "func2"
     assert len(func2.body.blocks) == 1
 
 
@@ -344,7 +344,7 @@ def test_call_te():
     assert rx_func.params[0] == x
     assert rx_func.params[1] == y
     assert rx_func.params[2] == z
-    assert rx_func.name.name_hint == "rx_func"
+    assert rx_func.attrs["global_symbol"] == "rx_func"
     assert rx_func.body.body == out
     assert len(rx_func.body.blocks) == 1
     assert len(rx_func.body.blocks[0].bindings) == 1
@@ -386,7 +386,7 @@ def test_emit_te():
     assert rx_func.params[0] == x
     assert rx_func.params[1] == y
     assert rx_func.params[2] == z
-    assert rx_func.name.name_hint == "rx_func"
+    assert rx_func.attrs["global_symbol"] == "rx_func"
     assert rx_func.body.body == out
     assert len(rx_func.body.blocks) == 1
     assert len(rx_func.body.blocks[0].bindings) == 1
@@ -453,7 +453,7 @@ def test_emit_te_multiple_output():
 
     # check call tir output shape is a Tuple of ShapeExpr
     assert rx_func.params[0] == x
-    assert rx_func.name.name_hint == "rx_func"
+    assert rx_func.attrs["global_symbol"] == "rx_func"
     call_node = rx_func.body.blocks[0].bindings[0].value
     assert call_node.op == relay.op.get("relax.call_tir")
     assert call_node.args[0].name_hint == "te_func"

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -144,11 +144,12 @@ def test_func():
     blocks = [rx.BindingBlock(bindings)]
     seqe = rx.SeqExpr(blocks, x)
     ret_type = rx.DynTensorType(-1, "float32")
-    func = rx.Function([x], seqe, ret_type, rx.GlobalVar("func"))
+    func = rx.Function([x], seqe, ret_type)
+    func = func.with_attr("global_symbol", "func")
     assert func.params[0] == x
     assert func.body == seqe
     assert func.ret_type == ret_type
-    assert func.name.name_hint == "func"
+    assert func.attrs["global_symbol"] == "func"
 
 
 def test_shape_of():

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -133,7 +133,7 @@ def test_function():
     blocks = [relax.BindingBlock(bindings)]
     seq_expr = relax.SeqExpr(blocks, x)
     ret_type = relax.DynTensorType(-1, "float32")
-    func = relax.Function([x], seq_expr, ret_type, relax.GlobalVar("func"))
+    func = relax.Function([x], seq_expr, ret_type)
     check_visit(func)
 
 

--- a/tests/python/relax/test_function_attr.py
+++ b/tests/python/relax/test_function_attr.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+import pytest
+import tvm
+from tvm.script import relax as R
+from tvm import relax
+
+
+@tvm.script.ir_module
+class InputModule:
+    @R.function
+    def relax_add(x: Tensor((2, 3), "float32"), y: Tensor((2, 3), "float32")) -> Tensor:
+        z1 = relax.add(x, y)
+        z2 = relax.add(z1, z1)
+        return z2
+
+    @R.function
+    def main(x: Tensor((2, 3), "float32"), y: Tensor((2, 3), "float32")) -> Tensor:
+        lv0 = relax_add(x, y)
+        return lv0
+
+
+def test_func_attr_setter():
+    mod = InputModule
+    assert isinstance(mod, tvm.IRModule)
+    # Annotate a function
+    annot_mod = mod["relax_add"].with_attr("Codegen", "test-codegen")
+    annot_mod = annot_mod.with_attr("global_symbol", "test-symbol")
+
+    # Test annotation
+    assert annot_mod.attrs
+    assert annot_mod.attrs["Codegen"] == "test-codegen"
+    assert annot_mod.attrs["global_symbol"] == "test-symbol"
+
+    # Update ir module
+    mod["relax_add"] = annot_mod
+
+    # Test with passes
+    # Annotation should stay the same unless the pass needs to modify it
+
+    # List of passes
+    passes = [relax.transform.ToNonDataflow()]
+    passes.append(relax.transform.CallTIRRewrite())
+    passes.append(relax.transform.VMMemoryLower())
+    passes.append(relax.transform.VMShapeLower())
+    seq = tvm.transform.Sequential(passes)
+
+    # Apply passes
+    new_mod = seq(mod)
+
+    # Test annotation
+    func = new_mod["relax_add"]
+    assert func.attrs
+    assert func.attrs["Codegen"] == "test-codegen"
+    assert func.attrs["global_symbol"] == "test-symbol"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/relax/test_function_attr.py
+++ b/tests/python/relax/test_function_attr.py
@@ -21,6 +21,21 @@ from tvm.script import relax as R
 from tvm import relax
 
 
+def _check_equal(x, y):
+    tvm.ir.assert_structural_equal(x, y)
+    tvm.ir.assert_structural_equal(y, x)
+
+    xhash = tvm.ir.structural_hash(x)
+    yhash = tvm.ir.structural_hash(y)
+
+    assert xhash == yhash
+
+
+def _check_save_roundtrip(x):
+    y = tvm.ir.load_json(tvm.ir.save_json(x))
+    _check_equal(x, y)
+
+
 @tvm.script.ir_module
 class InputModule:
     @R.function
@@ -35,20 +50,45 @@ class InputModule:
         return lv0
 
 
+def annotate(mod, func_name, attrs):
+    # Get func
+    annot_func = mod[func_name]
+    # Annotate a function
+    for key, val in attrs.items():
+        annot_func = annot_func.with_attr(key, val)
+    mod[func_name] = annot_func
+    return mod
+
+
 def test_func_attr_setter():
     mod = InputModule
     assert isinstance(mod, tvm.IRModule)
-    # Annotate a function
-    annot_func = mod["relax_add"].with_attr("Codegen", "test-codegen")
-    annot_func = annot_func.with_attr("global_symbol", "test-symbol")
+
+    mod = annotate(mod, "relax_add", {"Codegen": "test-codegen", "global_symbol": "test-symbol"})
+    _check_save_roundtrip(mod)
+    annot_func = mod["relax_add"]
 
     # Test annotation
     assert annot_func.attrs
     assert annot_func.attrs["Codegen"] == "test-codegen"
     assert annot_func.attrs["global_symbol"] == "test-symbol"
 
-    # Update ir module
-    mod["relax_add"] = annot_func
+
+def test_func_attr_roundtrip_and_equality():
+    mod = InputModule
+    assert isinstance(mod, tvm.IRModule)
+    mod1 = annotate(mod, "relax_add", {"Codegen": "test-codegen", "global_symbol": "test-symbol"})
+    mod2 = annotate(mod, "relax_add", {"Codegen": "test-codegen", "global_symbol": "test-symbol"})
+    _check_save_roundtrip(mod1)
+    _check_save_roundtrip(mod2)
+    _check_equal(mod1, mod2)
+
+
+def test_func_attr_setter_with_passes():
+    mod = InputModule
+    assert isinstance(mod, tvm.IRModule)
+    # Annotate
+    mod = annotate(mod, "relax_add", {"Codegen": "test-codegen", "global_symbol": "test-symbol"})
 
     # Test with passes
     # Annotation should stay the same unless the pass needs to modify it
@@ -57,11 +97,11 @@ def test_func_attr_setter():
     passes = [relax.transform.ToNonDataflow()]
     passes.append(relax.transform.CallTIRRewrite())
     passes.append(relax.transform.VMMemoryLower())
-    passes.append(relax.transform.VMShapeLower())
     seq = tvm.transform.Sequential(passes)
 
     # Apply passes
     new_mod = seq(mod)
+    _check_save_roundtrip(new_mod)
 
     # Test annotation
     func = new_mod["relax_add"]

--- a/tests/python/relax/test_function_attr.py
+++ b/tests/python/relax/test_function_attr.py
@@ -39,16 +39,16 @@ def test_func_attr_setter():
     mod = InputModule
     assert isinstance(mod, tvm.IRModule)
     # Annotate a function
-    annot_mod = mod["relax_add"].with_attr("Codegen", "test-codegen")
-    annot_mod = annot_mod.with_attr("global_symbol", "test-symbol")
+    annot_func = mod["relax_add"].with_attr("Codegen", "test-codegen")
+    annot_func = annot_func.with_attr("global_symbol", "test-symbol")
 
     # Test annotation
-    assert annot_mod.attrs
-    assert annot_mod.attrs["Codegen"] == "test-codegen"
-    assert annot_mod.attrs["global_symbol"] == "test-symbol"
+    assert annot_func.attrs
+    assert annot_func.attrs["Codegen"] == "test-codegen"
+    assert annot_func.attrs["global_symbol"] == "test-symbol"
 
     # Update ir module
-    mod["relax_add"] = annot_mod
+    mod["relax_add"] = annot_func
 
     # Test with passes
     # Annotation should stay the same unless the pass needs to modify it

--- a/tests/python/relax/test_pass_manager.py
+++ b/tests/python/relax/test_pass_manager.py
@@ -157,7 +157,7 @@ def test_dataflowblock_class_pass():
     @tvm.script.ir_module
     class Mod1:
         @R.function
-        def f1(x: Tensor((m, n), "float32")):
+        def f(x: Tensor((m, n), "float32")):
             with relax.dataflow():
                 lv0 = relax.multiply(x, x)
                 gv0 = relax.add(x, x)
@@ -167,7 +167,7 @@ def test_dataflowblock_class_pass():
     @tvm.script.ir_module
     class Mod2:
         @R.function
-        def f2(x: Tensor((m, n), "float32")):
+        def f(x: Tensor((m, n), "float32")):
             with relax.dataflow():
                 lv0 = relax.add(x, x)
                 gv0 = relax.add(x, x)
@@ -179,7 +179,7 @@ def test_dataflowblock_class_pass():
     assert block_pass.info.name == "TestReplaceBinding"
     updated_mod1 = block_pass(Mod1)
     updated_mod2 = block_pass(Mod2)
-    assert_structural_equal(updated_mod1["f1"], updated_mod2["f2"])
+    assert_structural_equal(updated_mod1["f"], updated_mod2["f"])
 
 
 def test_dataflowblock_pass():

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -49,7 +49,9 @@ def gen_mod(mod, name, binding):
             if k.name_hint == name:
                 # rename to main
                 gv = tvm.ir.GlobalVar("main")
-                funcs[gv] = tvm.relax.Function(v.params, v.body, v.ret_type, gv)
+                funcs[gv] = tvm.relax.Function(v.params, v.body, v.ret_type).with_attr(
+                    "global_symbol", "main"
+                )
         else:
             funcs[k] = v
     mod = tvm.IRModule(funcs)


### PR DESCRIPTION
This PR introduces function attribute in relax.
For now, we allow the subset of relay attributes necessary for the current need.
Please note that, instead of `kCompiler` used in relay attribute, this PR uses `kCodegen` to be more consistent with Bring-Your-Own-Codegen slogan. 

Since function attribute allows us to use `global_symbol`, this PR drops `Optional<GlobalVar> name` field in relax function and use `global_symbol` instead. In this case, parser will update this information accordingly during parsing. 

cc: @YuchenJin @tqchen @yongwww @psrivas2 