### PR TITLE
[Printer] Enable R.parser.pretty_print to print TIR PrimFunc

### DIFF
--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -44,6 +44,8 @@ Doc RelaxScriptPrinter::Print(const ObjectRef& node) {
     return VisitType(Downcast<Type>(node));
   } else if (node->IsInstance<PrimExprNode>()) {
     return VisitExpr(Downcast<PrimExpr>(node));
+  } else if (node->IsInstance<tir::PrimFuncNode>()) {
+    return tir::AsTVMScriptDoc(Downcast<tir::PrimFunc>(node));
   } else {
     return VisitNode(node);
   }
@@ -652,7 +654,8 @@ Doc RelaxScriptPrinter::GetUniqueName(std::string prefix, std::string fallback =
 bool RelaxScriptPrinter::ShowMetaData() { return show_meta_data_; }
 
 String AsRelaxScript(const ObjectRef& mod, bool show_meta_data) {
-  ICHECK(mod->IsInstance<relax::FunctionNode>() || mod->IsInstance<IRModuleNode>());
+  ICHECK(mod->IsInstance<IRModuleNode>() || mod->IsInstance<relax::FunctionNode>() ||
+         mod->IsInstance<tir::PrimFuncNode>());
   Doc doc;
   runtime::TypedPackedFunc<std::string(ObjectRef)> ftyped = nullptr;
   doc << TextPrinter(show_meta_data, ftyped).PrintRelax(mod);

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -770,6 +770,9 @@ def test_class_irmodule():
     assert isinstance(my_module, tvm.IRModule)
 
     R.parser.pretty_print(my_module)
+    # check that we can print TIR and Relax functions too using the same api.
+    R.parser.pretty_print(my_module["my_matmul"])
+    R.parser.pretty_print(my_module["f"])
 
     var_f = my_module.get_global_var("f")
     var_g = my_module.get_global_var("g")


### PR DESCRIPTION
Enable `R.parser.pretty_print` to print TensorIR functions. This way we can have a uniform API to print IRModule, TensorIR
function and Relax functions.