### PR TITLE
Add ShapeType to ShapeExpr.checked_type during construction

### DIFF
--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -49,6 +49,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   RELAX_EXPR_NORMALIZER_LEAF(ExternFuncNode);
   RELAX_EXPR_NORMALIZER_LEAF(GlobalVarNode);
   RELAX_EXPR_NORMALIZER_LEAF(OpNode);
+  RELAX_EXPR_NORMALIZER_LEAF(ShapeExprNode);
 
   // TODO(@altanh): CopyOnWrite
 
@@ -218,13 +219,6 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
       UpdateType(constant, type);
     }
     return constant;
-  }
-
-  Expr VisitExpr_(const ShapeExprNode* op) final {
-    ShapeExpr shape_expr = GetRef<ShapeExpr>(op);
-    ICHECK(op->checked_type_.defined());
-    ICHECK(!op->shape_.defined());
-    return shape_expr;
   }
 
   Expr VisitExpr_(const IfNode* op) final {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -222,10 +222,8 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
 
   Expr VisitExpr_(const ShapeExprNode* op) final {
     ShapeExpr shape_expr = GetRef<ShapeExpr>(op);
-
-    if (!shape_expr->checked_type_.defined()) {
-      UpdateType(shape_expr, ShapeType(Span()));
-    }
+    ICHECK(op->checked_type_.defined());
+    ICHECK(!op->shape_.defined());
     return shape_expr;
   }
 
@@ -382,13 +380,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
       // primitive op: look up FInferShape attribute
       Op op = Downcast<Op>(call->op);
       if (op_map_infer_shape_.count(op)) {
-        Optional<Expr> shape = op_map_infer_shape_[op](call, diag_ctx);
-        if (shape && shape.as<ShapeExprNode>()) {
-          if (!shape.value()->checked_type_.defined()) {
-            UpdateType(shape.value(), ShapeType(Span()));
-          }
-        }
-        return shape;
+        return op_map_infer_shape_[op](call, diag_ctx);
       }
     } else if (const auto* gv = call->op.as<GlobalVarNode>()) {
       // global function: find the function's shape_

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -41,6 +41,8 @@ ShapeExpr::ShapeExpr(Array<PrimExpr> values, Span span) {
   ObjectPtr<ShapeExprNode> n = make_object<ShapeExprNode>();
   n->values = std::move(values);
   n->span = span;
+  n->shape_ = NullOpt;
+  n->checked_type_ = ShapeType(Span());
   data_ = std::move(n);
 }
 

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -164,5 +164,18 @@ def test_shape_of():
         assert x == y
 
 
+def test_shape_expr():
+    shape_expr = rx.ShapeExpr([10, 20])
+    assert shape_expr.values[0] == 10
+    assert shape_expr.values[1] == 20
+    assert shape_expr.checked_type == rx.ShapeType()
+    assert shape_expr.shape_ is None
+
+    x = rx.Var("v0", (10, 20), rx.DynTensorType(2, "float32"))
+    assert x.shape_.values[0] == 10
+    assert x.shape_.values[1] == 20
+    assert x.shape_.checked_type == rx.ShapeType()
+    assert x.shape_.shape_ is None
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -177,5 +177,6 @@ def test_shape_expr():
     assert x.shape_.checked_type == rx.ShapeType()
     assert x.shape_.shape_ is None
 
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This PR adds `ShapeExpr.checked_type` during construction. 

Since `ShapeExpr` is a leaf node, it's best to add `shape_` and `checked_type_` as early as possible.

cc @YuchenJin @tqchen 