### PR TITLE
[Pass][BlockBuilder] Refactor shape lowering pass and BlockBuilder

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -162,7 +162,7 @@ class BlockBuilderNode : public Object {
    * \param gv The global var referring the function to be updated.
    * \param function The updated function.
    */
-  void UpdateFunction(const GlobalVar& gv, Function function);
+  void UpdateFunction(const GlobalVar& gv, BaseFunc function);
 
   /*!
    * \brief Get the context IRModule being built.

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -36,7 +36,7 @@ class VMShapeLowerMutator : public ExprMutator {
  public:
   static DataType ShapeDType() { return DataType::Int(64); }
 
-  explicit VMShapeLowerMutator(IRModule mod) { mod_ = mod; }
+  explicit VMShapeLowerMutator(IRModule mod) : ExprMutator(mod) { mod_ = mod; }
 
   IRModule Lower() {
     for (auto& p : mod_->functions) {
@@ -49,9 +49,9 @@ class VMShapeLowerMutator : public ExprMutator {
         shape_heap_ = Var("shape_heap", ShapeExpr({heap_size_}), heap_type);
 
         // mutate
-        func = this->VisitExpr(func);
+        Function updated_func = Downcast<Function>(VisitExpr(func));
+        builder_->UpdateFunction(p.first, updated_func);
       }
-      builder_->AddFunction(Downcast<BaseFunc>(func), p.first->name_hint);
     }
     return builder_->GetContextIRModule();
   }

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -702,7 +702,7 @@ GlobalVar BlockBuilderNode::AddFunction(const BaseFunc& func, const String& func
   }
 }
 
-void BlockBuilderNode::UpdateFunction(const GlobalVar& gv, Function updated_function) {
+void BlockBuilderNode::UpdateFunction(const GlobalVar& gv, BaseFunc updated_function) {
   context_mod_.CopyOnWrite();
   context_mod_->Update(gv, updated_function);
   func_map_[updated_function] = gv;
@@ -715,7 +715,13 @@ BlockBuilder BlockBuilder::Create(Optional<IRModule> mod) {
   if (mod) {
     n->context_mod_ = mod.value();
   }
-  return BlockBuilder(n);
+  BlockBuilder block_builder(n);
+  for (const auto& kv : n->context_mod_->functions) {
+    const GlobalVar& gv = kv.first;
+    const BaseFunc& func = kv.second;
+    block_builder->func_map_.emplace(func, gv);
+  }
+  return block_builder;
 }
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderCreate").set_body_typed([](Optional<IRModule> mod) {


### PR DESCRIPTION
Refactors the `VMShapeLower` pass to pass the before-transformation IRModule to the mutator, and applies mutation using `UpdateFunction` and `AddFunction` APIs in BlockBuilder. This is the pass writing paradigm introduced by #133 which allows the BlockBuilder to take an optional input IRModule with copy-on-write mechanism. This fixes the roundtrip check failure @sunggg encountered in #136.

Other changes:
- Initialize `func_map_` in `BlockBuilder::Create(mod)`: this avoids generating duplicated PrimFunc when calling `AddFunction` if the input IRModule is given;
- Update the signature of `UpdateFunction` to be able to update a PrimFunc in the IRModule.
- Add a test to check the IRModule attrs is preserved after applying the `VMShapeLower` pass, cc @sunggg.