### PR TITLE
[CI] Avoid running all relax examples in CI.

### DIFF
--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -30,7 +30,9 @@ export TVM_NUM_THREADS=2
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm}" pytest tests/python/relax
 
 # Run Relax examples
-ls ./apps/relax_examples/*.py | xargs python3
+python3 ./apps/relax_examples/mlp.py
+python3 ./apps/relax_examples/nn_module.py
+python3 ./apps/relax_examples/resnet.py
 
 # NOTE: also set by task_python_integration_gpuonly.sh.
 # if [ -z "${TVM_INTEGRATION_TESTSUITE_NAME:-}" ]; then


### PR DESCRIPTION
Currently the CI runs all of the python code under `apps/relax_examples/` to make sure PRs don't break these examples. The e2e tuning python script introduced by Siyuan in https://github.com/tlc-pack/relax/pull/153 needs bash script to set up the env and pass in parameters to the python script under this relax_examples folder, and tuning takes time so it's better not  run it in CI. 

This PR simply runs certain python code under this folder to avoid running the e2e tuning script, so it will make #153 pass the CI. I'm open to other suggestions such as adding these examples to unit tests and don't run the example code in CI at all.

cc @Hzfengsy @tqchen 