### PR TITLE
Support Closure

### DIFF
--- a/include/tvm/runtime/relax_vm/bytecode.h
+++ b/include/tvm/runtime/relax_vm/bytecode.h
@@ -72,8 +72,8 @@ enum class Opcode {
 struct Instruction {
   /*! \brief Random magic number that represents void argument. */
   static constexpr RegName kVoidArg = 0x00EC66FE0321975A;
-  /*! \brief Random magic number that represents the VM state. */
-  static constexpr RegName kVMStateRegister = 0x008D14FA4379015C;
+  /*! \brief Random magic number that represents the VM. */
+  static constexpr RegName kVMRegister = 0x008D14FA4379015C;
   /*!
    * \brief The kind of instruction's argument.
    */

--- a/include/tvm/runtime/relax_vm/executable.h
+++ b/include/tvm/runtime/relax_vm/executable.h
@@ -38,7 +38,6 @@ namespace tvm {
 namespace runtime {
 namespace relax_vm {
 
-
 /*!
  * \brief An object representing a vm closure.
  */
@@ -53,7 +52,7 @@ class VMClosureObj : public ClosureObj {
   Array<ObjectRef> free_vars;
 
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
-  static constexpr const char* _type_key = "vm.Closure";
+  static constexpr const char* _type_key = "relax.vm.Closure";
   TVM_DECLARE_FINAL_OBJECT_INFO(VMClosureObj, ClosureObj);
 };
 

--- a/include/tvm/runtime/relax_vm/executable.h
+++ b/include/tvm/runtime/relax_vm/executable.h
@@ -24,6 +24,7 @@
 #define TVM_RUNTIME_RELAX_VM_EXECUTABLE_H_
 
 #include <tvm/ir/expr.h>
+#include <tvm/runtime/container/closure.h>
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/registry.h>
 
@@ -36,6 +37,32 @@
 namespace tvm {
 namespace runtime {
 namespace relax_vm {
+
+
+/*!
+ * \brief An object representing a vm closure.
+ */
+class VMClosureObj : public ClosureObj {
+ public:
+  /*!
+   * \brief The function name. The function could be any
+   * function object that is compatible to the VM runtime.
+   */
+  String func_name;
+  /*! \brief The free variables of the closure. */
+  Array<ObjectRef> free_vars;
+
+  static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
+  static constexpr const char* _type_key = "vm.Closure";
+  TVM_DECLARE_FINAL_OBJECT_INFO(VMClosureObj, ClosureObj);
+};
+
+/*! \brief reference to closure. */
+class VMClosure : public Closure {
+ public:
+  VMClosure(String func_name, Array<ObjectRef> free_vars);
+  TVM_DEFINE_OBJECT_REF_METHODS(VMClosure, Closure, VMClosureObj);
+};
 
 /*!
  * \brief A representation of a Relax function in the VM.

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -173,7 +173,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param args The arguments to the closure.
    * \return The object representing the result.
    */
-  RegType Invoke_Closure(VMClosure clo, const std::vector<RegType>& args);
+  RegType InvokeClosure(VMClosure clo, const std::vector<RegType>& args);
   /*! \brief Run VM dispatch loop. */
   void RunLoop();
   /*!

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -67,19 +67,6 @@ struct VMFrame {
 };
 
 /*!
- * \brief The state of virtual machine, which can be referred in
- * instruction.
- */
-struct VMState {
-  /*! \brief The memory allocators. */
-  std::vector<Allocator*> allocators;
-  /*! \brief The kernel library. */
-  Optional<runtime::Module> lib;
-  /*! \brief Runtime physical device list. */
-  std::vector<Device> devices;
-};
-
-/*!
  * \brief The virtual machine.
  *
  * The virtual machine contains all the current execution state,
@@ -97,8 +84,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param devices The set of TVM devices.
    * \param alloc_types The allocator types for each device.
    */
-  void Init(const std::vector<Device>& devices, const std::vector<AllocatorType>& alloc_types,
-            const Optional<Module>& lib);
+  void Init(const std::vector<Device>& devices, const std::vector<AllocatorType>& alloc_types);
   /*!
    * \brief Load the executable for the virtual machine.
    * \param exec The executable.
@@ -127,8 +113,12 @@ class VirtualMachine : public runtime::ModuleNode {
 
   const char* type_key() const final { return "relax.VirtualMachine"; }
 
-  /*! \brief The state of the virtual machine, which can be referred by instructions. */
-  VMState state;
+  /*! \brief The kernel library. */
+  Optional<runtime::Module> lib;
+  /*! \brief The memory allocators. */
+  std::vector<Allocator*> allocators;
+  /*! \brief Runtime physical device list. */
+  std::vector<Device> devices;
 
  protected:
   /*!
@@ -167,13 +157,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \return The object representing the result.
    */
   RegType Invoke(Index fidx, const std::vector<RegType>& args);
-  /*!
-   * \brief Invoke a VMClosure.
-   * \param clo The VMClosure.
-   * \param args The arguments to the closure.
-   * \return The object representing the result.
-   */
-  RegType InvokeClosure(VMClosure clo, const std::vector<RegType>& args);
+
   /*! \brief Run VM dispatch loop. */
   void RunLoop();
   /*!

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -97,7 +97,8 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param devices The set of TVM devices.
    * \param alloc_types The allocator types for each device.
    */
-  void Init(const std::vector<Device>& devices, const std::vector<AllocatorType>& alloc_types);
+  void Init(const std::vector<Device>& devices, const std::vector<AllocatorType>& alloc_types,
+            const Optional<Module>& lib);
   /*!
    * \brief Load the executable for the virtual machine.
    * \param exec The executable.
@@ -166,6 +167,13 @@ class VirtualMachine : public runtime::ModuleNode {
    * \return The object representing the result.
    */
   RegType Invoke(Index fidx, const std::vector<RegType>& args);
+  /*!
+   * \brief Invoke a VMClosure.
+   * \param clo The VMClosure.
+   * \param args The arguments to the closure.
+   * \return The object representing the result.
+   */
+  RegType Invoke_Closure(VMClosure clo, const std::vector<RegType>& args);
   /*! \brief Run VM dispatch loop. */
   void RunLoop();
   /*!

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -70,7 +70,7 @@ VirtualMachine = vm.VirtualMachine
 load_exec_from_file = vm.load_exec_from_file
 
 # Operator
-from .op.base import call_tir, make_closure
+from .op.base import call_tir, make_closure, invoke_closure
 from .op.op_attrs import VMAllocStorageAttrs, VMAllocTensorAttrs
 
 # IRBuilder

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -70,7 +70,7 @@ VirtualMachine = vm.VirtualMachine
 load_exec_from_file = vm.load_exec_from_file
 
 # Operator
-from .op.base import call_tir
+from .op.base import call_tir, make_closure
 from .op.op_attrs import VMAllocStorageAttrs, VMAllocTensorAttrs
 
 # IRBuilder

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 """The base Relax operators."""
-from typing import Union, List, Optional
+from typing import Union, List, Optional, Callable
+
+from tvm.runtime.object import Object
 
 from . import _ffi_api
 from ..expr import Expr, ShapeExpr, Tuple, Call
@@ -70,3 +72,59 @@ def call_tir(
         raise TypeError("Not supported dtype for call_tir: " + str(type(dtype)))
 
     return _ffi_api.call_tir(func, args, shape, output_type, tir_vars)
+
+
+def make_closure(
+    func: Expr,
+    args: Union[Tuple, List[Expr]],
+) -> Object:
+    """
+    Create a closure with free variables and return the closure.
+
+    Parameters
+    ----------
+    func : Expr
+        The closure, can be ExternFunc or PrimFunc.
+
+    args : Union[Tuple, List[Expr]]
+        The input arguments.
+
+
+    Returns
+    -------
+    ret: Object
+        The VMClosure.
+    """
+
+    if isinstance(args, (list, tuple)):
+        args = Tuple(args)
+
+    return _ffi_api.make_closure(func, args)
+
+
+def invoke_closure(
+    closure: Expr,
+    args: Union[Tuple, List[Expr]],
+) -> Object:
+    """
+    Invoke a closure.
+
+    Parameters
+    ----------
+    closure : Expr
+        The VMClosure object.
+
+    args : Union[Tuple, List[Expr]]
+        The input arguments.
+
+
+    Returns
+    -------
+    ret: Object
+        The result.
+    """
+
+    if isinstance(args, (list, tuple)):
+        args = Tuple(args)
+
+    return _ffi_api.invoke_closure(closure, args)

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 """The base Relax operators."""
-from typing import Union, List, Optional, Callable
+from typing import Union, List, Optional
 
 from tvm.runtime.object import Object
 

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -21,7 +21,9 @@ from typing import List, Optional, Union, Dict, Tuple
 import tvm
 from tvm import relax
 from tvm.ir.module import IRModule
+from tvm.relay import Any
 from tvm.runtime import Device, Module, PackedFunc
+from tvm.runtime.object import Object
 from tvm.tir.function import PrimFunc
 from . import _ffi_api
 from ..rpc.base import RPC_SESS_MASK
@@ -137,7 +139,7 @@ class VirtualMachine(object):
     def __getitem__(self, key: str) -> PackedFunc:
         return self.module[key]
 
-    def invoke_closure(self, closure, *args):
+    def invoke_closure(self, closure: Object, *args: Any) -> Object:
         """Invoke a closure.
 
         Parameters

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -90,6 +90,7 @@ class VirtualMachine(object):
             dict.
         """
         self.module = exec.mod["vm_load_executable"]()
+        self._invoke_closure = self.module["invoke_closure"]
         self._setup_device(device, memory_cfg)
 
     def _setup_device(self, dev: Device, memory_cfg: Union[str, Dict[Device, str]]) -> None:
@@ -135,6 +136,24 @@ class VirtualMachine(object):
 
     def __getitem__(self, key: str) -> PackedFunc:
         return self.module[key]
+
+    def invoke_closure(self, closure, *args):
+        """Invoke a closure.
+
+        Parameters
+        ----------
+        closure : Object
+            The VMClosure Object.
+
+        args : list[tvm.runtime.NDArray] or list[np.ndarray]
+            The arguments to the closure.
+
+        Returns
+        -------
+        result : Object
+            The output.
+        """
+        return self._invoke_closure(closure, *args)
 
 
 def build(mod: tvm.IRModule, target: tvm.target.Target) -> Executable:

--- a/src/relax/backend/vm/builtin.cc
+++ b/src/relax/backend/vm/builtin.cc
@@ -61,7 +61,7 @@ TVM_REGISTER_GLOBAL("vm.builtin.alloc_closure")
     });
 
 TVM_REGISTER_GLOBAL("vm.builtin.invoke_closure").set_body([](TVMArgs args, TVMRetValue* rv) {
-  // args[0]: vm_state; args[1]: closure; args[2]: function arguments, tuple
+  // args[0]: vm_state; args[1]: closure; args[2, 3, ...]: function arguments
   void* vm_state_ptr = args[0];
   VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
   VMClosure vm_closure = args[1];

--- a/src/relax/backend/vm/builtin.cc
+++ b/src/relax/backend/vm/builtin.cc
@@ -65,11 +65,7 @@ TVM_REGISTER_GLOBAL("vm.builtin.invoke_closure").set_body([](TVMArgs args, TVMRe
 
   PackedFunc func{nullptr};
   func = vm->GetFunction(func_name, GetObjectPtr<Object>(vm));
-  if (!func.defined()) {
-    const PackedFunc* p_func = Registry::Get(func_name);
-    CHECK(p_func != nullptr);
-    func = *(p_func);
-  }
+  ICHECK(func != nullptr) << "cannot find closure " << func_name;
 
   // get closure free_vars
   Array<ObjectRef> cap_vars = vm_closure->free_vars;

--- a/src/relax/backend/vm/builtin.cc
+++ b/src/relax/backend/vm/builtin.cc
@@ -19,7 +19,6 @@
 /*!
  * \file src/relax/backend/vm/builtin.cc
  */
-#include <tvm/relax/expr.h>
 #include <tvm/runtime/container/adt.h>
 #include <tvm/runtime/data_type.h>
 #include <tvm/runtime/device_api.h>
@@ -29,7 +28,6 @@
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/relax_vm/bytecode.h>
-#include <tvm/runtime/relax_vm/executable.h>
 #include <tvm/runtime/relax_vm/memory_manager.h>
 #include <tvm/runtime/relax_vm/vm.h>
 
@@ -47,30 +45,26 @@ TVM_REGISTER_GLOBAL("vm.builtin.alloc_shape_heap").set_body_typed([](ShapeTuple 
   return NDArray::Empty(size, DLDataType{kDLInt, 64, 1}, DLDevice{kDLCPU, 0});
 });
 
+TVM_REGISTER_GLOBAL("vm.builtin.alloc_closure").set_body([](TVMArgs args, TVMRetValue* rv) {
+  std::vector<ObjectRef> cap_vars;
+  for (int i = 1; i < args.size(); ++i) {
+    cap_vars.push_back(args[i]);
+  }
+  String func_name = args[0];
+  VMClosure vm_closure(func_name, cap_vars);
 
-TVM_REGISTER_GLOBAL("vm.builtin.alloc_closure")
-    .set_body([](TVMArgs args, TVMRetValue* rv) {
-      std::vector<ObjectRef> cap_vars;
-      for (int i = 1; i < args.size(); ++i) {
-        cap_vars.push_back(args[i]);
-      }
-      String func_name = args[0];
-      VMClosure vm_closure(func_name, cap_vars);
-
-      *rv = std::move(vm_closure);
-    });
+  *rv = std::move(vm_closure);
+});
 
 TVM_REGISTER_GLOBAL("vm.builtin.invoke_closure").set_body([](TVMArgs args, TVMRetValue* rv) {
-  // args[0]: vm_state; args[1]: closure; args[2, 3, ...]: function arguments
-  void* vm_state_ptr = args[0];
-  VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
+  // args[0]: vm; args[1]: closure; args[2, 3, ...]: function arguments
+  void* vm_ptr = args[0];
+  VirtualMachine* vm = static_cast<VirtualMachine*>(vm_ptr);
   VMClosure vm_closure = args[1];
   runtime::String func_name = vm_closure->func_name;
 
   PackedFunc func{nullptr};
-  if (vm_state->lib.defined()) {
-    func = vm_state->lib.value()->GetFunction(func_name, true);
-  }
+  func = vm->GetFunction(func_name, GetObjectPtr<Object>(vm));
   if (!func.defined()) {
     const PackedFunc* p_func = Registry::Get(func_name);
     CHECK(p_func != nullptr);
@@ -117,17 +111,17 @@ TVM_REGISTER_GLOBAL("vm.builtin.load_shape").set_body_typed([](NDArray heap, Sha
 });
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
-    .set_body_typed([](void* vm_state_ptr, ShapeTuple buffer_size, Index device_index,
+    .set_body_typed([](void* vm_ptr, ShapeTuple buffer_size, Index device_index,
                        DLDataType dtype_hint) {
       ICHECK_EQ(buffer_size.size(), 1);
       int alignment = runtime::kAllocAlignment;
-      VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
-      ICHECK_LT(device_index, vm_state->devices.size())
+      VirtualMachine* vm = static_cast<VirtualMachine*>(vm_ptr);
+      ICHECK_LT(device_index, vm->devices.size())
           << "The device index is out of VM physical devices list";
 
       if (device_index == -1) {
-        // Allocate on host. Host is always the last element of vm_state->devices.
-        device_index = vm_state->devices.size() - 1;
+        // Allocate on host. Host is always the last element of vm->devices.
+        device_index = vm->devices.size() - 1;
       }
 
       int64_t size_imm = buffer_size[0];
@@ -136,7 +130,7 @@ TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
                  << ", device_index=" << device_index;
 
       auto storage_obj = runtime::SimpleObjAllocator().make_object<StorageObj>();
-      auto* alloc = vm_state->allocators[device_index];
+      auto* alloc = vm->allocators[device_index];
       ICHECK(alloc) << "Did you forget to init the VirtualMachine with devices?";
       storage_obj->buffer = alloc->Alloc(size_imm, alignment, dtype_hint);
       Storage storage(storage_obj);
@@ -170,13 +164,13 @@ TVM_REGISTER_GLOBAL("vm.binary_broadcast_shape_infer")
     });
 
 TVM_REGISTER_GLOBAL("vm.call_tir_dyn").set_body([](TVMArgs args, TVMRetValue* rv) {
-  void* vm_state_ptr = args[0];
-  VMState* vm_state = static_cast<VMState*>(vm_state_ptr);
+  void* vm_ptr = args[0];
+  VirtualMachine* vm = static_cast<VirtualMachine*>(vm_ptr);
   runtime::String func_name = args[1];
 
   PackedFunc func{nullptr};
-  if (vm_state->lib.defined()) {
-    func = vm_state->lib.value()->GetFunction(func_name, true);
+  if (vm->lib.defined()) {
+    func = vm->lib.value()->GetFunction(func_name, true);
   }
   if (!func.defined()) {
     const PackedFunc* p_func = Registry::Get(func_name);

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -251,7 +251,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   Instruction::Arg EmitAllocStorage(const Call& call_node) {
     // Handle args of the call
     std::vector<Instruction::Arg> args;
-    args.push_back(Instruction::Arg(Instruction::kVMStateRegister));
+    args.push_back(Instruction::Arg(Instruction::kVMRegister));
     for (Expr arg : call_node->args) {
       args.push_back(ConvertArg(arg));
     }
@@ -339,7 +339,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     auto func_name_index = builder_->EmitConstant(func_name_constant);
 
     std::vector<Instruction::Arg> args;
-    args.push_back(Instruction::Arg(Instruction::kVMStateRegister));
+    args.push_back(Instruction::Arg(Instruction::kVMRegister));
     args.push_back(Instruction::Arg(Instruction::kConstIdx, func_name_index));
     for (Expr arg : tir_args->fields) {
       args.push_back(ConvertArg(arg));
@@ -419,7 +419,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
 
     std::vector<Instruction::Arg> args;
     // VMState is utilized to help get the Function in builtin packedfunc
-    args.push_back(Instruction::Arg(Instruction::kVMStateRegister));
+    args.push_back(Instruction::Arg(Instruction::kVMRegister));
 
     auto lv = Downcast<Var>(call_node->args[0]);
     auto it = this->var_register_map_.find(lv);

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -64,8 +64,6 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
 
  protected:
   size_t NewRegister() { return registers_num_++; }
-  // TODO(@yuchen): when we support closure, this visitor should return a register that
-  // contains the closure object.
   Instruction::Arg VisitExpr_(const FunctionNode* func_node) {
     Optional<String> gsymbol = func_node->GetAttr<String>(tvm::attr::kGlobalSymbol);
     if (gsymbol.defined()) {
@@ -78,6 +76,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
       builder_->EmitFunction("local_func" + std::to_string(local_func_counter_++),
                              func_node->params.size());
     }
+
     for (Var param : func_node->params) {
       Instruction::Arg reg = this->VisitExpr(param);
       this->var_register_map_.insert({param, reg.data});
@@ -121,6 +120,10 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
         return EmitShape(call);
       } else if (call_node->op == call_tir_dyn_op_) {
         return EmitTirDynOp(call);
+      } else if (call_node->op == make_closure_op_) {
+        return EmitAllocClosure(call);
+      } else if (call_node->op == invoke_closure_op_) {
+        return EmitInvokeClosure(call);
       } else {
         // every "normal" operator is lowered to a global var in the IR module. The Attrs for those
         // ops are handled in a pass when lowering them to TIR.
@@ -385,6 +388,58 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     return Instruction::Arg(Instruction::kRegister, arg_register);
   }
 
+  Instruction::Arg EmitAllocClosure(const Call& call_node) {
+    ICHECK(call_node->args.size() == 2);
+    ICHECK(call_node->args[0]->IsInstance<GlobalVarNode>());
+    ICHECK(call_node->args[1]->IsInstance<TupleNode>());
+
+    auto gv = Downcast<GlobalVar>(call_node->args[0]);
+    auto closure_args = Downcast<Tuple>(call_node->args[1]);
+    auto func_name = gv->name_hint;
+
+    TVMRetValue func_name_constant;
+    func_name_constant = func_name;
+    auto func_name_index = builder_->EmitConstant(func_name_constant);
+
+    std::vector<Instruction::Arg> args;
+    args.push_back(Instruction::Arg(Instruction::kConstIdx, func_name_index));
+    for (Expr arg : closure_args->fields) {
+      args.push_back(ConvertArg(arg));
+    }
+
+    size_t dst_register = NewRegister();
+    builder_->EmitCall("vm.builtin.alloc_closure", args, dst_register);
+    return Instruction::Arg(Instruction::kRegister, dst_register);
+  }
+
+  Instruction::Arg EmitInvokeClosure(const Call& call_node) {
+    ICHECK(call_node->args.size() == 2);
+    ICHECK(call_node->args[0]->IsInstance<VarNode>());
+    ICHECK(call_node->args[1]->IsInstance<TupleNode>());
+
+    std::vector<Instruction::Arg> args;
+    // VMState is utilized to help get the Function in builtin packedfunc
+    args.push_back(Instruction::Arg(Instruction::kVMStateRegister));
+
+    auto lv = Downcast<Var>(call_node->args[0]);
+    auto it = this->var_register_map_.find(lv);
+    if (it != this->var_register_map_.end()) {
+      args.push_back(Instruction::Arg(Instruction::kRegister, it->second));
+    } else {
+      args.push_back(Instruction::Arg(Instruction::kRegister, registers_num_));
+    }
+
+    // free_vars of VMClosure
+    auto closure_args = Downcast<Tuple>(call_node->args[1]);
+    for (Expr arg : closure_args->fields) {
+      args.push_back(ConvertArg(arg));
+    }
+
+    size_t dst_register = NewRegister();
+    builder_->EmitCall("vm.builtin.invoke_closure", args, dst_register);
+    return Instruction::Arg(Instruction::kRegister, dst_register);
+  }
+
   bool IsConstantShape(ShapeExpr shape) const {
     for (PrimExpr e : shape->values) {
       if (!e->IsInstance<IntImmNode>()) {
@@ -443,6 +498,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   const Op& load_shape_op_ = Op::Get("relax.vm.builtin.load_shape");
   const Op& call_tir_dyn_op_ = Op::Get("relax.vm.call_tir_dyn");
   const Op& unique_op_ = Op::Get("relax.unique");
+  const Op& make_closure_op_ = Op::Get("relax.make_closure");
+  const Op& invoke_closure_op_ = Op::Get("relax.invoke_closure");
 };
 
 void VMCodeGen::CodeGen(IRModule rx_mod) {

--- a/src/relax/backend/vm/exec_builder.cc
+++ b/src/relax/backend/vm/exec_builder.cc
@@ -104,7 +104,7 @@ void ExecBuilderNode::CheckExecutable() {
         case Opcode::Call: {
           for (int i = 0; i < instr.num_args; ++i) {
             if (instr.args[i].kind() == Instruction::kRegister &&
-                instr.args[i].value() == Instruction::kVMStateRegister) {
+                instr.args[i].value() == Instruction::kVMRegister) {
               continue;
             }
             if (instr.args[i].kind() == Instruction::kRegister &&

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -64,10 +64,10 @@ Optional<Expr> InferShapeCallTIR(const Call& call, DiagnosticContext diag_ctx) {
   return output_shape;
 }
 
-Type InferTypeCallTIR(const Call& call, DiagnosticContext diag_ctx) {
+Type InferTypeArg(const Call& call, DiagnosticContext diag_ctx) {
   if (call->type_args.size() != 1) {
     diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                       << "type_args of call_tir should have exact 1 output type.");
+                       << "type_args should have exact 1 output type.");
   }
   Type output_type = call->type_args[0];
   return output_type;
@@ -82,7 +82,7 @@ RELAY_REGISTER_OP("relax.call_tir")
                   "ShapeExpr representing a tuple of ints to unpack during runtime. Omitted from "
                   "args if unused")
     .set_attr<FInferShape>("FInferShape", InferShapeCallTIR)
-    .set_attr<FInferType>("FInferType", InferTypeCallTIR);
+    .set_attr<FInferType>("FInferType", InferTypeArg);
 
 Expr MakeCallTIR(Expr func, Tuple args, Expr output_shape, Type output_type,
                  Optional<Expr> packed_ints) {
@@ -120,7 +120,7 @@ RELAY_REGISTER_OP("relax.invoke_closure")
     .set_num_inputs(2)
     .add_argument("closure", "Expr", "The VMClosure.")
     .add_argument("args", "Tuple", "The captured variables.")
-    .set_attr<FInferType>("FInferType", ReturnVoidType);
+    .set_attr<FInferType>("FInferType", InferTypeArg);
 
 Expr InvokeClosure(Expr closure, Tuple args) {
   static const Op& op = Op::Get("relax.invoke_closure");

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -216,21 +216,6 @@ Expr MakeVMAllocTensor(Expr storage, Expr shape) {
 
 TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_tensor").set_body_typed(MakeVMAllocTensor);
 
-// vm make_closure
-
-RELAY_REGISTER_OP("relax.vm.builtin.make_closure")
-    .set_num_inputs(2)
-    .add_argument("func", "Expr", "The closure.")
-    .add_argument("args", "Tuple", "The captured variables.")
-    .set_attr<FInferType>("FInferType", InferTypeVMAllocTensor);
-
-Expr MakeVMClosure(Expr func, Tuple args) {
-  static const Op& op = Op::Get("relax.vm.builtin.make_closure");
-  return Call(op, {func, args}, {}, {});
-}
-
-TVM_REGISTER_GLOBAL("relax.op.vm.builtin.make_closure").set_body_typed(MakeVMClosure);
-
 // vm store_shape
 
 RELAY_REGISTER_OP("relax.vm.builtin.store_shape")

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -99,6 +99,36 @@ Expr MakeCallTIR(Expr func, Tuple args, Expr output_shape, Type output_type,
 
 TVM_REGISTER_GLOBAL("relax.op.call_tir").set_body_typed(MakeCallTIR);
 
+// make_closure
+
+RELAY_REGISTER_OP("relax.make_closure")
+    .set_num_inputs(2)
+    .add_argument("func", "Expr", "The closure.")
+    .add_argument("args", "Tuple", "The captured variables.")
+    .set_attr<FInferType>("FInferType", ReturnObjectType);
+
+Expr MakeClosure(Expr func, Tuple args) {
+  static const Op& op = Op::Get("relax.make_closure");
+  return Call(op, {func, args}, {}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.make_closure").set_body_typed(MakeClosure);
+
+// invoke_closure
+
+RELAY_REGISTER_OP("relax.invoke_closure")
+    .set_num_inputs(2)
+    .add_argument("closure", "Expr", "The VMClosure.")
+    .add_argument("args", "Tuple", "The captured variables.")
+    .set_attr<FInferType>("FInferType", ReturnVoidType);
+
+Expr InvokeClosure(Expr closure, Tuple args) {
+  static const Op& op = Op::Get("relax.invoke_closure");
+  return Call(op, {closure, args}, {}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.invoke_closure").set_body_typed(InvokeClosure);
+
 // shape_of
 
 RELAY_REGISTER_OP("relax.shape_of")
@@ -185,6 +215,21 @@ Expr MakeVMAllocTensor(Expr storage, Expr shape) {
 }
 
 TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_tensor").set_body_typed(MakeVMAllocTensor);
+
+// vm make_closure
+
+RELAY_REGISTER_OP("relax.vm.builtin.make_closure")
+    .set_num_inputs(2)
+    .add_argument("func", "Expr", "The closure.")
+    .add_argument("args", "Tuple", "The captured variables.")
+    .set_attr<FInferType>("FInferType", InferTypeVMAllocTensor);
+
+Expr MakeVMClosure(Expr func, Tuple args) {
+  static const Op& op = Op::Get("relax.vm.builtin.make_closure");
+  return Call(op, {func, args}, {}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.vm.builtin.make_closure").set_body_typed(MakeVMClosure);
 
 // vm store_shape
 

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -22,6 +22,7 @@
  */
 
 #include <dmlc/memory_io.h>
+#include <tvm/runtime/object.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/relax_vm/executable.h>
 #include <tvm/runtime/relax_vm/vm.h>
@@ -50,6 +51,15 @@ enum ConstantType : int {
 #define STREAM_CHECK(val, section)                                          \
   ICHECK(val) << "Invalid VM file format in the " << section << " section." \
               << "\n";
+
+TVM_REGISTER_OBJECT_TYPE(VMClosureObj);
+
+VMClosure::VMClosure(String func_name, Array<ObjectRef> free_vars) {
+  auto ptr = make_object<VMClosureObj>();
+  ptr->func_name = func_name;
+  ptr->free_vars = std::move(free_vars);
+  data_ = std::move(ptr);
+}
 
 PackedFunc Executable::GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) {
   if (name == "stats") {

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -22,7 +22,6 @@
  */
 
 #include <dmlc/memory_io.h>
-#include <tvm/runtime/object.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/relax_vm/executable.h>
 #include <tvm/runtime/relax_vm/vm.h>
@@ -449,8 +448,8 @@ std::string RegNameToStr(RegName reg) {
   if (reg == Instruction::kVoidArg) {
     return "void";
   }
-  if (reg == Instruction::kVMStateRegister) {
-    return "%state";
+  if (reg == Instruction::kVMRegister) {
+    return "%vm";
   }
   return "%" + std::to_string(reg);
 }
@@ -473,8 +472,8 @@ std::string InstrArgToStr(Instruction::Arg arg) {
 std::string InstrArgToPyStr(Instruction::Arg arg) {
   switch (arg.kind()) {
     case Instruction::kRegister:
-      if (arg.value() == Instruction::kVMStateRegister) {
-        return "ib.r(state)";
+      if (arg.value() == Instruction::kVMRegister) {
+        return "ib.r(vm)";
       }
       return "ib.r(" + std::to_string(arg.value()) + ")";
     case Instruction::kImmediate:

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -916,7 +916,7 @@ def test_vm_closure():
             y: Tensor((2, 3), "float32"),
         ):
             clo = relax.make_closure(lifted_func_1, (x,))
-            res = relax.invoke_closure(clo, (y,))
+            res = relax.invoke_closure(clo, (y,), type_args=(Tensor))
             return res
 
     mod = TestClosure


### PR DESCRIPTION
As dicussed in https://github.com/tlc-pack/relax/issues/93, this pr:

- adds `VMClosure`, it stores the global function name and related free variables/captured variables.
- introduces `relax.make_closure` intrinsic, it was used to create a closure in relax ir. Each time when VM Codegen meets make_closure, it will emit a call to call into `alloc_closure` builtin packedfunc. 
- adds `relax.invoke_closure`, which invoke a closure in relax ir. 
-  implements `vm.builtin.alloc_closure` packedfunc, it leverages `VMClosure` to save closure related information like free variables. Reason why we need `VMClosure` is documented in issues 93.
- adds `vm.builtin.invoke_closure` packedfunc, we will find out the the related relax function via function name saved in `VMClosure`, and call into the packedfunc and return the outputs.
- removes `VMState`, and moves the members of `VMState` into `VirutualMachine`, because we would like to utilize VM to help find out the global relax packedfunc in `builtin.invoke_closure`. 

cc @YuchenJin @psrivas2 @sunggg 