### PR TITLE
[Bugfix][VM] Ensure set_input works over RPC by not returning an array of argument names

### DIFF
--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -190,6 +190,13 @@ class VirtualMachine : public runtime::ModuleNode {
   void SetInputTensorWithIndex(std::vector<RegType>& func_args, const TVMArgValue& inp_tensor,
                                int index, Device dev);
 
+  /*!
+   * \brief Look up whether the VM has a function by the given name.
+   * \param func_name the function's name
+   * \return The function, if it exists. Logs a fatal error if not.
+   */
+  VMFunction LookupVMFunction(const std::string& func_name);
+
  private:
   /*! \brief The loaded executable. */
   ObjectPtr<Executable> exec_;

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -91,7 +91,8 @@ class VirtualMachine(object):
         )
         self._invoke_closure = self.module["invoke_closure"]
         self._set_input = self.module["set_input"]
-        self._get_func_param_names = self.module["get_func_param_names"]
+        self._get_function_arity = self.module["get_function_arity"]
+        self._get_function_param_name = self.module["get_function_param_name"]
         self._setup_device(device, memory_cfg)
 
     def _setup_device(self, dev: Device, memory_cfg: Union[str, Dict[Device, str]]) -> None:
@@ -208,7 +209,8 @@ class VirtualMachine(object):
         if kwargs:
             # kwargs can be a super set of the required function parameters.
             # We only find the ones that are needed.
-            func_params = list(self._get_func_param_names(func_name))
+            func_arity = self._get_function_arity(func_name)
+            func_params = [self._get_function_param_name(func_name, i) for i in range(func_arity)]
             new_args = [None] * len(func_params)
             cnt = 0
             for k in kwargs:

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -122,7 +122,7 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
       std::string func_name = args[0];
       int index = args[1];
       const VMFunction& vm_func = LookupVMFunction(func_name);
