### PR TITLE
[CI] Enable Hexagon CI in Jenkins.

### DIFF
--- a/tests/python/contrib/test_hexagon/test_relax_integration.py
+++ b/tests/python/contrib/test_hexagon/test_relax_integration.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm.testing
+
+
+@tvm.testing.requires_hexagon
+def test_simple():
+    pass
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/scripts/task_python_hexagon.sh
+++ b/tests/scripts/task_python_hexagon.sh
@@ -40,7 +40,9 @@ if [[ "${device_serial}" == "simulator" ]]; then
 fi
 
 export ANDROID_SERIAL_NUMBER=${device_serial}
-run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon
+
+# Only test integration with Relax
+run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon/test_relax_integration.py
 
 if [[ "${device_serial}" == "simulator" ]]; then
     kill ${TRACKER_PID}


### PR DESCRIPTION
This PR enables running Hexagon tests in CI.

Since running all Hexagon tests in simulator is very slow, we only run Relax related hexagon tests`test_relax_integration.py`. This test file is empty right now and it would be populated as we push relax-hexagon related changes and corresponding tests.
