### PR TITLE
[Refactor] Generic dispatching for `IsBaseOf`; Simplify Type/Expr initializations; `relax` -> `R` in printer; Disallow local function in VMCodegen

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -116,7 +116,7 @@ class RuntimeDepShapeNode : public ExprNode {
 class RuntimeDepShape : public Expr {
  public:
   TVM_DLL explicit RuntimeDepShape(Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(RuntimeDepShape, Expr, RuntimeDepShapeNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(RuntimeDepShape, Expr, RuntimeDepShapeNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(RuntimeDepShapeNode);
 };
 

--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -53,7 +53,7 @@ class ShapeType : public Type {
  public:
   TVM_DLL ShapeType(Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ShapeType, Type, ShapeTypeNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ShapeType, Type, ShapeTypeNode);
 };
 
 class ObjectTypeNode : public TypeNode {
@@ -72,7 +72,7 @@ class ObjectType : public Type {
  public:
   TVM_DLL ObjectType(Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ObjectType, Type, ObjectTypeNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ObjectType, Type, ObjectTypeNode);
 };
 
 class DynTensorTypeNode : public BaseTensorTypeNode {

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -85,7 +85,7 @@ Doc RelaxScriptPrinter::VisitNode_(const relay::CallNode* op) {
 
   static const Op& call_tir_op = Op::Get("relax.call_tir");
   if (op->op == call_tir_op) {
-    doc << "relax.call_tir";
+    doc << "R.call_tir";
 
     for (const Expr& arg : op->args) {
       args.push_back(Print(arg));
@@ -114,7 +114,7 @@ Doc RelaxScriptPrinter::VisitNode_(const relay::CallNode* op) {
   }
 
   if (op->op.as<relax::ExternFuncNode>()) {
-    doc << "relax.call_packed";
+    doc << "R.call_packed";
     args.push_back(Print(op->op));
   } else {
     doc << Print(op->op);
@@ -253,7 +253,7 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::MatchShapeNode* op) {
   if (op->var.defined()) {
     doc << Print(op->var) << PrintVarAnnotation(op->var) << " = ";
   }
-  doc << "relax.match_shape(";
+  doc << "R.match_shape(";
   // TODO(@altanh): maybe op->pattern should just be a ShapeExpr?
   doc << Print(op->value) << ", " << Print(relax::ShapeExpr(op->pattern));
   doc << ")";
@@ -311,8 +311,8 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::DataflowBlockNode* op) {
     }
   }
   ICHECK(!return_vars.empty()) << "dataflow blocks should have at least one output variable";
-  body << "relax.output(" << Doc::Concat(return_vars, Doc::Text(", ")) << ")";
-  block << "with relax.dataflow():" << Doc::NewLine(4);
+  body << "R.output(" << Doc::Concat(return_vars, Doc::Text(", ")) << ")";
+  block << "with R.dataflow():" << Doc::NewLine(4);
   block << Doc::Indent(4, body) << Doc::NewLine();
   return block;
 }
@@ -367,13 +367,13 @@ TVM_DEFINE_RELAX_PRINTER_PRIMEXPR_BINOP(tir::FloorDivNode, " // ")
 
 Doc RelaxScriptPrinter::VisitExpr_(const tir::CastNode* op) {
   Doc doc;
-  doc << "tir.cast(" << PrintDType(op->dtype) << ", " << Print(op->value) << ")";
+  doc << "T.cast(" << PrintDType(op->dtype) << ", " << Print(op->value) << ")";
   return doc;
 }
 
 Doc RelaxScriptPrinter::VisitExpr_(const tir::MaxNode* op) {
   Doc doc;
-  doc << "tir.max(" << Print(op->a) << ", " << Print(op->b) << ")";
+  doc << "T.max(" << Print(op->a) << ", " << Print(op->b) << ")";
   return doc;
 }
 
@@ -515,7 +515,7 @@ Doc RelaxScriptPrinter::PrintPrimFunc(const String& name, const tir::PrimFunc& f
   // refactoring to avoid this?
   IRModule mod;
   mod->Add(relay::GlobalVar(name), func);
-  return tir::AsTVMScriptDoc(mod, "tir", false, func);
+  return tir::AsTVMScriptDoc(mod, "T", false, func);
 }
 
 Doc RelaxScriptPrinter::PrintIfStmt(const relax::Var& var, const relay::If& ite) {
@@ -547,9 +547,9 @@ Doc RelaxScriptPrinter::PrintFunctionDef(const Doc& name, const relax::Function&
     params.push_back(param);
   }
   if (ShowMetaData()) {
-    doc << "@relax.function(metadata=metadata)" << Doc::NewLine();
+    doc << "@R.function(metadata=metadata)" << Doc::NewLine();
   } else {
-    doc << "@relax.function" << Doc::NewLine();
+    doc << "@R.function" << Doc::NewLine();
   }
   doc << "def " << name << "(" << Doc::Concat(params, Doc::Text(", ")) << ")";
   if (func->ret_type.defined()) {

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -45,7 +45,7 @@ Doc RelaxScriptPrinter::Print(const ObjectRef& node) {
   } else if (node->IsInstance<PrimExprNode>()) {
     return VisitExpr(Downcast<PrimExpr>(node));
   } else if (node->IsInstance<tir::PrimFuncNode>()) {
-    return tir::AsTVMScriptDoc(Downcast<tir::PrimFunc>(node));
+    return tir::AsTVMScriptDoc(Downcast<tir::PrimFunc>(node), "T", false);
   } else {
     return VisitNode(node);
   }

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -69,15 +69,15 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   size_t NewRegister() { return registers_num_++; }
   Instruction::Arg VisitExpr_(const FunctionNode* func_node) {
     Optional<String> gsymbol = func_node->GetAttr<String>(tvm::attr::kGlobalSymbol);
+    ICHECK(gsymbol.defined()) << "there should be no local functions in Relax VM codegen phase. "
+                                 "Did you forget to apply LambdaLift pass?";
+
     Array<String> param_names;
     for (Var param : func_node->params) {
       param_names.push_back(param->name_hint());
     }
-    if (gsymbol.defined()) {
-      builder_->EmitFunction(gsymbol.value(), func_node->params.size(), param_names);
-    } else {
-      LOG(FATAL) << "ValueError: there should be no local functions in Relax VM codegen phase.";
-    }
+
+    builder_->EmitFunction(gsymbol.value(), func_node->params.size(), param_names);
 
     for (Var param : func_node->params) {
       Instruction::Arg reg = this->VisitExpr(param);

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -76,12 +76,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     if (gsymbol.defined()) {
       builder_->EmitFunction(gsymbol.value(), func_node->params.size(), param_names);
     } else {
-      // TODO(@yuchen): handle local functions that capture local vars outside the func
-      // TODO(@yuchen): a renaming pass to resolve name conflicts, e.g. the input module has a
-      // function named "local_funcN"
-      // lift the local func to a global func and process it normally
-      builder_->EmitFunction("local_func" + std::to_string(local_func_counter_++),
-                             func_node->params.size(), param_names);
+      LOG(FATAL) << "ValueError: there should be no local functions in Relax VM codegen phase.";
     }
 
     for (Var param : func_node->params) {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -370,7 +370,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   Optional<Expr> InferShape(const Call& call, DiagnosticContext diag_ctx, IRModule ctx_mod) {
     if (call->op.as<ExternFuncNode>()) {
       // call_packed: return RuntimeDepShape
-      return RuntimeDepShape(Span());
+      return RuntimeDepShape();
     } else if (call->op.as<OpNode>()) {
       // primitive op: look up FInferShape attribute
       Op op = Downcast<Op>(call->op);
@@ -389,7 +389,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
             return func_shape;
           } else {
             // TODO(@yuchen): add deducer for other cases
-            return RuntimeDepShape(Span());
+            return RuntimeDepShape();
           }
         }
       }
@@ -411,7 +411,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
             return func_shape;
           } else {
             // TODO(@yuchen, @yongwww): add deducer for other cases
-            return RuntimeDepShape(Span());
+            return RuntimeDepShape();
           }
         }
       }
@@ -429,7 +429,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     if (call->op.as<ExternFuncNode>()) {
       if (call->type_args.defined()) {
         if (call->type_args.size() == 0) {
-          return ObjectType(Span());
+          return ObjectType();
         } else if (call->type_args.size() == 1) {
           return call->type_args.front();
         } else {
@@ -605,7 +605,7 @@ Var BlockBuilderNode::EmitMatchShape(const Expr& value, const Array<PrimExpr>& p
       cur_frame->is_dataflow ? DataflowVar(vid, NullOpt, NullOpt) : Var(vid, NullOpt, NullOpt);
 
   if (value->checked_type().as<ShapeTypeNode>()) {
-    UpdateType(var, ShapeType(Span()));
+    UpdateType(var, ShapeType());
   } else if (const DynTensorTypeNode* tty = value->checked_type().as<DynTensorTypeNode>()) {
     ShapeExpr shape = ShapeExpr(pattern);
     UpdateShape(var, shape);

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -42,7 +42,7 @@ ShapeExpr::ShapeExpr(Array<PrimExpr> values, Span span) {
   n->values = std::move(values);
   n->span = span;
   n->shape_ = NullOpt;
-  n->checked_type_ = ShapeType(Span());
+  n->checked_type_ = ShapeType();
   data_ = std::move(n);
 }
 

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -53,9 +53,9 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs) {
 
 Type ReturnVoidType(const Call& call, DiagnosticContext diag_ctx) { return VoidType(); }
 
-Type ReturnObjectType(const Call& call, DiagnosticContext diag_ctx) { return ObjectType(Span()); }
+Type ReturnObjectType(const Call& call, DiagnosticContext diag_ctx) { return ObjectType(); }
 
-Type ReturnShapeType(const Call& call, DiagnosticContext diag_ctx) { return ShapeType(Span()); }
+Type ReturnShapeType(const Call& call, DiagnosticContext diag_ctx) { return ShapeType(); }
 
 // call_tir
 

--- a/tests/python/relax/test_type.py
+++ b/tests/python/relax/test_type.py
@@ -62,9 +62,43 @@ def test_subtype():
     t7 = rx.TupleType([t0, t1, t5])
     t8 = rx.TupleType([t1, t1, t5])
     t9 = rx.TupleType([t1, t3, t5])
+    t10 = rx.TupleType([t5, t3, t1])
+    t11 = rx.TupleType([t1, t3])
     assert is_base_of(t7, t8)
     assert is_base_of(t7, t9)
-    assert is_base_of(t7, t9)
+    assert is_base_of(t8, t9)
+    assert is_base_of(t9, t7) == False
+    assert is_base_of(t7, t10) == False
+    assert is_base_of(t11, t7) == False
+    assert is_base_of(t7, t11) == False
+
+    # FunctionType
+    t12 = rx.FuncType([t7], t0)
+    t13 = rx.FuncType([t7], t1)
+    t14 = rx.FuncType([t8], t0)
+    t15 = rx.FuncType([t8], t1)
+    t16 = rx.FuncType([t7, t0], t1)
+    t17 = rx.FuncType([t7, t4], t1)
+    assert is_base_of(t12, t13)
+    assert is_base_of(t12, t14)
+    assert is_base_of(t12, t15)
+    assert is_base_of(t13, t14) == False
+    assert is_base_of(t13, t15)
+    assert is_base_of(t14, t15)
+    assert is_base_of(t16, t17)
+    assert is_base_of(t12, t16) == False
+    assert is_base_of(t13, t16) == False
+
+    # ObjectType
+    t18 = rx.ObjectType()
+    assert is_base_of(t18, t0)
+    assert is_base_of(t18, t5)
+    assert is_base_of(t18, t7)
+    assert is_base_of(t18, t12)
+    assert is_base_of(t0, t18) == False
+    assert is_base_of(t5, t18) == False
+    assert is_base_of(t7, t18) == False
+    assert is_base_of(t12, t18) == False
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_type.py
+++ b/tests/python/relax/test_type.py
@@ -51,12 +51,16 @@ def test_subtype():
     assert is_base_of(t1, t2)
     assert is_base_of(t1, t3)
     assert is_base_of(t4, t3)
+    # a type is subtype of itself
+    assert is_base_of(t2, t2)
+    assert is_base_of(t3, t3)
     assert is_base_of(t2, t3) == False
     assert is_base_of(t3, t2) == False
 
     # check the subtype relation for ShapeType
     t5 = rx.ShapeType()
     t6 = rx.ShapeType()
+    assert is_base_of(t5, t5)
     assert is_base_of(t5, t6)
     assert is_base_of(t5, t0) == False
 
@@ -72,6 +76,7 @@ def test_subtype():
     assert is_base_of(t7, t8)
     assert is_base_of(t7, t9)
     assert is_base_of(t8, t9)
+    assert is_base_of(t8, t8)
     assert is_base_of(t9, t7) == False
     assert is_base_of(t7, t10) == False
     assert is_base_of(t11, t7) == False
@@ -89,10 +94,12 @@ def test_subtype():
     assert is_base_of(t12, t13)
     assert is_base_of(t12, t14)
     assert is_base_of(t12, t15)
+    assert is_base_of(t12, t12)
     assert is_base_of(t13, t14) == False
     assert is_base_of(t13, t15)
     assert is_base_of(t14, t15)
     assert is_base_of(t16, t17)
+    assert is_base_of(t16, t16)
     assert is_base_of(t12, t16) == False
     assert is_base_of(t13, t16) == False
 
@@ -103,6 +110,7 @@ def test_subtype():
     assert is_base_of(t18, t5)
     assert is_base_of(t18, t7)
     assert is_base_of(t18, t12)
+    assert is_base_of(t18, t18)
     assert is_base_of(t0, t18) == False
     assert is_base_of(t5, t18) == False
     assert is_base_of(t7, t18) == False

--- a/tests/python/relax/test_type.py
+++ b/tests/python/relax/test_type.py
@@ -36,7 +36,9 @@ def test_dyn_tensor_type():
 
 
 def test_subtype():
-    # DynTensorType
+    # check the subtype relation for DynTensorType
+    # e.g., DynTensorType(ndim=3, dtype="float32") is a subtype of DynTensorType(ndim=-1, dtype="float32")
+    # and DynTensorType(ndim=-1, "float32") is a subtype of DynTensorType(ndim=-1, dtype=None)
     t0 = rx.DynTensorType(-1, None)
     t1 = rx.DynTensorType(3, None)
     t2 = rx.DynTensorType(3, "int32")
@@ -52,13 +54,16 @@ def test_subtype():
     assert is_base_of(t2, t3) == False
     assert is_base_of(t3, t2) == False
 
-    # ShapeType
+    # check the subtype relation for ShapeType
     t5 = rx.ShapeType()
     t6 = rx.ShapeType()
     assert is_base_of(t5, t6)
     assert is_base_of(t5, t0) == False
 
-    # TupleType
+    # check the subtype relation for TupleType by checking if each field
+    # of the base TupleType is subtype of the field of the derived TupleType
+    # e.g., TupleType([DynTensorType(ndim=3, dtype="float32"), ShapeType()])
+    # is a subtype of TupleType([DynTensorType(ndim=-1, dtype="float32"), ShapeType()])
     t7 = rx.TupleType([t0, t1, t5])
     t8 = rx.TupleType([t1, t1, t5])
     t9 = rx.TupleType([t1, t3, t5])
@@ -72,7 +77,9 @@ def test_subtype():
     assert is_base_of(t11, t7) == False
     assert is_base_of(t7, t11) == False
 
-    # FunctionType
+    # check the subtype relation for FunctionType by checking the subtype relations of arg_types and ret_type
+    # e.g., FuncType([DynTensorType(ndim=3, dtype="float32")], DynTensorType(ndim=2, dtype="float32"))
+    # is a subtype of FuncType([DynTensorType(ndim=-1, dtype=None)], DynTensorType(ndim=-1, dtype="float32"))
     t12 = rx.FuncType([t7], t0)
     t13 = rx.FuncType([t7], t1)
     t14 = rx.FuncType([t8], t0)
@@ -89,7 +96,8 @@ def test_subtype():
     assert is_base_of(t12, t16) == False
     assert is_base_of(t13, t16) == False
 
-    # ObjectType
+    # check the subtype relation for ObjectType
+    # ObjectType is the base type of every type in Relax
     t18 = rx.ObjectType()
     assert is_base_of(t18, t0)
     assert is_base_of(t18, t5)

--- a/tests/python/relax/test_type.py
+++ b/tests/python/relax/test_type.py
@@ -116,6 +116,34 @@ def test_subtype():
     assert is_base_of(t7, t18) == False
     assert is_base_of(t12, t18) == False
 
+    # more complicated cases
+    # TupleType with all possible types as fields
+    t19 = rx.TupleType([t7, t0, t5, t12, t18])
+    t20 = rx.TupleType([t8, t1, t5, t15, t18])
+    t21 = rx.TupleType([t18, t18, t18, t18, t18])
+    assert is_base_of(t19, t20)
+    assert is_base_of(t21, t19)
+    assert is_base_of(t21, t20)
+    assert is_base_of(t20, t19) == False
+    assert is_base_of(t18, t20)
+    # FuncType with all possible types as arg_types and ret_type
+    t22 = rx.FuncType([t7, t0, t5, t12, t18], t0)
+    t23 = rx.FuncType([t8, t1, t5, t15, t18], t1)
+    t24 = rx.FuncType([t7], t0)
+    t25 = rx.FuncType([t18, t18, t18, t18, t18], t18)
+    t26 = rx.FuncType([t18], t18)
+    t27 = rx.FuncType([t7, t0, t5, t12, t18], t19)
+    t28 = rx.FuncType([t7, t0, t5, t12, t18], t20)
+    assert is_base_of(t22, t23)
+    assert is_base_of(t25, t23)
+    assert is_base_of(t18, t23)
+    assert is_base_of(t18, t22)
+    assert is_base_of(t27, t28)
+    assert is_base_of(t24, t22) == False
+    assert is_base_of(t24, t23) == False
+    assert is_base_of(t26, t23) == False
+    assert is_base_of(t28, t27) == False
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This PR refactors the following parts:
- Generic dispatching for `IsBaseOf`: `IsBaseOf` uses a bunch of if-else to check if the subtype relation between the base type and derived type, now it's changed to use a generic TypeFunctor to dispatch on the base class to do the check.
- Simplify Type/Expr initializations: We had to write `RuntimeDepShape(Span()`), `ObjectType(Span())` to initialize several Types and Exprs, this is due to the `TVM_DEFINE_OBJECT_REF_METHODS` macro that sets the constructor with `= default`. By changing to use `TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS`, we can now just write `RuntimeDepShape()` without specifying an empty span.
- `relax` -> `R` in printer: Change to print `R` rather than `relax` in TVMScript as the default behavior. This is consistent with our test cases and TIR convention: using `T` as shorthand.
- Disallow generating code for local function in VMCodegen: these local functions should have been lifted in the lambda lifting pass before codegen.