### PR TITLE
[Fix] fix print twice issue

### DIFF
--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -1711,8 +1711,8 @@ def from_source(
         )
     elif inspect.isfunction(input_func):
         env: Dict[str, Any] = input_func.__globals__
-        relax_prefix = [key for key in env.keys() if env[key] == relax_namespace]
-        tir_prefix = [key for key in env.keys() if env[key] == tir_namespace]
+        relax_prefix = [key for key in env.keys() if env[key] is relax_namespace]
+        tir_prefix = [key for key in env.keys() if env[key] is tir_namespace]
         return synr.to_ast(
             input_func, RelaxDiagnosticContext(mod), RelaxTransformer(mod, relax_prefix, tir_prefix)
         )


### PR DESCRIPTION
This PR fixes minor printer and parser issues.

Currently, the relax printer would print a PrimFunc twice with the same printer. That's would cause a renaming for tir func parameters. E.g the A_1 and B_1 in the following case:

```python
@tvm.script.ir_module
class Module:
    @tir.prim_func
    def main(A_1: tir.Buffer[8, "float32"], B_1: tir.Buffer[8, "float32"]) -> None:
        # function attr dict
        tir.func_attr({"global_symbol": "main", "tir.noalias": True})
        # body
        # with tir.block("root")
        for i in tir.serial(128):
            with tir.block("B"):
                vi = tir.axis.spatial(128, i)
                tir.reads(A_1[vi])
                tir.writes(B_1[vi])
                B_1[vi] = A_1[vi] + tir.float32(1)
```