### PR TITLE
[Fix] fix windows build issue

### DIFF
--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -145,7 +145,7 @@ class DimType : public Type {
  public:
   TVM_DLL DimType(Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(DimType, Type, DimTypeNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(DimType, Type, DimTypeNode);
 };
 
 /*!


### PR DESCRIPTION
`TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS` is needed when we have a default-like constructor (e.g. `(Span span = Span())`)