### PR TITLE
[PASS] Remove Unused Functions in IRModule

### DIFF
--- a/include/tvm/ir/function.h
+++ b/include/tvm/ir/function.h
@@ -68,7 +68,7 @@ enum class CallingConv : int {
 /*!
  * \brief Supported linkage types.
  */
-enum class TypeLinkage : int {
+enum class LinkageType : int {
   /*!
    * \brief Internal linkage.
    */
@@ -204,7 +204,7 @@ class BaseFuncNode : public RelayExprNode {
    * \code
    *
    *  void Example(const BaseFunc& f) {
-   *    if (f->GetLinkageType() == tvm::TypeLinkage::kExternal) {
+   *    if (f->GetLinkageType() == tvm::LinkageType::kExternal) {
    *      // Do not remove a function with external linkage
    *    }
    *  }
@@ -212,11 +212,11 @@ class BaseFuncNode : public RelayExprNode {
    * \endcode
    */
 
-  TypeLinkage GetLinkageType() const {
+  LinkageType GetLinkageType() const {
     if (GetAttr<String>(attr::kGlobalSymbol))
-      return TypeLinkage::kExternal;
+      return LinkageType::kExternal;
     else
-      return TypeLinkage::kInternal;
+      return LinkageType::kInternal;
   }
 
   static constexpr const char* _type_key = "BaseFunc";

--- a/include/tvm/ir/function.h
+++ b/include/tvm/ir/function.h
@@ -66,6 +66,68 @@ enum class CallingConv : int {
 };
 
 /*!
+ * \brief Supported linkage types.
+ */
+enum class TypeLinkage : int {
+  /*!
+   * \brief Internal linkage.
+   */
+  kInternal = 0,
+  /*!
+   * \brief External linkage.
+   - Function with external linkage should have a global symbol attached to it.
+   */
+  kExternal = 1
+};
+
+/*!
+ * \brief Generic attribute names that can be attached to any function.
+ *
+ * \sa tvm::tir::attr, tvm::relay::attr
+ */
+namespace attr {
+/*!
+ * \brief Indicates the special calling convention.
+ *
+ * Type: Integer
+ *
+ * \sa tvm::CallingConv
+ */
+constexpr const char* kCallingConv = "calling_conv";
+
+/*!
+ * \brief Compilation target of the function.
+ *
+ * Type: Target
+ *
+ * \sa tvm::Target
+ */
+constexpr const char* kTarget = "target";
+
+/*!
+ * \brief Global linker symbol of the function in generated code.
+ *
+ *  This option forces the code generator to name the
+ *  function with the given.
+ *
+ *  For example, we could set a global_symbol of a function
+ *  early to make sure that we can always refer to it by
+ *  the symbol name in the generated DLL.
+ *
+ *  We should not set the attribute for local functions,
+ *  so that the compiler can freely rename them.
+ *
+ *  A unique global symbol will be automatically assigned
+ *  to each function in the module before the target code
+ *  generation phase.
+ *
+ * Type: String
+ */
+constexpr const char* kGlobalSymbol = "global_symbol";
+
+}  // namespace attr
+
+/*!
  * \brief Base node of all functions.
  *
  * We support several variants of functions throughout the stack.
@@ -131,6 +193,32 @@ class BaseFuncNode : public RelayExprNode {
    */
   bool HasNonzeroAttr(const std::string& attr_key) const { return attrs.HasNonzeroAttr(attr_key); }
 
+  /*!
+   * \brief Get the type of the linkage.
+   *
+   * Currently, we only consider external/internal linkage.
+   * This can be extended in the future when necessary.
+   *
+   * \return Linkage type.
+   *
+   * \code
+   *
+   *  void Example(const BaseFunc& f) {
+   *    if (f->GetLinkageType() == tvm::TypeLinkage::kExternal) {
+   *      // Do not remove a function with external linkage
+   *    }
+   *  }
+   *
+   * \endcode
+   */
+
+  TypeLinkage GetLinkageType() const {
+    if (GetAttr<String>(attr::kGlobalSymbol))
+      return TypeLinkage::kExternal;
+    else
+      return TypeLinkage::kInternal;
+  }
+
   static constexpr const char* _type_key = "BaseFunc";
   static constexpr const uint32_t _type_child_slots = 2;
   TVM_DECLARE_BASE_OBJECT_INFO(BaseFuncNode, RelayExprNode);
@@ -145,51 +233,5 @@ class BaseFunc : public RelayExpr {
   TVM_DEFINE_OBJECT_REF_METHODS(BaseFunc, RelayExpr, BaseFuncNode);
 };
 
-/*!
- * \brief Generic attribute names that can be attached to any function.
- *
- * \sa tvm::tir::attr, tvm::relay::attr
- */
-namespace attr {
-/*!
- * \brief Indicates the special calling convention.
- *
- * Type: Integer
- *
- * \sa tvm::CallingConv
- */
-constexpr const char* kCallingConv = "calling_conv";
-
-/*!
- * \brief Compilation target of the function.
- *
- * Type: Target
- *
- * \sa tvm::Target
- */
-constexpr const char* kTarget = "target";
-
-/*!
- * \brief Global linker symbol of the function in generated code.
- *
- *  This option forces the code generator to name the
- *  function with the given.
- *
- *  For example, we could set a global_symbol of a function
- *  early to make sure that we can always refer to it by
- *  the symbol name in the generated DLL.
- *
- *  We should not set the attribute for local functions,
- *  so that the compiler can freely rename them.
- *
- *  A unique global symbol will be automatically assigned
- *  to each function in the module before the target code
- *  generation phase.
- *
- * Type: String
- */
-constexpr const char* kGlobalSymbol = "global_symbol";
-
-}  // namespace attr
 }  // namespace tvm
 #endif  // TVM_IR_FUNCTION_H_

--- a/python/tvm/ir/function.py
+++ b/python/tvm/ir/function.py
@@ -66,3 +66,19 @@ class BaseFunc(RelayExpr):
         return _ffi_api.BaseFuncWithAttr(
             res._move(), attr_key_or_dict, tvm.runtime.convert(attr_value)
         )
+
+    def without_attr(self, attr_key: str):
+        """Create a new copy of the function with an attribute without provided key.
+
+        Parameters
+        ----------
+        attr_key : str
+            The attribute key to delete from the attrubte pairs.
+
+
+        Returns
+        -------
+        func : Function
+            A new copy of the function
+        """
+        return _ffi_api.BaseFuncWithoutAttr(self, attr_key)

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -171,7 +171,7 @@ def BindParams(func_name: str, params: Dict[str, tvm.runtime.NDArray]) -> tvm.ir
     return _ffi_api.BindParams(func_name, params)
 
 
-def RemoveUnusedFunctions(entry_functions=None):
+def RemoveUnusedFunctions(entry_functions=None) -> tvm.ir.transform.Pass:
     """Remove unused global relax functions in a IRModule.
 
     Parameters

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -171,6 +171,24 @@ def BindParams(func_name: str, params: Dict[str, tvm.runtime.NDArray]) -> tvm.ir
     return _ffi_api.BindParams(func_name, params)
 
 
+def RemoveUnusedFunctions(entry_functions=None):
+    """Remove unused global relax functions in a IRModule.
+
+    Parameters
+    ----------
+    entry_functions: list[string]
+        The set of entry functions to start from.
+
+    Returns
+    -------
+    ret : tvm.transform.Pass
+        The registered pass to remove unused functions.
+    """
+    if entry_functions is None:
+        entry_functions = ["main"]
+    return _ffi_api.RemoveUnusedFunctions(entry_functions)
+
+
 def FoldConstant() -> tvm.ir.transform.Pass:
     """Fold constant expressions.
 

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -172,7 +172,7 @@ def BindParams(func_name: str, params: Dict[str, tvm.runtime.NDArray]) -> tvm.ir
 
 
 def RemoveUnusedFunctions(entry_functions=None) -> tvm.ir.transform.Pass:
-    """Remove unused global relax functions in a IRModule.
+    """Remove unused relax/prim functions without external linkage in a IRModule.
 
     Parameters
     ----------

--- a/src/ir/function.cc
+++ b/src/ir/function.cc
@@ -52,4 +52,18 @@ TVM_REGISTER_GLOBAL("ir.BaseFuncWithAttr")
       }
     });
 
+TVM_REGISTER_GLOBAL("ir.BaseFuncWithoutAttr")
+    .set_body_typed([](BaseFunc func, String key) -> BaseFunc {
+      if (func->IsInstance<tir::PrimFuncNode>()) {
+        return WithoutAttr(Downcast<tir::PrimFunc>(std::move(func)), key);
+      } else if (func->IsInstance<relay::FunctionNode>()) {
+        return WithoutAttr(Downcast<relay::Function>(std::move(func)), key);
+      } else if (func->IsInstance<relax::FunctionNode>()) {
+        return WithoutAttr(Downcast<relax::Function>(std::move(func)), key);
+      } else {
+        LOG(FATAL) << "Do not support function type " << func->GetTypeKey();
+        return func;
+      }
+    });
+
 }  // namespace tvm

--- a/src/relax/transform/removed_unused_funcs.cc
+++ b/src/relax/transform/removed_unused_funcs.cc
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ *
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/relax/backend/remove_unused_funcs.cc
+ * \brief Remove unused global relax functions in a IRModule.
+ */
+
+#include <tvm/relax/expr_functor.h>
+
+#include <iostream>
+#include <unordered_set>
+#include <vector>
+
+//#include "../../op/call/call.h"
+
+namespace tvm {
+namespace relax {
+
+/**
+ * \brief Detects all the functions that can be possibly called by entry function.
+ */
+struct CallTracer : ExprVisitor {
+  IRModule module_;
+
+  // Record the names of all encountered functions
+  std::unordered_set<std::string> called_funcs_;
+
+  // Record the expressions that are being visited
+  std::unordered_set<Expr, ObjectPtrHash, ObjectPtrEqual> visiting_;
+
+  explicit CallTracer(const IRModule& module) : module_{module}, called_funcs_{}, visiting_{} {}
+
+  void VisitExpr_(const GlobalVarNode* op) final {
+    called_funcs_.insert(op->name_hint);
+    auto func = module_->Lookup(op->name_hint);
+    if (const auto* function_node = func.as<FunctionNode>()) {
+      VisitExpr(GetRef<Function>(function_node));
+    }
+    // else: Don't visit PrimFuncs -- we don't need to collect any tir.Calls therein.
+  }
+
+  void VisitExpr_(const CallNode* call_node) final {
+    // TODO(sunggg): Check if shape functions need special handling.
+    ExprVisitor::VisitExpr_(call_node);
+  }
+
+  void VisitExpr_(const FunctionNode* func_node) final {
+    auto func = GetRef<Function>(func_node);
+    if (visiting_.find(func) == visiting_.end()) {
+      visiting_.insert(func);
+      for (auto param : func_node->params) {
+        ExprVisitor::VisitExpr(param);
+      }
+      ExprVisitor::VisitExpr(func_node->body);
+    }
+  }
+
+  std::unordered_set<std::string> Trace(const std::string& entry) {
+    called_funcs_.insert(entry);
+    auto main_func = module_->Lookup(entry);
+    VisitExpr(main_func);
+    return called_funcs_;
+  }
+};
+
+/*!
+ * \brief Remove functions that are not used.
+ *
+ * \param module IRModule.
+ * \param entry_funcs The set of functions that can be entry function.
+ *
+ * \return The module with dead functions removed.
+ */
+IRModule RemoveUnusedFunctions(const IRModule& module, Array<runtime::String> entry_funcs) {
+  std::unordered_set<std::string> called_funcs{};
+  for (auto entry : entry_funcs) {
+    auto funcs = CallTracer(module).Trace(entry);
+    called_funcs.insert(funcs.cbegin(), funcs.cend());
+  }
+  auto existing_functions = module->functions;
+  for (auto f : existing_functions) {
+    auto it = called_funcs.find(f.first->name_hint);
+    if (it == called_funcs.end()) {
+      module->Remove(f.first);
+    }
+  }
+  return module;
+}
+
+}  // namespace relax
+
+namespace transform {
+
+Pass RemoveUnusedFunctions(Array<runtime::String> entry_functions) {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =
+      [=](IRModule m, PassContext pc) { return relax::RemoveUnusedFunctions(m, entry_functions); };
+  return CreateModulePass(pass_func, 0, "RemoveUnusedFunctions", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.RemoveUnusedFunctions").set_body_typed(RemoveUnusedFunctions);
+
+}  // namespace transform
+}  // namespace tvm

--- a/tests/python/relax/test_transform_remove_unused_funcs.py
+++ b/tests/python/relax/test_transform_remove_unused_funcs.py
@@ -1,0 +1,185 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+import pytest
+import tvm
+import tvm.testing
+from tvm import relax
+import tvm.script
+from tvm.script import tir as T, relax as R
+
+
+def check_if_func_exists(mod, func_name):
+    gvs = [str(gv) for gv in mod.get_global_vars()]
+    return ("@" + func_name) in gvs
+
+
+def test_unused_relax_func():
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
+            T.func_attr({"global_symbol": "tir_matmul"})
+            A = T.match_buffer(x, (16, 16))
+            B = T.match_buffer(y, (16, 16))
+            C = T.match_buffer(z, (16, 16))
+            for i0, j, k0, i1, k1 in T.grid(4, 16, 4, 4, 4):
+                with T.block("matmul"):
+                    vi = T.axis.S(16, i0 * 4 + i1)
+                    vj = T.axis.S(16, j)
+                    vk = T.axis.R(16, k0 * 4 + k1)
+                    with T.init():
+                        C[vi, vj] = T.float32(0)
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+
+        @R.function
+        def unused_func(x: Tensor((16, 16), "float32"), w: Tensor((16, 16), "float32")):
+            gv0 = relax.add(x, w)
+            return gv0
+
+        @R.function
+        def main(
+            x: Tensor((16, 16), "float32"), w: Tensor((16, 16), "float32")
+        ) -> Tensor((16, 16), "float32"):
+            gv0 = R.call_tir(tir_matmul, (x, w), (16, 16), dtype="float32")
+            return gv0
+
+    mod = InputModule
+    assert mod
+    assert check_if_func_exists(mod, "unused_func")
+    new_mod = relax.transform.RemoveUnusedFunctions()(mod)
+    assert not check_if_func_exists(new_mod, "unused_func")
+
+    # Test with relax function w/ symbolic shape
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
+            T.func_attr({"global_symbol": "tir_matmul"})
+            m = T.var("int32")
+            n = T.var("int32")
+            k = T.var("int32")
+            A = T.match_buffer(x, (m, n))
+            B = T.match_buffer(y, (n, k))
+            C = T.match_buffer(z, (m, k))
+
+            for i, j, k in T.grid(m, k, n):
+                with T.block("matmul"):
+                    vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                    with T.init():
+                        C[vi, vj] = T.float32(0)
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+
+        @R.function
+        def unused_func(x: Tensor((m, n), "float32"), w: Tensor((n, k), "float32")):
+            gv0 = relax.add(x, w)
+            return gv0
+
+        @R.function
+        def foo(x: Tensor((m, n), "float32"), w: Tensor((n, k), "float32")):
+            gv0 = R.call_tir(tir_matmul, (x, w), (m, k), dtype="float32")
+            return gv0
+
+    mod = InputModule
+    assert mod
+    assert check_if_func_exists(mod, "unused_func")
+
+    # Test entry function other than "main"
+    new_mod = relax.transform.RemoveUnusedFunctions(entry_functions=["foo"])(mod)
+    assert check_if_func_exists(mod, "foo")
+    assert not check_if_func_exists(new_mod, "unused_func")
+
+
+def test_unused_prim_func():
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def unused_func(x: T.handle, y: T.handle, z: T.handle) -> None:
+            T.func_attr({"global_symbol": "tir_matmul"})
+            A = T.match_buffer(x, (16, 16))
+            B = T.match_buffer(y, (16, 16))
+            C = T.match_buffer(z, (16, 16))
+            for i0, j, k0, i1, k1 in T.grid(4, 16, 4, 4, 4):
+                with T.block("matmul"):
+                    vi = T.axis.S(16, i0 * 4 + i1)
+                    vj = T.axis.S(16, j)
+                    vk = T.axis.R(16, k0 * 4 + k1)
+                    with T.init():
+                        C[vi, vj] = T.float32(0)
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+
+        @R.function
+        def relax_add(x: Tensor((16, 16), "float32"), w: Tensor((16, 16), "float32")):
+            gv0 = relax.add(x, w)
+            return gv0
+
+        @R.function
+        def main(
+            x: Tensor((16, 16), "float32"), w: Tensor((16, 16), "float32")
+        ) -> Tensor((16, 16), "float32"):
+            gv0 = relax_add(x, w)
+            return gv0
+
+    mod = InputModule
+    assert mod
+    assert check_if_func_exists(mod, "unused_func")
+    new_mod = relax.transform.RemoveUnusedFunctions()(mod)
+    assert not check_if_func_exists(new_mod, "unused_func")
+
+
+def test_multiple_unused_funcs():
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def unused_func1(x: T.handle, y: T.handle, z: T.handle) -> None:
+            T.func_attr({"global_symbol": "tir_matmul"})
+            A = T.match_buffer(x, (16, 16))
+            B = T.match_buffer(y, (16, 16))
+            C = T.match_buffer(z, (16, 16))
+            for i0, j, k0, i1, k1 in T.grid(4, 16, 4, 4, 4):
+                with T.block("matmul"):
+                    vi = T.axis.S(16, i0 * 4 + i1)
+                    vj = T.axis.S(16, j)
+                    vk = T.axis.R(16, k0 * 4 + k1)
+                    with T.init():
+                        C[vi, vj] = T.float32(0)
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+
+        @R.function
+        def unused_func2(x: Tensor((16, 16), "float32"), w: Tensor((16, 16), "float32")):
+            gv0 = relax.add(x, w)
+            return gv0
+
+        @R.function
+        def main(
+            x: Tensor((16, 16), "float32"), w: Tensor((16, 16), "float32")
+        ) -> Tensor((16, 16), "float32"):
+            gv0 = relax.add(x, w)
+            return gv0
+
+    mod = InputModule
+    assert mod
+    assert check_if_func_exists(mod, "unused_func1")
+    assert check_if_func_exists(mod, "unused_func2")
+    new_mod = relax.transform.RemoveUnusedFunctions()(mod)
+    assert not check_if_func_exists(new_mod, "unused_func1")
+    assert not check_if_func_exists(new_mod, "unused_func2")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
When we lower a function (e.g., relax->tir, tir->binary, relax->binary), we may no longer need the original function. 
This PR examines an IRModule and removes unused (relax/tir) functions if they are not going to be externally referenced (can be checked by `global_symbol`). 

cc. @YuchenJin @psrivas2 @yongwww 