-      if (index >= vm_func.param_names.size()) {
+      if (static_cast<size_t>(index) >= vm_func.param_names.size()) {
         LOG(FATAL) << "ValueError: Invalid index for " << func_name << " (" << index << " out of "
                    << vm_func.param_names.size() << ")";
       }

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -40,6 +40,17 @@ inline TVMRetValue CopyConstantTo(TVMRetValue src, const DLDevice& dev) {
   return ret;
 }
 
+VMFunction VirtualMachine::LookupVMFunction(const std::string& func_name) {
+  const auto& m = this->exec_->global_map;
+  ICHECK(exec_) << "The executable is not created yet.";
+  if (m.find(func_name) != m.end()) {
+    Index gf_idx = m.at(func_name);
+    const VMFunction& vm_func = exec_->global_funcs[gf_idx];
+    return vm_func;
+  }
+  LOG(FATAL) << "ValueError: Unknown function: " << func_name;
+}
+
 PackedFunc VirtualMachine::GetFunction(const std::string& name,
                                        const ObjectPtr<Object>& sptr_to_self) {
   if (name == "vm_initialization") {
@@ -100,22 +111,22 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
   } else if (name == "set_input") {
     return PackedFunc(
         [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { SetInput(args[0], args, 1); });
-  } else if (name == "get_func_param_names") {
+  } else if (name == "get_function_arity") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       std::string func_name = args[0];
-      const auto& m = exec_->global_map;
-      ICHECK(exec_) << "The executable is not created yet.";
-      if (m.find(func_name) != m.end()) {
-        Index gf_idx = m.at(func_name);
-        const VMFunction& vm_func = exec_->global_funcs[gf_idx];
-        Array<String> param_names;
-        for (size_t i = 0; i < vm_func.param_names.size(); i++) {
-          param_names.push_back(vm_func.param_names[i]);
-        }
-        *rv = param_names;
-      } else {
-        LOG(FATAL) << "ValueError: Unknown function: " << func_name;
+      const VMFunction& vm_func = LookupVMFunction(func_name);
+      *rv = static_cast<int>(vm_func.param_names.size());
+    });
+  } else if (name == "get_function_param_name") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      std::string func_name = args[0];
+      int index = args[1];
+      const VMFunction& vm_func = LookupVMFunction(func_name);
+      if (index >= vm_func.param_names.size()) {
+        LOG(FATAL) << "ValueError: Invalid index for " << func_name << " (" << index << " out of "
+                   << vm_func.param_names.size() << ")";
       }
+      *rv = vm_func.param_names[index];
     });
   }
 

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -41,14 +41,14 @@ inline TVMRetValue CopyConstantTo(TVMRetValue src, const DLDevice& dev) {
 }
 
 VMFunction VirtualMachine::LookupVMFunction(const std::string& func_name) {
-  const auto& m = this->exec_->global_map;
   ICHECK(exec_) << "The executable is not created yet.";
-  if (m.find(func_name) != m.end()) {
-    Index gf_idx = m.at(func_name);
-    const VMFunction& vm_func = exec_->global_funcs[gf_idx];
-    return vm_func;
+  const auto& m = this->exec_->global_map;
+  if (m.find(func_name) == m.end()) {
+    LOG(FATAL) << "ValueError: Unknown function: " << func_name;
   }
-  LOG(FATAL) << "ValueError: Unknown function: " << func_name;
+  Index gf_idx = m.at(func_name);
+  const VMFunction& vm_func = exec_->global_funcs[gf_idx];
+  return vm_func;
 }
 
 PackedFunc VirtualMachine::GetFunction(const std::string& name,

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -932,7 +932,7 @@ class TestVMSetInput:
         return gv0
 
 
-def perform_set_input_trial(vm, device):
+def perform_set_input_trial(vm: relax.VirtualMachine, device: tvm.runtime.Device) -> None:
     a = tvm.nd.array(np.random.rand(32, 32).astype("float32"), device)
     b = tvm.nd.array(np.random.rand(32, 32).astype("float32"), device)
     vm.set_input("main", a, b)

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -22,7 +22,8 @@ import pytest
 import tvm
 import tvm.script
 import tvm.testing
-from tvm import relax, te, tir, topi, TVMError
+from tvm import relax, rpc, te, tir, topi, TVMError
+from tvm.contrib import utils
 from tvm.relax.testing import nn
 from tvm.script import relax as R, tir as T
 
@@ -906,24 +907,15 @@ def test_vm_invoke_closure():
     )
 
 
-def test_set_input():
-    @tvm.script.ir_module
-    class TestVMSetInput:
-        @R.function
-        def main(x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")) -> Tensor:
-            gv0 = relax.call_packed(
-                "test.vm.mul", x, w, type_args=(Tensor(ndim=2, dtype="float32"))
-            )
-            return gv0
+@tvm.script.ir_module
+class TestVMSetInput:
+    @R.function
+    def main(x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")) -> Tensor:
+        gv0 = relax.call_packed("test.vm.mul", x, w, type_args=(Tensor(ndim=2, dtype="float32")))
+        return gv0
 
-    target = tvm.target.Target("llvm", host="llvm")
-    exec = relax.vm.build(TestVMSetInput, target)
-    exec.mod.export_library("exec.so")
-    exec_loaded = relax.vm.Executable(tvm.runtime.load_module("exec.so"))
-    os.remove("exec.so")
-    print(exec_loaded.as_python())
-    vm = relax.VirtualMachine(exec_loaded, tvm.cpu())
 
+def perform_set_input_trial(vm):
     a = tvm.nd.array(np.random.rand(32, 32))
     b = tvm.nd.array(np.random.rand(32, 32))
     vm.set_input("main", a, b)
@@ -934,6 +926,45 @@ def test_set_input():
     res1 = vm["main"]()
     tvm.testing.assert_allclose(res0.numpy(), a.numpy() * b.numpy(), rtol=1e-7, atol=1e-7)
     tvm.testing.assert_allclose(res0.numpy(), res1.numpy(), rtol=1e-7, atol=1e-7)
+
+
+def test_set_input():
+    target = tvm.target.Target("llvm", host="llvm")
+    exec = relax.vm.build(TestVMSetInput, target)
+    exec.mod.export_library("exec.so")
+    exec_loaded = relax.vm.Executable(tvm.runtime.load_module("exec.so"))
+    os.remove("exec.so")
+    print(exec_loaded.as_python())
+    vm = relax.VirtualMachine(exec_loaded, tvm.cpu())
+
+    perform_set_input_trial(vm)
+
+
+def test_set_input_rpc():
+    target = tvm.target.Target("llvm", host="llvm")
+    exec = relax.vm.build(TestVMSetInput, target)
+    temp = utils.tempdir()
+    path = temp.relpath("vm_library.so")
+    exec.mod.export_library(path)
+
+    # Use local rpc server for testing.
+    # Server must use popen so it doesn't inherit the current process state. It
+    # will crash otherwise.
+    # Adapted from relay/test_vm.py
+    def check_remote(server):
+        remote = rpc.connect(server.host, server.port, session_timeout=10)
+
+        # Upload the serialized Executable.
+        remote.upload(path)
+        # Get a handle to remote Executable.
+        rexec = remote.load_module("vm_library.so")
+
+        device = remote.cpu()
+        # Build a VM out of the executable and context.
+        vm = relax.vm.VirtualMachine(exec=rexec, device=device)
+        perform_set_input_trial(vm)
+
+    check_remote(rpc.Server("127.0.0.1"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, attempting to use the VM's `set_input` method will fail over RPC because `set_input` calls `get_func_param_names`, which returns an array of parameter names. RPC does not support sending arrays. This PR corrects this issue by instead having `set_input` query the function arity and then query the argument names one by one, which is the approach taken by the Relay VM (accordingly, the names for the functions used to do this, `get_function_arity` and `get_function_param_name`, are taken from the Relay VM).

This PR also adds a unit test over RPC on localhost. Please review @YuchenJin; I also wonder if we should have more RPC unit tests in that file.