### PR TITLE
Fix shape lowering pass bug for non i64 dims.

### DIFF
--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -185,6 +185,10 @@ class WellFormedChecker : public relax::ExprVisitor {
     for (PrimExpr expr : op->values) {
       // check if the symbolic vars in the expr are defined, e.g, 2 * m
       prim_expr_visitor_(expr);
+      if (!expr.dtype().is_int()) {
+        Malformed(Diagnostic::Error(expr->span)
+                  << "Shape expressions must be of integer type, but got " << expr.dtype());
+      }
     }
   }
 

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -142,6 +142,8 @@ class VMShapeLowerMutator : public ExprMutator {
     for (PrimExpr e : s->values) {
       Map<tir::Var, PrimExpr> var_mapping = BuildVarMapping(e, buffer);
       PrimExpr value = tir::Substitute(e, var_mapping);
+      // cast value to shape heap dtype
+      if (value.dtype() != ShapeDType()) value = tir::Cast(ShapeDType(), value);
       int idx = expr2slot_.at(e);
       seq.push_back(tir::BufferStore(buffer, value, {idx}));
     }

--- a/tests/python/relax/test_relay_translator.py
+++ b/tests/python/relax/test_relay_translator.py
@@ -247,5 +247,15 @@ def test_multiple_dynamic_dims():
     verify_vm_outputs([12, 5, 24], relay_vm, relax_vm)
 
 
+def test_layout_transform():
+    shape = (relay.Any(), 3, 224, 224)
+    a = relay.var("a", shape=shape)
+    b = relay.layout_transform(a, "NCHW", "NHWC")
+    relay_mod = tvm.IRModule.from_expr(relay.Function([a], b))
+
+    relay_vm, relax_vm = translate_and_build_vms(relay_mod)
+    verify_vm_outputs([1, 3, 224, 224], relay_vm, relax_vm)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Prior to this change, VM Shape Lowering pass did not cast integer values to shape heap dtype (i64) which resulted in incorrect values when read from heap later. This PR adds a cast to i64 for such values.

This also adds well-formed check to ensure shape dimensions are of integer types.

This allows relay operators like layout_transform (found in most convnet models) with unknown batch dimension to be successfully imported to Relax and execute.