### PR TITLE
Run static/dynamic models over Hexagon using Relax VM RPC

### DIFF
--- a/include/tvm/runtime/relax_vm/executable.h
+++ b/include/tvm/runtime/relax_vm/executable.h
@@ -23,7 +23,6 @@
 #ifndef TVM_RUNTIME_RELAX_VM_EXECUTABLE_H_
 #define TVM_RUNTIME_RELAX_VM_EXECUTABLE_H_
 
-#include <tvm/ir/expr.h>
 #include <tvm/runtime/container/closure.h>
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/registry.h>

--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -23,7 +23,9 @@ import tempfile
 from typing import Union
 
 import tvm
+from tvm import relax
 from tvm import rpc as _rpc
+from tvm.contrib import utils
 import tvm.contrib.hexagon as hexagon
 from tvm.relay.backend.executor_factory import (
     ExecutorFactoryModule,
@@ -247,13 +249,13 @@ class Session:
             graph_json, graph_debug_mod, self.device, dump_root=str(dump_root)
         )
 
-    def get_executor_from_factory(self, module: ExecutorFactoryModule):
+    def get_executor_from_factory(self, module: Union[ExecutorFactoryModule, relax.vm.Executable]):
         """Create a local GraphModule which consumes a remote libmod.
 
         Parameters
         ----------
 
-        module : ExecutorFactoryModule
+        module : Union[ExecutorFactoryModule, relax.vm.Executable]
 
             The module to upload to the remote
             session and load.
@@ -262,6 +264,8 @@ class Session:
             return self._aot_executor_from_factory(module)
         if isinstance(module, GraphExecutorFactoryModule):
             return self._graph_executor_from_factory(module)
+        if isinstance(module, relax.vm.Executable):
+            return self._relax_vm_executable_executor(module)
 
         raise TypeError(f"Unsupported executor type: {type(module)}")
 
@@ -312,6 +316,38 @@ class Session:
 
         """
         return self.get_graph_executor(module.get_graph_json(), module.get_lib())
