### PR TITLE
[VM] Deprecate API to save/load executable to file

### DIFF
--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -67,7 +67,6 @@ FuncType = ty.FuncType
 # VM
 ExecBuilder = exec_builder.ExecBuilder
 VirtualMachine = vm.VirtualMachine
-load_exec_from_file = vm.load_exec_from_file
 
 # Operator
 from .op.base import call_tir, make_closure, invoke_closure

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -37,17 +37,12 @@ class Executable(object):
     def __init__(self, mod: Module):
         self.mod = mod
         self._stats = self.mod["stats"]
-        self._save_to_file = self.mod["save_to_file"]
         self._as_text = self.mod["as_text"]
         self._as_python = self.mod["as_python"]
 
     def stats(self) -> str:
         """print the detailed statistics of the executable."""
         return self._stats()
-
-    def save_to_file(self, path: str) -> None:
-        """serialize and write the executable to a file."""
-        self._save_to_file(path)
 
     def as_text(self) -> str:
         """print the instructions as text format."""
@@ -56,10 +51,6 @@ class Executable(object):
     def as_python(self) -> str:
         """print the instructions as python program."""
         return self._as_python()
-
-
-def load_exec_from_file(path: str) -> Executable:
-    return Executable(_ffi_api.ExecutableLoadFromFile(path))
 
 
 class VirtualMachine(object):

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -63,12 +63,6 @@ VMClosure::VMClosure(String func_name, Array<ObjectRef> free_vars) {
 PackedFunc Executable::GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) {
   if (name == "stats") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->Stats(); });
-  } else if (name == "save_to_file") {
-    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
-      CHECK_EQ(args.size(), 1);
-      std::string path = args[0];
-      this->SaveToFile(path, "");
-    });
   } else if (name == "as_text") {
     return PackedFunc(
         [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->AsText(); });

--- a/tests/python/relax/test_transform_codegen_pass.py
+++ b/tests/python/relax/test_transform_codegen_pass.py
@@ -50,11 +50,11 @@ def check_executable(exec, dev, inputs, expected):
 
 # TODO(sunggg): Serialize TRT runtime module. This might be helpful: `module.export_library(file_name)``
 def check_roundtrip(exec0, dev, inputs, expected):
-    exec0.save_to_file("exec.tmp")
-    exec1 = relax.load_exec_from_file("exec.tmp")
+    exec0.mod.export_library("exec.so")
+    exec1 = relax.vm.Executable(tvm.runtime.load_module("exec.so"))
+    os.remove("exec.so")
     assert exec0.stats() == exec1.stats()
     assert exec0.as_text() == exec1.as_text()
-    os.remove("exec.tmp")
 
     check_executable(exec0, dev, inputs, expected)
     check_executable(exec1, dev, inputs, expected)


### PR DESCRIPTION
Executable `save_to_file` and `load_exec_from_file` API was used to save/load just the executable to/from file. This was confusing as it did not export the TensorIR kernels in the Relax Module, thus leading to bugs such as https://github.com/tlc-pack/relax/issues/175. Moreover, the API was only used in some tests, and not useful for end
user.

Deprecating this API to have a single uniform way of serializing/deserializing TVM IRModule using `export_library` and `tvm.runtime.load_module` API.