### PR TITLE
[Parser] Add FuncType support

### DIFF
--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -402,6 +402,25 @@ Doc RelaxScriptPrinter::VisitType_(const relay::TupleTypeNode* node) {
   return doc;
 }
 
+Doc RelaxScriptPrinter::VisitType_(const relay::FuncTypeNode* node) {
+  Doc doc;
+  doc << "Callable";
+  if (node->type_params.size() != 0) {
+    doc << "(";
+    std::vector<Doc> type_params;
+    for (Type type_param : node->type_params) {
+      type_params.push_back(Print(type_param));
+    }
+    doc << Doc::Concat(type_params);
+    doc << ")";
+  }
+  std::vector<Doc> arg_types;
+  for (Type arg_type : node->arg_types) {
+    arg_types.push_back(Print(arg_type));
+  }
+  return doc << "((" << Doc::Concat(arg_types) << "), " << Print(node->ret_type) << ")";
+}
+
 Doc RelaxScriptPrinter::PrintAttr(const ObjectRef& attr) {
   if (attr.defined()) {
     if (const StringObj* str = attr.as<StringObj>()) {

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -418,6 +418,8 @@ Doc RelaxScriptPrinter::VisitType_(const relay::FuncTypeNode* node) {
   for (Type arg_type : node->arg_types) {
     arg_types.push_back(Print(arg_type));
   }
+  // TODO(@yongwww): Change it to Callable[[Arg1Type, Arg2Type, ...,], ReturnType]
+  //                 to be consistent with Python type hint syntax,
   return doc << "((" << Doc::Concat(arg_types) << "), " << Print(node->ret_type) << ")";
 }
 

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -312,6 +312,7 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   Doc VisitType_(const relax::ObjectTypeNode* node) override;
   Doc VisitType_(const relax::DynTensorTypeNode* node) override;
   Doc VisitType_(const relay::TupleTypeNode* node) override;
+  Doc VisitType_(const relay::FuncTypeNode* node) override;
 
   Doc PrintAttr(const ObjectRef& attr);
   std::vector<Doc> PrintAttrs(const Attrs& attrs);

--- a/src/relax/ir/type.cc
+++ b/src/relax/ir/type.cc
@@ -123,8 +123,9 @@ bool IsBaseOf(const Type& base, const Type& derived) {
       if (!IsBaseOf(base_func->ret_type, derived_func->ret_type)) {
         return false;
       }
+      return true;
     }
-    return true;
+    return false;
   } else if (base.as<ObjectTypeNode>()) {
     return true;
   } else {

--- a/src/relax/ir/type.cc
+++ b/src/relax/ir/type.cc
@@ -110,6 +110,21 @@ bool IsBaseOf(const Type& base, const Type& derived) {
       return true;
     }
     return false;
+  } else if (auto base_func = base.as<FuncTypeNode>()) {
+    if (auto derived_func = derived.as<FuncTypeNode>()) {
+      if (base_func->arg_types.size() != derived_func->arg_types.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < base_func->arg_types.size(); ++i) {
+        if (!IsBaseOf(base_func->arg_types[i], derived_func->arg_types[i])) {
+          return false;
+        }
+      }
+      if (!IsBaseOf(base_func->ret_type, derived_func->ret_type)) {
+        return false;
+      }
+    }
+    return true;
   } else if (base.as<ObjectTypeNode>()) {
     return true;
   } else {

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -369,13 +369,12 @@ def test_func_type():
     class TestFuncType:
         @R.function
         def global_func_1(
-            x: Tensor((m, n), "float32"), y: Tensor((m, n), "float32")
+            x: Tensor((m, n), "float32")
         ) -> Callable((Tensor((m, n), "float32")), Tensor((m, n), "float32")):
             @R.function
-            def local_func_1(z: Tensor((m, n), "float32")) -> Tensor((m, n), "float32"):
-                s1 = relax.add(x, y)
-                s2 = relax.add(z, s1)
-                return s2
+            def local_func_1(y: Tensor((m, n), "float32")) -> Tensor((m, n), "float32"):
+                s = relax.add(x, y)
+                return s
 
             return local_func_1
 

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -364,5 +364,45 @@ def test_runtime_dep_shape():
     assert x.__str__() == "_"
 
 
+def test_func_type():
+    @tvm.script.ir_module
+    class TestFuncType:
+        @R.function
+        def global_func_1(
+            x: Tensor((m, n), "float32"), y: Tensor((m, n), "float32")
+        ) -> Callable((Tensor((m, n), "float32")), Tensor((m, n), "float32")):
+            @R.function
+            def local_func_1(z: Tensor((m, n), "float32")) -> Tensor((m, n), "float32"):
+                s1 = relax.add(x, y)
+                s2 = relax.add(z, s1)
+                return s2
+
+            return local_func_1
+
+        @R.function
+        def global_func_2(
+            x: Tensor((m, n), "float32")
+        ) -> Callable(
+            (Tensor(None, "float32", ndim=2)),
+            Callable((Tensor((m, n), "float32"),), Tensor((m, n), "float32")),
+        ):
+            @R.function
+            def local_func_1(
+                y: Tensor((m, n), "float32")
+            ) -> Callable((Tensor((m, n), "float32"),), Tensor((m, n), "float32")):
+                @R.function
+                def local_func_2(z: Tensor((m, n), "float32")) -> Tensor(None, "float32", ndim=2):
+                    s1 = relax.add(x, y)
+                    s2 = relax.add(z, s1)
+                    return s2
+
+                return local_func_2
+
+            return local_func_1
+
+    func_type = TestFuncType
+    check_roundtrip(func_type)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Support FuncType in Parser & Printer.

If a relax function's return type is a `FuncType`,  we are using `Callable` type to do the type annotation in the printed IR, and  Callable can take other Callable as argument to handle multi-nested functions.

```
# Example
@R.function
def func( x: Tensor((m, n), "float32")) -> Callable((Tensor((m, n), "float32")), Tensor((m, n), "float32")):
    @R.function
    def local_func(z: Tensor((m, n), "float32")) -> Tensor((m, n), "float32"):
        return relax.add(z, z)
    return local_func_1
```


cc @YuchenJin @psrivas2 @sunggg @Hzfengsy 