+
+    def _relax_vm_executable_executor(
+        self,
+        vm_exec: relax.vm.Executable,
+    ):
+        """Create a local TVM module which consumes a remote vm executable.
+
+        Paramters
+        ---------
+
+        vm_exec : relax.vm.Executable
+            The Relax VM Executable to upload to the remote and load. This will typically be the
+            output of `relax.vm.build`.
+
+        Returns
+        -------
+        TVMModule :
+            TVM module object
+        """
+        assert self._rpc is not None, "Hexagon session must be started using __enter__ prior to use"
+
+        temp_dir = utils.tempdir()
+        path_exec = temp_dir.relpath("exec.so")
+
+        vm_exec.mod.export_library(
+            path_exec,
+            fcompile=hexagon.create_aot_shared,
+            hexagon_arch="v68",
+        )
+
+        self.upload(path_exec, "exec.so")
+        return self._rpc.get_function("tvm.hexagon.load_module")("exec.so")
 
     def _aot_executor_from_factory(
         self,

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -467,7 +467,7 @@ class Module(object):
                             object_format = "cu"
                     has_c_module = True
                 else:
-                    assert module.type_key == "llvm" or module.type_key == "static_library"
+                    assert module.is_dso_exportable
                     object_format = "o"
             path_obj = os.path.join(workspace_dir, f"lib{index}.{object_format}")
             module.save(path_obj)

--- a/src/runtime/hexagon/hexagon_module.h
+++ b/src/runtime/hexagon/hexagon_module.h
@@ -64,6 +64,7 @@ class HexagonModuleNode : public runtime::ModuleNode {
   const char* type_key() const final { return "hexagon"; }
   void SaveToFile(const std::string& file_name, const std::string& format) override;
   void SaveToBinary(dmlc::Stream* stream) override;
+  bool IsDSOExportable() const final { return true; }
 
  protected:
   std::string data_;

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -17,7 +17,7 @@
  * under the License.
  */
 /*!
- * \file src/relax/backend/vm/builtin.cc
+ * \file src/runtime/relax_vm/builtin.cc
  */
 #include <tvm/runtime/container/adt.h>
 #include <tvm/runtime/data_type.h>
@@ -121,9 +121,6 @@ TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage")
       }
 
       int64_t size_imm = buffer_size[0];
-      DLOG(INFO) << "AllocStorage: allocation_size=" << size_imm << ", alignment=" << alignment
-                 << ", dtype_hint=" << runtime::DLDataType2String(dtype_hint)
-                 << ", device_index=" << device_index;
 
       auto storage_obj = runtime::SimpleObjAllocator().make_object<StorageObj>();
       auto* alloc = vm->allocators[device_index];
@@ -144,12 +141,8 @@ TVM_REGISTER_GLOBAL("vm.binary_broadcast_shape_infer")
       for (; i <= std::min(ndim0, ndim1); ++i) {
         int64_t lhs_dim = lhs_shape[ndim0 - i];
         int64_t rhs_dim = rhs_shape[ndim1 - i];
-        if (lhs_dim == 1 || rhs_dim == 1 || lhs_dim == rhs_dim) {
-          output_shape.push_back(std::max(lhs_dim, rhs_dim));
-        } else {
-          LOG(FATAL) << "Incompatible shapes " << lhs_shape << " and " << rhs_shape
-                     << " for broadcasting";
-        }
+        ICHECK(lhs_dim == rhs_dim || lhs_dim == 1 || rhs_dim == 1);
+        output_shape.push_back(std::max(lhs_dim, rhs_dim));
       }
       size_t max_ndim = std::max(ndim0, ndim1);
       ShapeTuple& longer_shape = (ndim0 > ndim1) ? lhs_shape : rhs_shape;

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -41,9 +41,11 @@ TVM_REGISTER_GLOBAL("vm.builtin.shape_of").set_body_method(&NDArray::Shape);
 
 TVM_REGISTER_GLOBAL("vm.builtin.copy").set_body_typed([](NDArray src) { return src; });
 
-TVM_REGISTER_GLOBAL("vm.builtin.alloc_shape_heap").set_body_typed([](ShapeTuple size) {
-  return NDArray::Empty(size, DLDataType{kDLInt, 64, 1}, DLDevice{kDLCPU, 0});
-});
+TVM_REGISTER_GLOBAL("vm.builtin.alloc_shape_heap")
+    .set_body_typed([](void* vm_ptr, ShapeTuple size) {
+      VirtualMachine* vm = static_cast<VirtualMachine*>(vm_ptr);
+      return NDArray::Empty(size, DLDataType{kDLInt, 64, 1}, vm->devices[0]);
+    });
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_closure").set_body([](TVMArgs args, TVMRetValue* rv) {
   std::vector<ObjectRef> cap_vars;

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -166,7 +166,7 @@ void Executable::SetInstructionData(Index i, Index j, ExecWord val) {
 }
 
 Instruction Executable::GetInstruction(Index i) const {
-  size_t offset = instr_offset[i];
+  Index offset = instr_offset[i];
   Opcode op = static_cast<Opcode>(instr_data[offset]);
   switch (op) {
     case Opcode::Call: {
@@ -383,7 +383,7 @@ void Executable::LoadConstantSection(dmlc::Stream* strm) {
       cell = ndarray;
       this->constants.push_back(cell);
     } else if (constant_type == ConstantType::kShapeTuple) {
-      size_t size;
+      uint64_t size;
       strm->Read(&size);
       std::vector<ShapeTuple::index_type> data(size);
       for (size_t i = 0; i < size; ++i) {
@@ -398,7 +398,7 @@ void Executable::LoadConstantSection(dmlc::Stream* strm) {
       cell = dtype;
       this->constants.push_back(cell);
     } else if (constant_type == ConstantType::kString) {
-      size_t size;
+      uint64_t size;
       strm->Read(&size);
       std::vector<char> data(size);
       for (size_t i = 0; i < size; ++i) {

--- a/tests/python/contrib/test_hexagon/test_relax_integration.py
+++ b/tests/python/contrib/test_hexagon/test_relax_integration.py
@@ -15,12 +15,280 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import numpy as np
+import pytest
 import tvm.testing
+from tvm import relay, relax, runtime
+from tvm.relax.testing import relay_translator
+from tvm.contrib.hexagon.session import Session
+from tvm.script import relax as R, tir as T
+from tvm.relay import testing
 
 
 @tvm.testing.requires_hexagon
-def test_simple():
-    pass
+def test_conv2d(hexagon_session: Session):
+    dtype = "float32"
+    data = relay.var("data", relay.TensorType((1, 64, 64, 3), dtype))
+    weight = relay.var("weight", relay.TensorType((5, 5, 3, 8), dtype))
+    y = relay.nn.conv2d(
+        data,
+        weight,
+        padding=(2, 2),
+        kernel_size=(5, 5),
+        data_layout="NHWC",
+        kernel_layout="HWIO",
+        out_dtype="float32",
+    )
+    f = relay.Function([data, weight], y)
+    relay_mod = tvm.IRModule.from_expr(f)
+
+    # target_hexagon = "llvm -keys=hexagon -link-params=0 -mattr=+hvxv69,+hvx-length128b,+hvx-qfloat,-hvx-ieee-fp -mcpu=hexagonv69 -mtriple=hexagon"
+    target_hexagon = tvm.target.hexagon("v68")
+    target = tvm.target.Target(target_hexagon, host=target_hexagon)
+    relax_mod = relay_translator.from_relay(relay_mod["main"], target)
+
+    ex = relax.vm.build(relax_mod, target)
+    dev = hexagon_session.device
+    vm_mod = hexagon_session.get_executor_from_factory(ex)
+    vm_rt = relax.VirtualMachine(vm_mod, dev)
+
+    data_np = np.random.rand(1, 64, 64, 3).astype(np.float32)
+    weight_np = np.random.rand(5, 5, 3, 8).astype(np.float32)
+
+    # Run on hexagon and get result
+    data = tvm.nd.array(data_np, dev)
+    weight = tvm.nd.array(weight_np, dev)
+    hexagon_res = vm_rt["main"](data, weight)
+
+    # Compile and run on Relay for comparison.
+    dev = tvm.cpu()
+    data = tvm.nd.array(data_np, dev)
+    weight = tvm.nd.array(weight_np, dev)
+
+    target = tvm.target.Target("llvm", host="llvm")
+    vm_exec = relay.vm.compile(relay_mod, target=target)
+    vm_factory = runtime.vm.VirtualMachine(vm_exec, tvm.cpu())
+    relay_res = vm_factory.invoke("main", data, weight)
+    tvm.testing.assert_allclose(hexagon_res.numpy(), relay_res.numpy(), rtol=1e-3)
+
+
+@pytest.mark.skip("Dynamic shape bug")
+@tvm.testing.requires_hexagon
+def test_conv2d_dyn(hexagon_session: Session):
+    dtype = "float32"
+    data = relay.var("data", relay.TensorType((relay.Any(), 64, 64, 3), dtype))
+    weight = relay.var("weight", relay.TensorType((5, 5, 3, 8), dtype))
+    y = relay.nn.conv2d(
+        data,
+        weight,
+        padding=(2, 2),
+        kernel_size=(5, 5),
+        data_layout="NHWC",
+        kernel_layout="HWIO",
+        out_dtype="float32",
+    )
+    f = relay.Function([data, weight], y)
+    relay_mod = tvm.IRModule.from_expr(f)
+
+    target_hexagon = tvm.target.hexagon("v68")
+    target = tvm.target.Target(target_hexagon, host=target_hexagon)
+    relax_mod = relay_translator.from_relay(relay_mod["main"], target)
+
+    ex = relax.vm.build(relax_mod, target)
+    hexgaon_device = hexagon_session.device
+    vm_mod = hexagon_session.get_executor_from_factory(ex)
+    vm_rt = relax.VirtualMachine(vm_mod, hexgaon_device)
+
+    data_np = np.random.rand(1, 64, 64, 3).astype(np.float32)
+    weight_np = np.random.rand(5, 5, 3, 8).astype(np.float32)
+
+    # Run on hexagon and get result
+    data = tvm.nd.array(data_np, hexgaon_device)
+    weight = tvm.nd.array(weight_np, hexgaon_device)
+    vm_rt.set_input("main", data, weight)
+    vm_rt["main"]()
+    hexagon_res = vm_rt.get_outputs()
+
+    # Compile and run on Relay for comparison.
+    cpu_device = tvm.cpu()
+    data = tvm.nd.array(data_np, cpu_device)
+    weight = tvm.nd.array(weight_np, cpu_device)
+
+    target = tvm.target.Target("llvm", host="llvm")
+    vm_exec = relay.vm.compile(relay_mod, target=target)
+    vm_factory = runtime.vm.VirtualMachine(vm_exec, tvm.cpu())
+    relay_res = vm_factory.invoke("main", data, weight)
+    tvm.testing.assert_allclose(hexagon_res.numpy(), relay_res.numpy(), rtol=1e-3)
+
+
+@tvm.testing.requires_hexagon
+def test_mlp(hexagon_session: Session):
+    relay_mod, params = testing.mlp.get_workload(batch_size=1, dtype="float32")
+
+    target_hexagon = tvm.target.hexagon("v68")
+    target = tvm.target.Target(target_hexagon, host=target_hexagon)
+    relax_mod = relay_translator.from_relay(relay_mod["main"], target, params)
+
+    ex = relax.vm.build(relax_mod, target)
+    hexagon_device = hexagon_session.device
+
+    vm_mod = hexagon_session.get_executor_from_factory(ex)
+    vm_rt = relax.VirtualMachine(vm_mod, hexagon_device)
+
+    shape = (1, 1, 28, 28)
+    data_np = np.random.rand(*shape).astype("float32")
+    data = tvm.nd.array(data_np, hexagon_device)
+    hexagon_res = vm_rt["main"](data)
+
+    # Compile and run on Relay for comparison.
+    cpu_dev = tvm.cpu()
+    data = tvm.nd.array(data_np, cpu_dev)
+
+    target = tvm.target.Target("llvm", host="llvm")
+    vm_exec = relay.vm.compile(relay_mod, target=target)
+    vm_factory = runtime.vm.VirtualMachine(vm_exec, cpu_dev)
+    relay_res = vm_factory.invoke("main", data, **params)
+    tvm.testing.assert_allclose(hexagon_res.numpy(), relay_res.numpy(), rtol=1e-3)
+
+
+@pytest.mark.skip("Dynamic shape bug")
+@tvm.testing.requires_hexagon
+def test_mlp_dyn(hexagon_session: Session):
+    relay_mod, params = testing.mlp.get_workload(batch_size=relay.Any(), dtype="float32")
+    shape = (1, 1, 28, 28)
+    data_np = np.random.rand(*shape).astype("float32")
+
+    target_hexagon = tvm.target.hexagon("v68")
+    target = tvm.target.Target(target_hexagon, host=target_hexagon)
+
+    # translate the relay mobilenet and bind params
+    relax_mod = relay_translator.from_relay(relay_mod["main"], target, params)
+
+    # Compile and run on Hexagon.
+    ex = relax.vm.build(relax_mod, target)
+    dev = hexagon_session.device
+
+    vm_mod = hexagon_session.get_executor_from_factory(ex)
+    vm_rt = relax.VirtualMachine(vm_mod, dev)
+    data = tvm.nd.array(data_np, dev)
+    hexagon_res = vm_rt["main"](data)
+
+    # Compile and run on Relay for comparison.
+    dev = tvm.cpu()
+    data = tvm.nd.array(data_np, dev)
+
+    target = tvm.target.Target("llvm", host="llvm")
+    vm_exec = relay.vm.compile(relay_mod, target=target)
+    vm_factory = runtime.vm.VirtualMachine(vm_exec, tvm.cpu())
+    relay_res = vm_factory.invoke("main", data, **params)
+    print(hexagon_res)
+    print(relay_res)
+    tvm.testing.assert_allclose(hexagon_res.numpy(), relay_res.numpy(), rtol=1e-3)
+
+
+def get_onnx_mobilenet():
+    """Download and import mobilenet model with ONNX"""
+    import onnx  # pylint: disable=import-outside-toplevel
+
+    model_url = "https://github.com/onnx/models/raw/main/vision/classification/mobilenet/model/mobilenetv2-7.onnx"
+    model_path = tvm.contrib.download.download_testdata(
+        model_url, "mobilenetv2-7.onnx", module="onnx"
+    )
+    return onnx.load(model_path)
+
+
+@pytest.mark.skip("takes too long (~20min)")
+@tvm.testing.requires_hexagon
+def test_mobilenet_onnx(hexagon_session: Session):
+    onnx_model = get_onnx_mobilenet()
+    data_np = np.random.rand(1, 3, 224, 224).astype("float32")
+    shape_dict = {"input": data_np.shape}
+    relay_mod, _ = relay.frontend.from_onnx(onnx_model, shape_dict, freeze_params=True)
+
+    target_hexagon = tvm.target.hexagon("v68")
+    target = tvm.target.Target(target_hexagon, host=target_hexagon)
+    relax_mod = relay_translator.from_relay(relay_mod["main"], target_hexagon)
+
+    # Compile and run on Hexagon.
+    ex = relax.vm.build(relax_mod, target)
+    dev = hexagon_session.device
+
+    vm_mod = hexagon_session.get_executor_from_factory(ex)
+    vm_rt = relax.VirtualMachine(vm_mod, dev)
+    data = tvm.nd.array(data_np, dev)
+    hexagon_res = vm_rt["main"](data)
+
+    # Compile and run on LLVM for comparison.
+    relax_mod = relay_translator.from_relay(relay_mod["main"], "llvm")
+    ex = relax.vm.build(relax_mod, "llvm")
+    dev = tvm.cpu()
+    vm_rt = relax.VirtualMachine(ex, dev)
+    data = tvm.nd.array(data_np, dev)
+    llvm_res = vm_rt["main"](data)
+    tvm.testing.assert_allclose(hexagon_res.numpy(), llvm_res.numpy(), rtol=1e-3)
+
+
+@pytest.mark.skip("takes too long (~20min)")
+@tvm.testing.requires_hexagon
+def test_mobilenet(hexagon_session: Session):
+    relay_mod, params = testing.mobilenet.get_workload(batch_size=1, dtype="float32")
+    data_np = np.random.rand(1, 3, 224, 224).astype("float32")
+
+    target_hexagon = tvm.target.hexagon("v68")
+    target = tvm.target.Target(target_hexagon, host=target_hexagon)
+
+    # translate the relay mobilenet and bind params
+    relax_mod = relay_translator.from_relay(relay_mod["main"], target, params)
+
+    # Compile and run on Hexagon.
+    ex = relax.vm.build(relax_mod, target)
+    dev = hexagon_session.device
+
+    vm_mod = hexagon_session.get_executor_from_factory(ex)
+    vm_rt = relax.VirtualMachine(vm_mod, dev)
+    data = tvm.nd.array(data_np, dev)
+    hexagon_res = vm_rt["main"](data)
+
+    # Compile and run on LLVM for comparison.
+    relax_mod = relay_translator.from_relay(relay_mod["main"], "llvm", params)
+    ex = relax.vm.build(relax_mod, "llvm")
+    dev = tvm.cpu()
+    vm_rt = relax.VirtualMachine(ex, dev)
+    data = tvm.nd.array(data_np, dev)
+    llvm_res = vm_rt["main"](data)
+    tvm.testing.assert_allclose(hexagon_res.numpy(), llvm_res.numpy(), rtol=1e-3)
+
+
+@pytest.mark.skip("takes too long (~20min)")
+@tvm.testing.requires_hexagon
+def test_mobilenet_dyn(hexagon_session: Session):
+    relay_mod, params = testing.mobilenet.get_workload(batch_size=relay.Any(), dtype="float32")
+    data_np = np.random.rand(1, 3, 224, 224).astype("float32")
+
+    target_hexagon = tvm.target.hexagon("v68")
+    target = tvm.target.Target(target_hexagon, host=target_hexagon)
+
+    # translate the relay mobilenet and bind params
+    relax_mod = relay_translator.from_relay(relay_mod["main"], target, params)
+
+    # Compile and run on Hexagon.
+    ex = relax.vm.build(relax_mod, target)
+    dev = hexagon_session.device
+
+    vm_mod = hexagon_session.get_executor_from_factory(ex)
+    vm_rt = relax.VirtualMachine(vm_mod, dev)
+    data = tvm.nd.array(data_np, dev)
+    hexagon_res = vm_rt["main"](data)
+
+    # Compile and run on Relay for comparison.
+    dev = tvm.cpu()
+    data = tvm.nd.array(data_np, dev)
+
+    target = tvm.target.Target("llvm", host="llvm")
+    vm_exec = relay.vm.compile(relay_mod, target=target)
+    vm_factory = runtime.vm.VirtualMachine(vm_exec, tvm.cpu())
+    relay_res = vm_factory.invoke("main", data, **params)
+    tvm.testing.assert_allclose(hexagon_res.numpy(), relay_res.numpy(), rtol=1e-3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR aims to upstream to Relax the changes that were necessary to run static and dynamic shaped models on Hexagon using Relax. It includes the following changes:

- [x] Add set_input interface to Relax VM (https://github.com/tlc-pack/relax/pull/166): Since RPC has limited support for TVM object system and the assumption is the remote only has a minimal C runtime which does not support tvm object(like tvm::runtime::NDArray), this change adds a `set_input` interface to Relax VM, which internally converts NDArray in the function arguments to DLTensor.
- [x] Move Relax VM builtins to src/runtime: This fixes a bug we encountered while loading the module for hexagon. Since it was building the minimal runtime it was missing definition of Relax VM builtins.
- [x] Fix hexagon module loading (add IsDSOExportable).
- [x] Enable Hexagon CI (https://github.com/tlc-pack/relax/pull/169)
- [x] Improve test coverage for Relax VM RPC.
- [x] Fix int32/64 bug.

The bug where simple model with scalar relay constant runs into an error needs further investigation and I'll submit a separate PR for that one.

Co-authored-by: Yuchen Jin <yuchenj@cs.washington.edu>