### PR TITLE
Print/parse tir cast/max operations in Relax shape

### DIFF
--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -361,7 +361,19 @@ TVM_DEFINE_RELAX_PRINTER_PRIMEXPR_BINOP(tir::AddNode, " + ")
 TVM_DEFINE_RELAX_PRINTER_PRIMEXPR_BINOP(tir::SubNode, " - ")
 TVM_DEFINE_RELAX_PRINTER_PRIMEXPR_BINOP(tir::MulNode, " * ")
 TVM_DEFINE_RELAX_PRINTER_PRIMEXPR_BINOP(tir::DivNode, " / ")
-TVM_DEFINE_RELAX_PRINTER_PRIMEXPR_BINOP(tir::FloorDivNode, " // ");
+TVM_DEFINE_RELAX_PRINTER_PRIMEXPR_BINOP(tir::FloorDivNode, " // ")
+
+Doc RelaxScriptPrinter::VisitExpr_(const tir::CastNode* op) {
+  Doc doc;
+  doc << "tir.cast(" << PrintDType(op->dtype) << ", " << Print(op->value) << ")";
+  return doc;
+}
+
+Doc RelaxScriptPrinter::VisitExpr_(const tir::MaxNode* op) {
+  Doc doc;
+  doc << "tir.max(" << Print(op->a) << ", " << Print(op->b) << ")";
+  return doc;
+}
 
 Doc RelaxScriptPrinter::VisitType_(const relax::ShapeTypeNode* node) { return Doc::Text("Shape"); }
 

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -295,6 +295,8 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   Doc VisitExpr_(const tir::MulNode* op) override;
   Doc VisitExpr_(const tir::DivNode* op) override;
   Doc VisitExpr_(const tir::FloorDivNode* op) override;
+  Doc VisitExpr_(const tir::CastNode* op) override;
+  Doc VisitExpr_(const tir::MaxNode* op) override;
 
   Doc PrintIRModule(const IRModule& mod);
   Doc PrintPrimFunc(const String& name, const tir::PrimFunc& func);

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -167,6 +167,24 @@ def test_unexpected_ndim_type():
             return x
 
 
+def test_unexpected_tir_cast_args():
+    # tir.cast expects 2 arguments, but got 3
+    with pytest.raises(tvm.error.DiagnosticError):
+
+        @R.function
+        def f(x: Tensor((m,), "float32")):
+            return relax.call_tir("foo", (x,), (tir.cast("int32", m, 1),), dtype="float32")
+
+
+def test_unexpected_tir_max_args():
+    # tir.max expects 2 arguments, but got 1
+    with pytest.raises(tvm.error.DiagnosticError):
+
+        @R.function
+        def f(x: Tensor((m, n), "float32")):
+            return relax.call_tir("foo", (x,), (tir.max(m),), dtype="float32")
+
+
 def test_match_shape():
     @R.function
     def f(x: Tensor(_, "float32")):

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -326,6 +326,24 @@ def test_class_irmodule():
     check_roundtrip(my_module)
 
 
+def test_tir_max():
+    @R.function
+    def tir_max(x: Tensor((m, n), "float32")):
+        gv = relax.call_tir("my_extern", (x,), (tir.max(n, m),), dtype="float32")
+        return gv
+
+    check_roundtrip(tir_max)
+
+
+def test_tir_cast():
+    @R.function
+    def tir_cast(x: Tensor((m,), "float32")):
+        gv = relax.call_tir("my_extern", (x,), (tir.cast("int32", m),), dtype="float32")
+        return gv
+
+    check_roundtrip(tir_cast)
+
+
 def test_dyntensor_type():
     x = relax.DynTensorType(ndim=3, dtype="float32")
     assert x.__str__() == 'Tensor[ndim=3, dtype="float32"]'


### PR DESCRIPTION
Add support to print and parse `tir.cast` and `tir.max` in Relax function.

These ops are commonly used in shape expression in Relax. These two operators often show up when importing Relay module
with `Any` dims to Relax module.

For example, this change adds support to import the following relay modules:

```
def @main(%a: Tensor[(?, 3, 224, 224), float32]) {
  layout_transform(%a, src_layout="NCHW", dst_layout="NHWC")
}
```
```
def @main(%a: Tensor[(?), float32], %b: Tensor[(?), float32]) {
  add(%a, %b)
}
```    

This PR resolves bug https://github.com/tlc-pack/relax/issues/147