### PR TITLE
WellFormed Instrument

### DIFF
--- a/python/tvm/relax/ir/instrument.py
+++ b/python/tvm/relax/ir/instrument.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=no-else-return, invalid-name
 """Common relax pass instrumentation across IR variants."""
 import tvm
 from tvm import relax

--- a/python/tvm/relax/ir/instrument.py
+++ b/python/tvm/relax/ir/instrument.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=no-else-return, invalid-name
+"""Common relax pass instrumentation across IR variants."""
+import tvm
+from tvm import relax
+
+
+@tvm.instrument.pass_instrument
+class WellFormedInstrument:
+    """An instrument that checks the input/output IRModule of the Pass
+    is well formed. It will skip specific passes, like Normalize.
+    """
+
+    def __init__(self):
+        self.skip_pass_name = ["Normalize", "ResolveGlobals"]
+
+    def run_before_pass(self, mod, pass_info):
+        if pass_info.name not in self.skip_pass_name:
+            assert relax.analysis.well_formed(mod)
+
+    def run_after_pass(self, mod, pass_info):
+        if pass_info.name not in self.skip_pass_name:
+            assert relax.analysis.well_formed(mod)

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -128,7 +128,7 @@ class WellFormedChecker : public relax::ExprVisitor {
       // register symbolic var defined in the shape annotation of function params
       if (param->shape_) {
         Expr var_shape = Downcast<Expr>(param->shape_);
-        if (var_shape.as<RuntimeDepShapeNode>()) {
+        if (var_shape.as<RuntimeDepShapeNode>() || var_shape.as<TupleNode>()) {
           VisitExpr(var_shape);
         } else {
           for (PrimExpr expr : Downcast<ShapeExpr>(var_shape)->values) {

--- a/tests/python/relax/conftest.py
+++ b/tests/python/relax/conftest.py
@@ -1,4 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+
 import pytest
+
 import tvm
 from tvm.relax.ir.instrument import WellFormedInstrument
 

--- a/tests/python/relax/conftest.py
+++ b/tests/python/relax/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+import tvm
+from tvm import relax
+
+
+@tvm.instrument.pass_instrument
+class WellFormedInstrument:
+    """An instrument that checks input/output mod is well formed.
+    It will skip specific passes, like Normalize.
+    """
+
+    def __init__(self):
+        self.skip_pass_name = ["Normalize", "ResolveGlobals"]
+
+    def run_before_pass(self, mod, pass_info):
+        if pass_info.name in self.skip_pass_name:
+            return
+        assert relax.analysis.well_formed(mod)
+
+    def run_after_pass(self, mod, pass_info):
+        if pass_info.name in self.skip_pass_name:
+            return
+        assert relax.analysis.well_formed(mod)
+
+
+tvm.transform.PassContext.current().override_instruments([WellFormedInstrument()])

--- a/tests/python/relax/conftest.py
+++ b/tests/python/relax/conftest.py
@@ -1,26 +1,6 @@
 import pytest
 import tvm
-from tvm import relax
-
-
-@tvm.instrument.pass_instrument
-class WellFormedInstrument:
-    """An instrument that checks input/output mod is well formed.
-    It will skip specific passes, like Normalize.
-    """
-
-    def __init__(self):
-        self.skip_pass_name = ["Normalize", "ResolveGlobals"]
-
-    def run_before_pass(self, mod, pass_info):
-        if pass_info.name in self.skip_pass_name:
-            return
-        assert relax.analysis.well_formed(mod)
-
-    def run_after_pass(self, mod, pass_info):
-        if pass_info.name in self.skip_pass_name:
-            return
-        assert relax.analysis.well_formed(mod)
+from tvm.relax.ir.instrument import WellFormedInstrument
 
 
 tvm.transform.PassContext.current().override_instruments([WellFormedInstrument()])


### PR DESCRIPTION
1. Wrap WellFormed pass into a Pass Instrument. We will turn it on before the test session starts.

https://github.com/tlc-pack/relax/blob/3f02fe79d016a6c5b0f722cc3a99acbfda1c28a7/tests/python/relax/conftest.py#L6

It will override `WellFormedInstrument` to the current `PassContext`, which works for all unit tests, i.e., check the input/output IRModule for each Pass.

We can also turn WellFormed check on like
```python
with tvm.transform.PassContext(instruments=[WellFormedInstrument()]):
    mod = relax.transform.FuseFMA()(mod)
    # other pass
    ... 
```
2. Bug fix in Wellformed check.  `TupleType` in Function parameters.

Q: Where to keep relax-only Pass Instruments?
Now I put `WellFormedInstrument` into `tvm/relax/ir/instrument.py`, following [PassTimingInstrument](https://github.com/tlc-pack/relax/blob/3571ce2446b8fd41f9ba6cbf85c93e7476f6c814/python/tvm/ir/instrument.py#L231-L257) in [tvm/ir/instrument.py](https://github.com/tlc-pack/relax/blob/relax/python/tvm/ir/instrument.py). Welcome to new ideas.

cc: @YuchenJin