### PR TITLE
[Pass] Relax Transform FuseTIR

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -149,6 +149,13 @@ TVM_DLL Pass AnnotateTIROpPattern();
  */
 TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
 
+/*!
+ * \brief Fuse relax sub-function into a larger TIR function if possible.
+    this pass works together with FuseOps to perform operator fusion.
+
+ * \return The Pass.
+ */
+TVM_DLL Pass FuseTIR();
 }  // namespace transform
 }  // namespace relax
 }  // namespace tvm

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -213,6 +213,17 @@ def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
     return _ffi_api.FuseOps(fuse_opt_level)
 
 
+def FuseTIR() -> tvm.ir.transform.Pass:
+    """Fuse primitive relax function into a larger TIR function if possible
+
+    Returns
+    -------
+    ret : tvm.transform.Pass
+        The registered pass for tir fusion.
+    """
+    return _ffi_api.FuseTIR()
+
+
 def _wrap_class_function_pass(pass_cls, pass_info):
     """Wrap a python class as function pass."""
 

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -356,15 +356,11 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   // Helper function to check if a ShapeExpr is constant shape or tuple of constant shape
   bool IsConstantShapes(const Expr& shape) const {
     if (const auto* shape_expr = shape.as<ShapeExprNode>()) {
-      for (const PrimExpr& e : shape_expr->values) {
-        if (!e->IsInstance<IntImmNode>()) return false;
-      }
-      return true;
+      return std::all_of(shape_expr->values.begin(), shape_expr->values.end(),
+                         [](const PrimExpr& e) { return e->IsInstance<IntImmNode>(); });
     } else if (const auto* shape_tuple = shape.as<TupleNode>()) {
-      for (const Expr& e : shape_tuple->fields) {
-        if (!IsConstantShapes(e)) return false;
-      }
-      return true;
+      return std::all_of(shape_tuple->fields.begin(), shape_tuple->fields.end(),
+                         [&](const Expr& e) { return IsConstantShapes(e); });
     } else {
       return false;
     }

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -252,12 +252,10 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     }
 
     if (!node->shape_ && node->tuple->shape_) {
-      if (node->checked_type_.as<DynTensorTypeNode>()) {
-        // TODO(@prakalp, @yuchen): assign the shape_ to RuntimeDepShape when we cannot obtain the
-        // field
-        if (const TupleNode* shape = node->tuple->shape_.as<TupleNode>()) {
-          UpdateShape(node, shape->fields[node->index]);
-        }
+      // TODO(@prakalp, @yuchen): assign the shape_ to RuntimeDepShape when we cannot obtain the
+      // field
+      if (const TupleNode* shape = node->tuple->shape_.as<TupleNode>()) {
+        UpdateShape(node, shape->fields[node->index]);
       }
     }
 

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -1,0 +1,738 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+#include <tvm/tir/stmt_functor.h>
+
+#include "../../relay/analysis/graph_partitioner.h"
+#include "../../support/arena.h"
+#include "../../tir/ir/functor_common.h"
+
+namespace tvm {
+namespace tir {
+
+/*!
+ * \brief Substitute a given source buffer with a given target buffer in statements or expressions.
+ */
+class BufferSubstituter : private StmtExprMutator {
+ public:
+  static Stmt Substitute(const Map<Buffer, Buffer>& buffer_map, Stmt stmt) {
+    return BufferSubstituter(buffer_map)(std::move(stmt));
+  }
+
+ private:
+  explicit BufferSubstituter(const Map<Buffer, Buffer>& buffer_map) {
+    for (const auto& kv : buffer_map) {
+      const Buffer& src = kv.first;
+      const Buffer& tgt = kv.second;
+      buffer_var_map_[src->data.get()] = tgt;
+    }
+  }
+
+  PrimExpr VisitExpr_(const VarNode* _op) final {
+    auto it = buffer_var_map_.find(_op);
+    if (it != buffer_var_map_.end()) {
+      return it->second->data;
+    } else {
+      return GetRef<PrimExpr>(_op);
+    }
+  }
+
+  PrimExpr VisitExpr_(const BufferLoadNode* _op) final {
+    BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(_op));
+    auto it = buffer_var_map_.find(load->buffer->data.get());
+    if (it != buffer_var_map_.end()) {
+      auto n = make_object<BufferLoadNode>(*load.get());
+      n->buffer = it->second;
+      return BufferLoad(n);
+    } else {
+      return std::move(load);
+    }
+  }
+
+  Stmt VisitStmt_(const BufferStoreNode* _op) final {
+    BufferStore store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(_op));
+    auto it = buffer_var_map_.find(store->buffer->data.get());
+    if (it != buffer_var_map_.end()) {
+      auto n = CopyOnWrite(store.get());
+      n->buffer = it->second;
+      return BufferStore(n);
+    } else {
+      return std::move(store);
+    }
+  }
+
+  PrimExpr VisitExpr_(const LoadNode* _op) final {
+    Load load = Downcast<Load>(StmtExprMutator::VisitExpr_(_op));
+    auto it = buffer_var_map_.find(load->buffer_var.get());
+    if (it != buffer_var_map_.end()) {
+      auto n = make_object<LoadNode>(*load.get());
+      n->buffer_var = it->second->data;
+      return Load(n);
+    } else {
+      return std::move(load);
+    }
+  }
+
+  Stmt VisitStmt_(const StoreNode* _op) final {
+    Store store = Downcast<Store>(StmtExprMutator::VisitStmt_(_op));
+    auto it = buffer_var_map_.find(store->buffer_var.get());
+    if (it != buffer_var_map_.end()) {
+      auto n = CopyOnWrite(store.get());
+      n->buffer_var = it->second->data;
+      return Store(n);
+    } else {
+      return std::move(store);
+    }
+  }
+
+  Stmt VisitStmt_(const BlockNode* _op) final {
+    Block block = Downcast<Block>(StmtMutator::VisitStmt_(_op));
+
+    // Define the mutation functions.
+    auto f_mutate_match_buffers = [this](const MatchBufferRegion& match_buffer) {
+      const Buffer& src_buffer = match_buffer->source->buffer;
+      auto it = buffer_var_map_.find(src_buffer->data.get());
+      if (it != buffer_var_map_.end()) {
+        return MatchBufferRegion(match_buffer->buffer,
+                                 BufferRegion(it->second, match_buffer->source->region));
+      } else {
+        return match_buffer;
+      }
+    };
+
+    auto f_mutate_read_write_region = [this](const BufferRegion& buffer_region) {
+      auto it = buffer_var_map_.find(buffer_region->buffer->data.get());
+      return it == buffer_var_map_.end() ? buffer_region
+                                         : BufferRegion(it->second, buffer_region->region);
+    };
+
+    // Step 1. Mutate `match_buffers`.
+    Array<MatchBufferRegion> match_buffers =
+        MutateArray(block->match_buffers, f_mutate_match_buffers);
+    // Step 2. Mutate the read/write region.
+    Array<BufferRegion> reads = MutateArray(block->reads, f_mutate_read_write_region);
+    Array<BufferRegion> writes = MutateArray(block->writes, f_mutate_read_write_region);
+
+    reads = UnionAccessRegion(reads);
+    writes = UnionAccessRegion(writes);
+
+    if (reads.same_as(block->reads) &&    //
+        writes.same_as(block->writes) &&  //
+        match_buffers.same_as(block->match_buffers)) {
+      return std::move(block);
+    } else {
+      auto n = CopyOnWrite(block.get());
+      n->reads = std::move(reads);
+      n->writes = std::move(writes);
+      n->match_buffers = std::move(match_buffers);
+      return Block(n);
+    }
+  }
+
+ private:
+  /*! \brief Mapping from src buffer.data to tgt buffer. */
+  std::unordered_map<const tir::VarNode*, tir::Buffer> buffer_var_map_;
+
+  static Array<tir::BufferRegion> UnionAccessRegion(const Array<BufferRegion>& regions) {
+    // For now we only allow Buffer access the same elements.
+    // e.g. `[A[vi, vj], A[vi, vj]]` is a legal pattern but need to union to `A[vi, vj]`
+    // However, `A[vi, vj], A[vi, vj + 1]` is not allow for now.
+    Array<BufferRegion> ret;
+    std::unordered_map<const BufferNode*, Region> buffer_region_set;
+
+    for (const BufferRegion& region : regions) {
+      auto it = buffer_region_set.find(region->buffer.get());
+      if (it == buffer_region_set.end()) {
+        ret.push_back(region);
+        buffer_region_set[region->buffer.get()] = region->region;
+      } else {
+        ICHECK(tvm::StructuralEqual()(region->region, it->second));
+      }
+    }
+
+    if (ret.size() == regions.size()) {
+      return regions;
+    } else {
+      return ret;
+    }
+  }
+};
+
+/*! \brief A mutator which detect block name duplication and deduplicate the names. */
+class BlockNameDeduplicator : public tir::StmtMutator {
+ private:
+  Stmt VisitStmt_(const BlockNode* op) final {
+    Block block = Downcast<Block>(tir::StmtMutator::VisitStmt_(op));
+
+    String name = GetUniqueName(block->name_hint);
+
+    if (name == block->name_hint) {
+      return std::move(block);
+    } else {
+      ObjectPtr<BlockNode> n = CopyOnWrite(block.get());
+      n->name_hint = std::move(name);
+      return Stmt(n);
+    }
+  }
+
+  String GetUniqueName(const String& prefix) {
+    String unique_prefix = prefix;
+    auto it = name_count_.find(prefix);
+    while (name_count_.count(unique_prefix)) {
+      unique_prefix = prefix + "_" + std::to_string(++it->second);
+    }
+    name_count_[unique_prefix] = 0;
+    return unique_prefix;
+  }
+
+  /*! \brief The count map to make block name unique. */
+  std::unordered_map<String, int> name_count_;
+};
+
+}  // namespace tir
+
+namespace relax {
+
+class FusedTIRConstructor : public ExprVisitor {
+ public:
+  /*!
+   * \brief Construct a fused TIR PrimFunc from a relax sub-function
+   * \param mod The IRModule
+   * \param gv The global var of relax subfunction to be fused into one PrimFunc
+   * \return The fused TIR PrimFunc
+   */
+  static tir::PrimFunc GetFusedTIR(const IRModule& mod, const GlobalVar& gv) {
+    FusedTIRConstructor visitor(mod, gv->name_hint);
+    BaseFunc f = mod->Lookup(gv);
+    CHECK(f->IsInstance<relax::FunctionNode>())
+        << "Expected relax functions, but got: " << f->GetTypeKey();
+    CHECK(f->HasNonzeroAttr(relax::attr::kPrimitive))
+        << "Expected a function with attr `kPrimitive`";
+    visitor(Downcast<relax::Function>(f));
+    return visitor.fused_tir_;
+  }
+
+ private:
+  explicit FusedTIRConstructor(const IRModule& mod, const String& func_name)
+      : mod_(mod), func_name_(func_name) {}
+
+  void VisitExpr_(const FunctionNode* func) final {
+    Array<Var> input_output_vars;
+    Array<String> input_output_names;
+
+    // Step 1. Collect function input params
+    for (const Var& relax_param : func->params) {
+      input_output_vars.push_back(relax_param);
+      input_output_names.push_back(relax_param->name_hint());
+    }
+
+    // Step 2. Collect function output binding vars
+    ICHECK(func->body->IsInstance<SeqExprNode>());
+    Expr body = Downcast<SeqExpr>(func->body)->body;
+    if (const auto* var = body.as<VarNode>()) {
+      output_vars_.insert(var);
+      input_output_vars.push_back(GetRef<Var>(var));
+      input_output_names.push_back("output");
+    } else if (const auto* tuple = body.as<TupleNode>()) {
+      for (size_t i = 0; i < tuple->fields.size(); ++i) {
+        const auto* var = tuple->fields[i].as<VarNode>();
+        ICHECK_NOTNULL(var);
+        output_vars_.insert(var);
+        input_output_vars.push_back(GetRef<Var>(var));
+        input_output_names.push_back("output_" + std::to_string(i));
+      }
+    } else {
+      LOG(FATAL) << "Var or Tuple of Var are expected to be the function output, but got: " << body;
+    }
+
+    // Step 3. Create buffers for func inputs and outputs.
+    ICHECK_EQ(input_output_vars.size(), input_output_names.size());
+    for (size_t i = 0; i < input_output_vars.size(); ++i) {
+      const Var& var = input_output_vars[i];
+      const String& name = input_output_names[i];
+      auto ret = CreateParamsAndBuffers(var->checked_type(),  //
+                                        var->shape(),         //
+                                        name);
+      const Array<tir::Var>& params = ret.first;
+      const Array<tir::Buffer>& buffers = ret.second;
+      ICHECK_EQ(params.size(), buffers.size());
+      for (size_t i = 0; i < params.size(); ++i) {
+        func_info_.buffer_map.Set(params[i], buffers[i]);
+        func_info_.params.push_back(params[i]);
+      }
+      func_info_.var2buffers.Set(var, buffers);
+    }
+
+    // Step 4. Visit Function body.
+    ExprVisitor::VisitExpr_(func);
+
+    // Step 5. Create PrimFunc
+    fused_tir_ = ConstructFunc();
+  }
+
+  void VisitBinding_(const VarBindingNode* binding) final {
+    static const Op& call_tir_op_ = Op::Get("relax.call_tir");
+    this->VisitExpr(binding->value);
+    if (const auto* call = binding->value.as<CallNode>()) {
+      if (call->op.same_as(call_tir_op_)) {
+        VisitCallTIR(call, binding->var);
+      } else {
+        LOG(FATAL) << "Only call_tir is supported in primitive function, but got: "
+                   << binding->value;
+      }
+    } else if (const auto* tuple_get_item = binding->value.as<TupleGetItemNode>()) {
+      VisitTupleGetItem(tuple_get_item, binding->var);
+    } else {
+      LOG(FATAL) << "Unsupported binding value: " << binding->value;
+    }
+  }
+
+  void VisitBinding_(const MatchShapeNode* match_shape) final {
+    // TODO(relax-team): support match shape in primitive functions;
+    LOG(FATAL) << "MatchShape is unsupported in primitive functions";
+  }
+
+  /********** Binding Value Handler **********/
+
+  void VisitCallTIR(const CallNode* call, const Var& binding_var) {
+    static const Op& call_tir_op_ = Op::Get("relax.call_tir");
+    ICHECK(call->op == call_tir_op_);
+    // Step 1. Get Global var and PrimFunc
+    GlobalVar gv = Downcast<GlobalVar>(call->args[0]);
+    Optional<tir::PrimFunc> prim_func_ = GetPrimFunc(gv);
+    ICHECK(prim_func_.defined()) << "Cannot find the prim_func of the call_tir in the module: "
+                                 << gv;
+    // Step 2. Renew all vars/buffer definitions and blocks to avoid duplication
+    tir::PrimFunc prim_func = tir::RenewDefs(prim_func_.value());
+
+    // Step 3. Check functions are all schedulable funcs. i.e. the body of func is root block
+    // TODO(Siyuan): support un-schedulable functions.
+    ICHECK(prim_func->body->IsInstance<tir::BlockRealizeNode>())
+        << "Only schedulable functions (whose body is the root block) can be fused";
+    const tir::BlockRealize& root_realize = Downcast<tir::BlockRealize>(prim_func->body);
+    const tir::Block& root_block = root_realize->block;
+
+    // Step 4. Add all the original alloc_buffers and body to the fused function.
+    func_info_.alloc_buffers.insert(func_info_.alloc_buffers.end(),
+                                    root_block->alloc_buffers.begin(),
+                                    root_block->alloc_buffers.end());
+    func_info_.bodies.push_back(root_block->body);
+
+    // Step 5. Map input arguments to buffer
+    MapInputBuffer(prim_func, call->args[1]);
+    size_t num_output_buffers = GetCallTIROutputSize(call);
+    if (!output_vars_.count(binding_var.get())) {
+      // Allocate buffer if it is an intermediate var in the fused function,
+      AllocateIntermediateBuffer(binding_var, prim_func, num_output_buffers);
+    } else {
+      // Map old output buffer to the new one in the buffer map
+      MapOutputBuffer(binding_var, prim_func, num_output_buffers);
+    }
+    // Update fused func name
+    func_info_.global_name += "_" + gv->name_hint;
+  }
+
+  void VisitTupleGetItem(const TupleGetItemNode* tuple_get_item, const Var& binding_var) {
+    ICHECK(binding_var->IsInstance<DataflowVarNode>())
+        << "Currently TupleGetItem outputs are not allowed";
+    const Var& tuple_var = Downcast<Var>(tuple_get_item->tuple);
+    auto it = func_info_.var2buffers.find(tuple_var);
+    if (it != func_info_.var2buffers.end()) {
+      int begin_buf_idx = 0;
+      int end_buf_idx = 0;
+      const TupleType& tuple_type = Downcast<TupleType>(tuple_get_item->tuple->checked_type());
+      for (int i = 0; i < tuple_get_item->index; ++i) {
+        begin_buf_idx += GetTensorNum(tuple_type->fields[i]);
+      }
+      end_buf_idx = begin_buf_idx + GetTensorNum(tuple_type->fields[tuple_get_item->index]);
+      func_info_.var2buffers.Set(
+          binding_var, {(*it).second.begin() + begin_buf_idx, (*it).second.begin() + end_buf_idx});
+    }
+  }
+
+  /********** Helper Functions **********/
+
+  /*!
+   * \brief Pattern match op to a TIR function and look it up.
+   * \return The TIR function, or nullopt if patter match fails.
+   */
+  Optional<tir::PrimFunc> GetPrimFunc(const GlobalVar& global_var) {
+    // NOTE: as check works for nullptr(returns null)
+    Optional<BaseFunc> base_func = mod_->functions.Get(global_var);
+    if (auto* pfunc = base_func.as<tir::PrimFuncNode>()) {
+      return GetRef<tir::PrimFunc>(pfunc);
+    } else {
+      return NullOpt;
+    }
+  }
+
+  /*!
+   * \brief Get the number of outputs for a call_tir node.
+   * \return The number of outputs.
+   */
+  static size_t GetCallTIROutputSize(const CallNode* call) {
+    static const Op& call_tir_op_ = Op::Get("relax.call_tir");
+    ICHECK(call->op.same_as(call_tir_op_));
+    const Expr& output_shapes = call->args[2];
+    if (const auto* tuple_output_shapes = output_shapes.as<TupleNode>()) {
+      return tuple_output_shapes->fields.size();
+    } else {
+      return 1;
+    }
+  }
+
+  /*! \brief Map old TIR func param buffer to new buffer, and then update `buffer_subst_map` */
+  void MapArgsToBuffer(const Array<Expr> args, const Array<tir::Buffer>& buffers) {
+    size_t buffer_idx = 0;
+    for (const Expr& arg : args) {
+      if (const auto* v = arg.as<VarNode>()) {
+        auto it = func_info_.var2buffers.find(GetRef<Var>(v));
+        // Substitute the buffer with the already allocated one if it is an intermediate var
+        if (it != func_info_.var2buffers.end()) {
+          for (const tir::Buffer& target_buffer : (*it).second) {
+            ICHECK_LT(buffer_idx, buffers.size());
+            const tir::Buffer& buffer = buffers[buffer_idx];
+            // TODO(relax-team): Add support for symbolic shape fusion
+            for (const PrimExpr& shape_expr : buffer->shape) {
+              ICHECK(shape_expr.as<IntImmNode>());
+            }
+            func_info_.buffer_subst_map.Set(buffer, target_buffer);
+            buffer_idx++;
+          }
+        }
+      }
+    }
+    // Make sure every buffers are maped.
+    ICHECK_EQ(buffer_idx, buffers.size());
+  }
+
+  /*!
+   * \brief Update buffer mapping `func_info_.buffer_subst_map` for input args
+   * \param func The old TIR PrimFunc
+   * \param output_size The number of output params. All output params are at the end of param list.
+   */
+  void MapInputBuffer(const tir::PrimFunc& func, const relax::Expr& args) {
+    Array<Expr> arg_list;
+    Array<tir::Buffer> buffer_list;
+    if (const auto* arg_tuple = args.as<TupleNode>()) {
+      arg_list = arg_tuple->fields;
+    } else {
+      arg_list = {args};
+    }
+
+    ICHECK_GE(func->params.size(), arg_list.size());
+    for (size_t i = 0; i < arg_list.size(); ++i) {
+      const tir::Var& param = func->params[i];
+      const tir::Buffer& buffer = func->buffer_map.at(param);
+      buffer_list.push_back(buffer);
+    }
+
+    MapArgsToBuffer(arg_list, buffer_list);
+  }
+
+  /*!
+   * \brief Update buffer mapping `func_info_.buffer_subst_map` if the PrimFunc output(s) are also
+   * the output(s) of fused function.
+   * \param func The old TIR PrimFunc
+   * \param output_size The number of output params. All output params are at the end of param list.
+   */
+  void MapOutputBuffer(const relax::Var& binding_var, const tir::PrimFunc& func,
+                       size_t output_size) {
+    Array<tir::Buffer> buffer_list;
+    size_t n = func->params.size();
+    ICHECK_GE(n, output_size);
+    for (size_t i = 0; i < output_size; ++i) {
+      const tir::Var& param = func->params[n - output_size + i];
+      const tir::Buffer& buffer = func->buffer_map.at(param);
+      buffer_list.push_back(buffer);
+    }
+    MapArgsToBuffer({binding_var}, buffer_list);
+  }
+
+  /*!
+   * \brief Allocate buffer(s) and update `func_info.var2buffers` if the PrimFunc output(s) are
+   * intermediate results.
+   * \param binding_var The relax binding var
+   * \param func The old TIR PrimFunc
+   * \param output_size The number of output params. All output params are at the end of param list.
+   */
+  void AllocateIntermediateBuffer(const relax::Var& binding_var, const tir::PrimFunc& func,
+                                  size_t output_size) {
+    size_t n = func->params.size();
+    ICHECK_GE(n, output_size);
+    // Allocate intermediate buffer
+    Array<tir::Buffer> alloc_buffers;
+    for (size_t i = 0; i < output_size; ++i) {
+      const tir::Var& param = func->params[n - output_size + i];
+      const tir::Buffer& buffer = func->buffer_map.at(param);
+      func_info_.alloc_buffers.push_back(buffer);
+      alloc_buffers.push_back(buffer);
+    }
+    // Update var2buffers
+    func_info_.var2buffers.Set(binding_var, alloc_buffers);
+  }
+
+  /*!
+   * \brief Create an TIR func params and buffers with specified relax type and shape
+   * \param type The specified relax type, which can be DynTensorType or Tuple
+   * \param shape The specified shape, which can be ShapeExpr or Tuple
+   * \param name_hint The name hint for params and buffers
+   * \param index The index used for unique name_hint if type is Tuple.
+   *              -1 means no need to add postfix since the relax param is not a Tuple.
+   * \return The created TIR func params and buffers
+   */
+  static std::pair<Array<tir::Var>, Array<tir::Buffer>> CreateParamsAndBuffers(
+      Type type, relax::Expr shape, const String& name_hint, int index = -1) {
+    Array<tir::Var> params;
+    Array<tir::Buffer> buffers;
+    if (const auto* shape_expr = shape.as<ShapeExprNode>()) {
+      // Case 1. the relax param is a DynTensor, we directly create a tir var and buffer
+      ICHECK(type->IsInstance<DynTensorTypeNode>());
+      String name = index == -1 ? name_hint : name_hint + "_" + std::to_string(index);
+      DataType dtype = Downcast<DynTensorType>(type)->dtype;
+      tir::Buffer buffer = tir::decl_buffer(shape_expr->values, dtype, name);
+      // Differentiate buffer name and param name by adding prefix `v_` to param
+      // Every symbol should be unique in TVMScript, and Buffer is used more than param
+      // So we decide to make sure buffer names have better readability.
+      tir::Var param = tir::Var("p_" + name, PrimType(DataType::Handle()));
+      params.push_back(std::move(param));
+      buffers.push_back(std::move(buffer));
+    } else if (const auto* shape_tuple = shape.as<TupleNode>()) {
+      // Case 2. the relax param is a Tuple, we recursively visit each field until it's a DynTensor
+      ICHECK(type->IsInstance<TupleTypeNode>());
+      TupleType tuple_type = Downcast<TupleType>(type);
+      // Enable postfix
+      if (index == -1) index = 0;
+      for (size_t i = 0; i < shape_tuple->fields.size(); ++i) {
+        auto ret =
+            CreateParamsAndBuffers(tuple_type->fields[i], shape_tuple->fields[i], name_hint, index);
+        const Array<tir::Var>& ret_params = ret.first;
+        const Array<tir::Buffer>& ret_buffers = ret.second;
+        ICHECK_EQ(ret_params.size(), ret_buffers.size());
+        // Adding tuple field results to the end of params and buffers.
+        params.insert(params.end(), ret_params.begin(), ret_params.end());
+        buffers.insert(buffers.end(), ret_buffers.begin(), ret_buffers.end());
+        index += ret_params.size();
+      }
+    } else {
+      ICHECK(false) << "shapes are expected to be ShapeExprNode or TupleNode";
+    }
+    return std::make_pair(params, buffers);
+  }
+
+  /*!
+   * \brief Construct fused TIR func with collected FuseFuncInfo
+   * \return The fused TIR
+   */
+  tir::PrimFunc ConstructFunc() {
+    Map<String, ObjectRef> attr_map;
+    attr_map.Set("tir.noalias", tir::const_true());
+    ICHECK(func_info_.global_name != "fused");
+    // TODO(relax-team): remove global_symbol later.
+    attr_map.Set("global_symbol", String(func_info_.global_name));
+    tir::Stmt body = tir::BlockNameDeduplicator()(tir::SeqStmt::Flatten(func_info_.bodies));
+    body = tir::BufferSubstituter::Substitute(func_info_.buffer_subst_map, body);
+    body = tir::Block({}, {}, {}, "root", std::move(body), NullOpt, func_info_.alloc_buffers);
+    body = tir::BlockRealize({}, Bool(true), Downcast<tir::Block>(body));
+    tir::PrimFunc func(func_info_.params, body, VoidType(), func_info_.buffer_map,
+                       Optional<Map<tir::Var, tir::Buffer>>(), DictAttrs(attr_map));
+    return func;
+  }
+
+  /*! \brief Get DynTensor numbers from recursive Tuples. */
+  static size_t GetTensorNum(const Type& type) {
+    if (type.as<DynTensorTypeNode>()) {
+      return 1;
+    } else if (const auto* tuple_type = type.as<TupleTypeNode>()) {
+      size_t num = 0;
+      for (const Type& type : tuple_type->fields) {
+        num += GetTensorNum(type);
+      }
+      return num;
+    } else {
+      LOG(FATAL) << "DynTensorType and TupleType are expect, but got: " << type;
+      return 0;
+    }
+  }
+
+  /********** Function Info **********/
+
+  /*! \brief auxiliary information for FuseTIR */
+  struct FuseFuncInfo {
+    /*! \brief The arguments for calling prim_func */
+    Array<Expr> arguments;
+    /*!
+     * \brief The map from each dataflow var (intermediate var) to the corresponding buffers
+     * allocated in the fused func
+     */
+    Map<Var, Array<tir::Buffer>> var2buffers;
+    /*! \brief The buffers to allocate in the fused func*/
+    Array<tir::Buffer> alloc_buffers;
+    /*! \brief The bodies of the original funcs, which is also the body of the fused func. */
+    Array<tir::Stmt> bodies;
+    /*! \brief The params of the fused function*/
+    Array<tir::Var> params;
+    /*!
+     * \brief The map from buffer in original functions to corresponding buffer in the fused
+     * function
+     */
+    Map<tir::Buffer, tir::Buffer> buffer_subst_map;
+    /*! \brief The `buffer_map` in the fused function*/
+    Map<tir::Var, tir::Buffer> buffer_map;
+    /*! \brief The name of the fused function */
+    std::string global_name = "fused";
+  };
+
+  /*! \brief The IRModule */
+  const IRModule& mod_;
+  /*! \brief The name hint for the input func. */
+  String func_name_;
+  /*! \brief The helper info to fuse TIR prim_func */
+  FuseFuncInfo func_info_;
+  /*! \brief The tir function after fusion*/
+  tir::PrimFunc fused_tir_;
+  /*! \brief Output vars */
+  std::unordered_set<const VarNode*> output_vars_;
+};
+
+/*!
+ * \brief The helper class to fuse TIR functions and build a new module which calls the fused TIR.
+ */
+class TIRFuseMutator : public ExprMutator {
+ public:
+  static IRModule Transform(const IRModule& mod) {
+    // Since TIRFuseMutator will delete bunch of PrimFunc, we create an empty block builder.
+    TIRFuseMutator mutator(mod);
+    // Step 1. Fuse all primitive relax functions, store the result in `fused_tir_funcs_`
+    for (const auto& kv : mod->functions) {
+      const GlobalVar& gv = kv.first;
+      const BaseFunc& func = kv.second;
+      // Only fuse primitive relax functions
+      if (func->IsInstance<relax::FunctionNode>() && func->HasNonzeroAttr(attr::kPrimitive)) {
+        tir::PrimFunc fused_tir = FusedTIRConstructor::GetFusedTIR(mod, gv);
+        mutator.fused_tir_funcs_.Set(gv, fused_tir);
+      }
+    }
+
+    // Step 2. Update all non-primitive relax functions and add it, with the dependent function,
+    // into the new IRModule
+    for (const auto& kv : mod->functions) {
+      const GlobalVar& gv = kv.first;
+      const BaseFunc& func = kv.second;
+      if (func->IsInstance<relax::FunctionNode>() && !func->HasNonzeroAttr(attr::kPrimitive)) {
+        relax::Function update_func = Downcast<Function>(mutator.VisitExpr(func));
+        mutator.builder_->AddFunction(update_func, gv->name_hint);
+      }
+    }
+    return mutator.builder_->GetContextIRModule();
+  }
+
+ private:
+  explicit TIRFuseMutator(const IRModule& mod) : mod_(mod) {}
+
+  Expr VisitExpr_(const CallNode* op) final {
+    static const Op& call_tir_op_ = Op::Get("relax.call_tir");
+    Call call = Downcast<Call>(ExprMutator::VisitExpr_(op));
+    if (call->op->IsInstance<GlobalVarNode>()) {
+      // Case 1. It is a relax cross function call
+      GlobalVar old_gv = Downcast<GlobalVar>(call->op);
+      auto it = fused_tir_funcs_.find(old_gv);
+      if (it != fused_tir_funcs_.end()) {
+        const tir::PrimFunc& fused_tir = (*it).second;
+        // Case 1.1. It calls a primitive relax function, update the call into a call_tir
+        GlobalVar fused_tir_gv = this->builder_->AddFunction(fused_tir, old_gv->name_hint);
+        // Step a. Flatten all args since call_tir does not support Tuple value.
+        Array<Expr> arg_list;
+        for (const Expr& arg : call->args) {
+          Array<Expr> flattened = FlattenArg(arg);
+          arg_list.insert(arg_list.end(), flattened.begin(), flattened.end());
+        }
+        // Step b. Detect call_tir type args
+        Array<Type> call_type_args;
+        if (const auto* type = call->checked_type().as<TupleTypeNode>()) {
+          call_type_args = type->fields;
+        } else {
+          call_type_args = {call->checked_type()};
+        }
+        Array<Expr> call_args = {fused_tir_gv, Tuple(arg_list), call->shape()};
+        return Call(call_tir_op_, call_args, call->attrs, call_type_args);
+      } else {
+        // Case 1.2. The callee function is not primitive, nothing to do.
+        return call;
+      }
+    } else if (call->op == call_tir_op_) {
+      // Case 2. It is a call_tir, re-emit the PrimFunc.
+      GlobalVar gv = Downcast<GlobalVar>(call->args[0]);
+      tir::PrimFunc func = Downcast<tir::PrimFunc>(mod_->Lookup(gv));
+      GlobalVar new_gv = this->builder_->AddFunction(func, gv->name_hint);
+      return Call(call->op, {new_gv, call->args[1], call->args[2]}, call->attrs, call->type_args,
+                  call->span);
+    } else {
+      // Case 3. CallNode in other types. Leave it as it is.
+      return call;
+    }
+  }
+
+  /********** Helper Functions **********/
+
+  /*! \brief Flatten the call args if it's Tuple by emitting `TupleGetItem`. */
+  Array<Expr> FlattenArg(const Expr& arg) {
+    if (const auto* tuple_shape = arg->shape().as<TupleNode>()) {
+      Array<Expr> arg_list;
+      for (size_t i = 0; i < tuple_shape->fields.size(); ++i) {
+        Expr new_arg = builder_->Emit(TupleGetItem(arg, i));
+        Array<Expr> flattened = FlattenArg(new_arg);
+        arg_list.insert(arg_list.end(), flattened.begin(), flattened.end());
+      }
+      return arg_list;
+    } else {
+      return {arg};
+    }
+  }
+
+ private:
+  /*! \brief The IRModule */
+  const IRModule& mod_;
+  /*! \brief The map from global var of primitive relax function to generated prim func. */
+  Map<GlobalVar, tir::PrimFunc> fused_tir_funcs_;
+};
+
+IRModule FuseTIR(IRModule mod) {
+  mod = TIRFuseMutator::Transform(mod);
+  return mod;
+}
+
+namespace transform {
+
+Pass FuseTIR() {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =  //
+      [=](IRModule m, PassContext pc) { return relax::FuseTIR(m); };
+  return CreateModulePass(/*pass_function=*/pass_func,  //
+                          /*opt_level=*/0,              //
+                          /*pass_name=*/"FuseTIR",      //
+                          /*required=*/{});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.FuseTIR").set_body_typed(FuseTIR);
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -1,0 +1,438 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+import sys
+import tvm
+from tvm import topi
+from tvm import relax
+
+
+def _check(mod_actual, mod_expected):
+    mod_actual = relax.transform.FuseTIR()(mod_actual)
+    tvm.ir.assert_structural_equal(mod_actual, mod_expected)
+
+
+def test_simple():
+    def before():
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        p0 = relax.Var("p0", (), relax.DynTensorType(0, "float32"))
+
+        with bb.function("fused_add_exp_squeeze", [x, p0], attrs={"Primitive": True}):
+            with bb.dataflow():
+                lv0 = bb.emit_te(topi.add, x, p0)
+                lv1 = bb.emit_te(topi.exp, lv0)
+                gv = bb.emit_output(bb.call_te(topi.squeeze, lv1))
+            bb.emit_func_output(gv)
+        fused_add_exp_squeeze = bb.get().get_global_var("fused_add_exp_squeeze")
+
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("main", [x, p0]):
+            with bb.dataflow():
+                gv = bb.emit_output(relax.Call(fused_add_exp_squeeze, [x, p0]))
+            bb.emit_func_output(gv)
+
+        return bb.get()
+
+    def expected():
+        def fused_add_exp_squeeze(x, p0):
+            add = topi.add(x, p0)
+            exp = topi.exp(add)
+            squeeze = topi.squeeze(exp)
+            return squeeze
+
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        p0 = relax.Var("p0", (), relax.DynTensorType(0, "float32"))
+        with bb.function("main", [x, p0]):
+            with bb.dataflow():
+                gv = bb.emit_output(bb.call_te(fused_add_exp_squeeze, x, p0))
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    _check(before(), expected())
+
+
+def test_conv2d_fuse():
+    def before(dtype):
+        bb = relax.BlockBuilder()
+        tensor_type = relax.DynTensorType(4, dtype)
+
+        # Grouped function 1
+        x = relax.Var("x", (1, 16, 64, 64), tensor_type)
+        w = relax.Var("w", (16, 16, 3, 3), tensor_type)
+        p0 = relax.Var("p0", (), relax.DynTensorType(0, dtype))
+        with bb.function("fused_conv2d_add1_add2", [x, w, p0], attrs={"Primitive": True}):
+            with bb.dataflow():
+                lv0 = bb.emit_te(
+                    topi.nn.conv2d,
+                    x,
+                    w,
+                    strides=1,
+                    padding=1,
+                    dilation=1,
+                    primfunc_name_hint="conv2d",
+                )
+                lv1 = bb.emit_te(topi.add, p0, lv0, primfunc_name_hint="add1")
+                gv = bb.emit_output(bb.call_te(topi.add, lv0, lv1, primfunc_name_hint="add2"))
+            bb.emit_func_output(gv)
+
+        # Grouped function 2
+        x = relax.Var("x", (1, 16, 64, 64), tensor_type)
+        w = relax.Var("w", (16, 16, 1, 1), tensor_type)
+        y = relax.Var("y", (1, 16, 64, 64), tensor_type)
+        with bb.function("fused_conv2d1_add2", [x, w, y], attrs={"Primitive": True}):
+            with bb.dataflow():
+                lv0 = bb.emit_te(
+                    topi.nn.conv2d,
+                    x,
+                    w,
+                    strides=1,
+                    padding=0,
+                    dilation=1,
+                    primfunc_name_hint="conv2d1",
+                )
+                gv = bb.emit_output(bb.call_te(topi.add, lv0, y, primfunc_name_hint="add2"))
+            bb.emit_func_output(gv)
+
+        # Get the global variables of the grouped functions
+        mod = bb.get()
+        fused_conv2d_add1_add2 = mod.get_global_var("fused_conv2d_add1_add2")
+        fused_conv2d1_add2 = mod.get_global_var("fused_conv2d1_add2")
+
+        # Main function
+        x = relax.Var("x", (1, 16, 64, 64), tensor_type)
+        w1 = relax.Var("w1", (16, 16, 3, 3), tensor_type)
+        w2 = relax.Var("w2", (16, 16, 1, 1), tensor_type)
+        w3 = relax.Var("w3", (16, 16, 3, 3), tensor_type)
+        with bb.function("main", [x, w1, w2, w3]):
+            with bb.dataflow():
+                lv0 = bb.emit_te(topi.add, x, relax.const(1, dtype))
+                lv1 = bb.emit(relax.Call(fused_conv2d_add1_add2, [lv0, w1, relax.const(1, dtype)]))
+                lv2 = bb.emit_te(
+                    topi.nn.conv2d,
+                    lv1,
+                    w3,
+                    strides=1,
+                    padding=1,
+                    dilation=1,
+                )
+                gv = bb.emit_output(relax.Call(fused_conv2d1_add2, [lv1, w2, lv2]))
+            bb.emit_func_output(gv)
+
+        return bb.get()
+
+    def expected(dtype):
+        def fused_conv2d_add1_add2(x, w, p):
+            conv = topi.nn.conv2d(x, w, strides=1, padding=1, dilation=1)
+            add = topi.add(p, conv)
+            return topi.add(conv, add)
+
+        def fused_conv2d1_add2(x, w, p):
+            conv = topi.nn.conv2d(x, w, strides=1, padding=0, dilation=1)
+            return topi.add(conv, p)
+
+        bb = relax.BlockBuilder()
+        tensor_type = relax.DynTensorType(4, dtype)
+
+        # Main function
+        x = relax.Var("x", (1, 16, 64, 64), tensor_type)
+        w1 = relax.Var("w1", (16, 16, 3, 3), tensor_type)
+        w2 = relax.Var("w2", (16, 16, 1, 1), tensor_type)
+        w3 = relax.Var("w3", (16, 16, 3, 3), tensor_type)
+        with bb.function("main", [x, w1, w2, w3]):
+            with bb.dataflow():
+                lv0 = bb.emit_te(topi.add, x, relax.const(1, dtype))
+                lv1 = bb.emit_te(fused_conv2d_add1_add2, lv0, w1, relax.const(1, dtype))
+                lv2 = bb.emit_te(
+                    topi.nn.conv2d,
+                    lv1,
+                    w3,
+                    strides=1,
+                    padding=1,
+                    dilation=1,
+                )
+                gv = bb.emit_output(bb.call_te(fused_conv2d1_add2, lv1, w2, lv2))
+            bb.emit_func_output(gv)
+
+        return bb.get()
+
+    _check(before("float32"), expected("float32"))
+
+
+def test_two_subfunction():
+    def before():
+        bb = relax.BlockBuilder()
+        x1 = relax.Var("x1", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("fused_exp_squeeze", [x1], attrs={"Primitive": True}):
+            with bb.dataflow():
+                lv1 = bb.emit_te(topi.exp, x1)
+                gv = bb.emit_output(bb.call_te(topi.squeeze, lv1))
+            bb.emit_func_output(gv)
+        mod = bb.get()
+
+        func_gv = mod.get_global_var("fused_exp_squeeze")
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv = bb.emit(relax.Call(func_gv, [x]))
+                lv2 = bb.emit(relax.Call(func_gv, [lv]))
+                gv = bb.emit_output(lv2)
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    def fused_exp_squeeze(x):
+        exp = topi.exp(x)
+        squeeze = topi.squeeze(exp)
+        return squeeze
+
+    def expected():
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv = bb.emit_te(fused_exp_squeeze, x)
+                lv2 = bb.emit_te(fused_exp_squeeze, lv)
+                gv = bb.emit_output(lv2)
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    _check(before(), expected())
+
+
+def test_fuse_same_primfunc():
+    def before():
+        bb = relax.BlockBuilder()
+        x1 = relax.Var("x1", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("fused_exp_exp_squeeze", [x1], attrs={"Primitive": True}):
+            with bb.dataflow():
+                lv1 = bb.emit_te(topi.exp, x1)
+                lv2 = bb.emit_te(topi.exp, lv1)
+                gv = bb.emit_output(bb.call_te(topi.squeeze, lv2))
+            bb.emit_func_output(gv)
+        mod = bb.get()
+
+        func_gv = mod.get_global_var("fused_exp_exp_squeeze")
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv = bb.emit(relax.Call(func_gv, [x]))
+                gv = bb.emit_output(lv)
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    def fused_exp_exp_squeeze(x):
+        exp = topi.exp(x)
+        exp = topi.exp(exp)
+        squeeze = topi.squeeze(exp)
+        return squeeze
+
+    def expected():
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv = bb.emit_te(fused_exp_exp_squeeze, x)
+                gv = bb.emit_output(lv)
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    _check(before(), expected())
+
+
+def test_fuse_with_tuple_as_param():
+    dyn_tensor_type = relax.DynTensorType(1, "float32")
+    tuple_type = relax.TupleType([dyn_tensor_type, dyn_tensor_type])
+    tuple_shape = relax.Tuple([relax.ShapeExpr([10]), relax.ShapeExpr([10])])
+
+    def before():
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", tuple_shape, tuple_type)
+        with bb.function("fused_exp_add", [x], attrs={"Primitive": True}):
+            with bb.dataflow():
+                lv0 = bb.emit(relax.TupleGetItem(x, 0))
+                lv1 = bb.emit(relax.TupleGetItem(x, 1))
+                lv2 = bb.emit_te(topi.exp, lv0)
+                gv = bb.emit_output(bb.call_te(topi.add, lv2, lv1))
+            bb.emit_func_output(gv)
+        mod = bb.get()
+
+        func_gv = mod.get_global_var("fused_exp_add")
+        x = relax.Var("x", tuple_shape, tuple_type)
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                gv = bb.emit_output(relax.Call(func_gv, [x]))
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    def expected():
+        def fused_exp_add(x1, x2):
+            exp = topi.exp(x1)
+            return topi.add(exp, x2)
+
+        bb = relax.BlockBuilder()
+        dyn_tensor_type = relax.DynTensorType(1, "float32")
+        tuple_type = relax.TupleType([dyn_tensor_type, dyn_tensor_type])
+        tuple_shape = relax.Tuple([relax.ShapeExpr([10]), relax.ShapeExpr([10])])
+        x = relax.Var("x", tuple_shape, tuple_type)
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv0 = bb.emit(relax.TupleGetItem(x, 0))
+                lv1 = bb.emit(relax.TupleGetItem(x, 1))
+                gv = bb.emit_output(bb.call_te(fused_exp_add, lv0, lv1))
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    _check(before(), expected())
+
+
+def test_fuse_with_nested_tuple_as_param():
+    dyn_tensor_type = relax.DynTensorType(1, "float32")
+    tuple_type = relax.TupleType(
+        [dyn_tensor_type, relax.TupleType([dyn_tensor_type, dyn_tensor_type])]
+    )
+    shape = relax.ShapeExpr([10])
+    tuple_shape = relax.Tuple([shape, relax.Tuple([shape, shape])])
+
+    def before():
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", tuple_shape, tuple_type)
+        with bb.function("fused_exp_add_add", [x], attrs={"Primitive": True}):
+            with bb.dataflow():
+                lv0 = bb.emit(relax.TupleGetItem(x, 0))
+                lv0_exp = bb.emit_te(topi.exp, lv0)
+                lv1 = bb.emit(relax.TupleGetItem(x, 1))
+                lv1_0 = bb.emit(relax.TupleGetItem(lv1, 0))
+                lv1_1 = bb.emit(relax.TupleGetItem(lv1, 1))
+                lv2 = bb.emit_te(topi.add, lv1_0, lv1_1)
+                gv = bb.emit_output(bb.call_te(topi.add, lv0_exp, lv2))
+            bb.emit_func_output(gv)
+        mod = bb.get()
+
+        func_gv = mod.get_global_var("fused_exp_add_add")
+        x = relax.Var("x", tuple_shape, tuple_type)
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                gv = bb.emit_output(relax.Call(func_gv, [x]))
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    def expected():
+        def fused_exp_add_add(x1, x2, x3):
+            exp = topi.exp(x1)
+            add = topi.add(x2, x3)
+            return topi.add(exp, add)
+
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", tuple_shape, tuple_type)
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv0 = bb.emit(relax.TupleGetItem(x, 0))
+                lv1 = bb.emit(relax.TupleGetItem(x, 1))
+                lv2 = bb.emit(relax.TupleGetItem(lv1, 0))
+                lv3 = bb.emit(relax.TupleGetItem(lv1, 1))
+                gv = bb.emit_output(bb.call_te(fused_exp_add_add, lv0, lv2, lv3))
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    _check(before(), expected())
+
+
+def test_fuse_with_call_tir_in_main():
+    def before():
+        bb = relax.BlockBuilder()
+        x1 = relax.Var("x1", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("fused_exp_squeeze", [x1], attrs={"Primitive": True}):
+            with bb.dataflow():
+                lv = bb.emit_te(topi.exp, x1)
+                gv = bb.emit_output(bb.call_te(topi.squeeze, lv))
+            bb.emit_func_output(gv)
+        mod = bb.get()
+
+        func_gv = mod.get_global_var("fused_exp_squeeze")
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv0 = bb.emit(relax.Call(func_gv, [x]))
+                lv1 = bb.emit_te(topi.add, lv0, relax.const(1, "float32"))
+                gv = bb.emit_output(lv1)
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    def expected():
+        def fused_exp_squeeze(x):
+            exp = topi.exp(x)
+            squeeze = topi.squeeze(exp)
+            return squeeze
+
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv = bb.emit_te(fused_exp_squeeze, x)
+                lv2 = bb.emit_te(topi.add, lv, relax.const(1, "float32"))
+                gv = bb.emit_output(lv2)
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    _check(before(), expected())
+
+
+def test_fuse_with_const_in_argument():
+    def before():
+        bb = relax.BlockBuilder()
+        x1 = relax.Var("x1", [10, 20], relax.DynTensorType(2, "float32"))
+        x2 = relax.Var("x2", [], relax.DynTensorType(0, "float32"))
+        with bb.function("fused_add_exp_squeeze", [x1, x2], attrs={"Primitive": True}):
+            with bb.dataflow():
+                lv0 = bb.emit_te(topi.add, x1, x2)
+                lv1 = bb.emit_te(topi.exp, lv0)
+                gv = bb.emit_output(bb.call_te(topi.squeeze, lv1))
+            bb.emit_func_output(gv)
+        mod = bb.get()
+
+        func_gv = mod.get_global_var("fused_add_exp_squeeze")
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv = bb.emit(relax.Call(func_gv, [x, relax.const(1, "float32")]))
+                gv = bb.emit_output(lv)
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    def fused_add_exp_squeeze(x, y):
+        add = topi.add(x, y)
+        exp = topi.exp(add)
+        squeeze = topi.squeeze(exp)
+        return squeeze
+
+    def expected():
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", [10, 20], relax.DynTensorType(2, "float32"))
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv = bb.emit_te(fused_add_exp_squeeze, x, relax.const(1, "float32"))
+                gv = bb.emit_output(lv)
+            bb.emit_func_output(gv)
+        return bb.get()
+
+    _check(before(), expected())
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -22,9 +22,9 @@ from tvm import topi
 from tvm import relax
 
 
-def _check(mod_actual, mod_expected):
-    mod_actual = relax.transform.FuseTIR()(mod_actual)
-    tvm.ir.assert_structural_equal(mod_actual, mod_expected)
+def _check(mod_before, mod_expected):
+    mod = relax.transform.FuseTIR()(mod_before)
+    tvm.ir.assert_structural_equal(mod, mod_expected)
 
 
 def test_simple():


### PR DESCRIPTION
In this PR we introduce the relax pass FuseTIR, following the PR https://github.com/tlc-pack/relax/pull/141

FuseTIR will find `primitive` functions and generate PrimFuncs for them. Here is a simple example:

Before:
```python
# primitive relax function before FuseTIR
@relax.function
def fused_add_exp_squeeze(x: Tensor((10, 20), "float32"), p0: Tensor((), "float32")) -> Tensor(None, "float32", ndim = 2):
    # block 0
    with relax.dataflow():
        lv = relax.call_tir(add, (x, p0), (10, 20), dtype="float32")
        lv1 = relax.call_tir(exp, (lv,), (10, 20), dtype="float32")
        gv = relax.call_tir(squeeze, (lv1,), (10, 20), dtype="float32")
        relax.output(gv)
    return gv

@relax.function
def main(x1: Tensor((10, 20), "float32"), p0: Tensor((), "float32")) -> Tensor(None, "float32", ndim = 2):
    # block 0
    with relax.dataflow():
        gv1: Tensor((10, 20), "float32") = fused_add_exp_squeeze(x1, p0)
        relax.output(gv1)
    return gv1
```
After:
```python
@tir.prim_func
def fused_add_exp_squeeze(rxplaceholder_2: tir.Buffer[(10, 20), "float32"], rxplaceholder_3: tir.Buffer[(), "float32"], T_squeeze_1: tir.Buffer[(10, 20), "float32"]) -> None:
    # function attr dict
    tir.func_attr({"global_symbol": "fused_add_exp_squeeze", "tir.noalias": True})
    # body
    # with tir.block("root")
    T_add_1 = tir.alloc_buffer([10, 20], dtype="float32")
    compute_1 = tir.alloc_buffer([10, 20], dtype="float32")
    for i0, i1 in tir.grid(10, 20):
        with tir.block("T_add"):
            ax0, ax1 = tir.axis.remap("SS", [i0, i1])
            tir.reads(rxplaceholder_2[ax0, ax1], rxplaceholder_3[()])
            tir.writes(T_add_1[ax0, ax1])
            T_add_1[ax0, ax1] = rxplaceholder_2[ax0, ax1] + rxplaceholder_3[()]
    for i0, i1 in tir.grid(10, 20):
        with tir.block("compute"):
            i0_2, i1_2 = tir.axis.remap("SS", [i0, i1])
            tir.reads(T_add_1[i0_2, i1_2])
            tir.writes(compute_1[i0_2, i1_2])
            compute_1[i0_2, i1_2] = tir.exp(T_add_1[i0_2, i1_2], dtype="float32")
    for i0_3, i1_3 in tir.grid(10, 20):
        with tir.block("T_squeeze"):
            ax0, ax1 = tir.axis.remap("SS", [i0_3, i1_3])
            tir.reads(compute_1[ax0, ax1])
            tir.writes(T_squeeze_1[ax0, ax1])
            T_squeeze_1[ax0, ax1] = compute_1[ax0, ax1]

@relax.function
def main(x: Tensor((10, 20), "float32"), p0: Tensor((), "float32")) -> Tensor(None, "float32", ndim = 2):
    # block 0
    with relax.dataflow():
        gv = relax.call_tir(fused_add_exp_squeeze, (x, p0), (10, 20), dtype="float32")
        relax.output(gv)
    return gv
```

Thanks again for the efforts from @jinhongyii and @MasterJH5574. We are working on FuseOps and FuseTIR together.

cc @tqchen @YuchenJin @yongwww @sunggg @psrivas2 
