### PR TITLE
highlight tvm script with pygment on vscode dark theme

### DIFF
--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -72,6 +72,7 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
                 "scipy",
                 "synr",
                 "tornado",
+                "Pygments",
             ],
         ),
     ),

--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -64,6 +64,7 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
         (
             "Base requirements needed to install tvm",
             [
+                "Pygments",
                 "attrs",
                 "cloudpickle",
                 "decorator",
@@ -72,7 +73,6 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
                 "scipy",
                 "synr",
                 "tornado",
-                "Pygments",
             ],
         ),
     ),

--- a/python/tvm/ir/highlight.py
+++ b/python/tvm/ir/highlight.py
@@ -16,12 +16,16 @@
 # under the License.
 """Highlight printed TVM script.
 """
+import os
 
 from pygments import highlight as phl
 from pygments.lexers import Python3Lexer
 from pygments.formatters import Terminal256Formatter
 from pygments.style import Style
 from pygments.token import Keyword, Name, Comment, String, Number, Operator
+
+
+_SCRIPT_THEME = os.getenv("TVM_SCRIPT_THEME", default="LIGHT")
 
 
 class VSCDark(Style):
@@ -43,6 +47,26 @@ class VSCDark(Style):
     }
 
 
+class JupyterLight(Style):
+    """A Jupyter-Notebook-like Pygment style configuration"""
+
+    background_color = "#f8f8f8"
+    default_style = ""
+
+    styles = {
+        Keyword: "bold #008000",
+        Keyword.Type: "nobold #008000",
+        Name.Function: "#0000FF",
+        Name.Class: "bold #0000FF",
+        Name.Decorator: "#AA22FF",
+        String: "#BA2121",
+        Number: "#008000",
+        Operator: "bold #AA22FF",
+        Operator.Word: "bold #008000",
+        Comment: "italic #007979",
+    }
+
+
 def highlight(text: str) -> str:
     """
     Highlight given TVM script string with Pygment
@@ -57,4 +81,14 @@ def highlight(text: str) -> str:
     str
         The resulting string highlighted by ANSI escape code
     """
-    return phl(text, Python3Lexer(), Terminal256Formatter(style=VSCDark))
+    style = None
+    if _SCRIPT_THEME == "LIGHT":
+        style = JupyterLight
+    elif _SCRIPT_THEME == "DARK":
+        style = VSCDark
+    else:
+        raise ValueError(
+            f"Unknown theme environement variable: `{_SCRIPT_THEME}`."
+            " Set TVM_SCRIPT_THEME to LIGHT or DARK"
+        )
+    return phl(text, Python3Lexer(), Terminal256Formatter(style=style))

--- a/python/tvm/ir/highlight.py
+++ b/python/tvm/ir/highlight.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Highlight printed TVM script.
+"""
+
+from pygments import highlight as phl
+from pygments.lexers import Python3Lexer
+from pygments.formatters import Terminal256Formatter
+from pygments.style import Style
+from pygments.token import Keyword, Name, Comment, String, Number, Operator
+
+
+class VSCDark(Style):
+    """A VSCode-Dark-like Pygment style configuration"""
+
+    styles = {
+        Keyword: "bold #c586c0",
+        Keyword.Namespace: "#4ec9b0",
+        Keyword.Type: "#82aaff",
+        Name: "#9cdcfe",
+        Name.Function: "bold #dcdcaa",
+        Name.Class: "bold #569cd6",
+        Name.Decorator: "italic #fe4ef3",
+        String: "#ce9178",
+        Number: "#b5cea8",
+        Operator: "#bbbbbb",
+        Operator.Word: "#569cd6",
+        Comment: "italic #6a9956",
+    }
+
+
+def highlight(text: str) -> str:
+    """
+    Highlight given TVM script string with Pygment
+
+    Parameters
+    ----------
+    text : str
+        String of the TVM script
+
+    Returns
+    -------
+    str
+        The resulting string highlighted by ANSI escape code
+    """
+    return phl(text, Python3Lexer(), Terminal256Formatter(style=VSCDark))

--- a/python/tvm/ir/highlight.py
+++ b/python/tvm/ir/highlight.py
@@ -69,7 +69,7 @@ class JupyterLight(Style):
 
 def highlight(text: str) -> str:
     """
-    Highlight given TVM script string with Pygment
+    Highlight given TVM script string with Pygments
 
     Parameters
     ----------

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -284,7 +284,9 @@ class IRModule(Node):
         script : str
             The TVM Script of the IRModule
         """
-        return tvm._ffi.get_global_func("script.AsTVMScript")(self, tir_prefix, show_meta)  # type: ignore
+        return tvm._ffi.get_global_func("script.AsTVMScript")(
+            self, tir_prefix, show_meta
+        )  # type: ignore
 
     def get_attr(self, attr_key):
         """Get the IRModule attribute.

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -288,6 +288,20 @@ class IRModule(Node):
             self, tir_prefix, show_meta
         )  # type: ignore
 
+    def show(self, style: str = "light") -> None:
+        """
+        A sugar for print highlighted TVM script.
+
+        Parameters
+        ----------
+        style : str, optional
+            Pygements styles extended by "light" (default) and "dark", by default "light"
+        """
+        from tvm.script.highlight import cprint  # pylint: disable=import-outside-toplevel
+
+        # Use deferred import to avoid circular import while keeping cprint under tvm/script
+        cprint(self, style=style)
+
     def get_attr(self, attr_key):
         """Get the IRModule attribute.
 

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -22,6 +22,7 @@ import tvm._ffi
 from .base import Node
 from . import expr as _expr
 from ..ir.function import BaseFunc
+from .highlight import highlight
 from . import type as _ty
 from . import _ffi_api
 
@@ -284,8 +285,8 @@ class IRModule(Node):
         script : str
             The TVM Script of the IRModule
         """
-        return tvm._ffi.get_global_func("script.AsTVMScript")(
-            self, tir_prefix, show_meta
+        return highlight(
+            tvm._ffi.get_global_func("script.AsTVMScript")(self, tir_prefix, show_meta)
         )  # type: ignore
 
     def get_attr(self, attr_key):

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -295,7 +295,7 @@ class IRModule(Node):
         Parameters
         ----------
         style : str, optional
-            Pygements styles extended by "light" (default) and "dark", by default "light"
+            Pygments styles extended by "light" (default) and "dark", by default "light"
         """
         from tvm.script.highlight import cprint  # pylint: disable=import-outside-toplevel
 

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -22,7 +22,6 @@ import tvm._ffi
 from .base import Node
 from . import expr as _expr
 from ..ir.function import BaseFunc
-from .highlight import highlight
 from . import type as _ty
 from . import _ffi_api
 
@@ -285,9 +284,7 @@ class IRModule(Node):
         script : str
             The TVM Script of the IRModule
         """
-        return highlight(
-            tvm._ffi.get_global_func("script.AsTVMScript")(self, tir_prefix, show_meta)
-        )  # type: ignore
+        return tvm._ffi.get_global_func("script.AsTVMScript")(self, tir_prefix, show_meta)  # type: ignore
 
     def get_attr(self, attr_key):
         """Get the IRModule attribute.

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -245,7 +245,7 @@ class Function(BaseFunc):
         Parameters
         ----------
         style : str, optional
-            Pygements styles extended by "light" (default) and "dark", by default "light"
+            Pygments styles extended by "light" (default) and "dark", by default "light"
         """
         from tvm.script.highlight import cprint  # pylint: disable=import-outside-toplevel
 

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -223,6 +223,35 @@ class Function(BaseFunc):
         """
         return Call(self, args, None, None)
 
+    def script(self, show_meta: bool = False) -> str:
+        """Print relax.Function into TVMScript
+
+        Parameters
+        ----------
+        show_meta : bool
+            Whether to show meta information
+
+        Returns
+        -------
+        script : str
+            The TVM Script of the relax.Function
+        """
+        return tvm._ffi.get_global_func("script.AsRelaxScript")(self, show_meta)  # type: ignore
+
+    def show(self, style: str = "light") -> None:
+        """
+        A sugar for print highlighted TVM script.
+
+        Parameters
+        ----------
+        style : str, optional
+            Pygements styles extended by "light" (default) and "dark", by default "light"
+        """
+        from tvm.script.highlight import cprint  # pylint: disable=import-outside-toplevel
+
+        # Use deferred import to avoid circular import while keeping cprint under tvm/script
+        cprint(self, style=style)
+
 
 @tvm._ffi.register_object("relax.expr.ExternFunc")
 class ExternFunc(BaseFunc):

--- a/python/tvm/script/highlight.py
+++ b/python/tvm/script/highlight.py
@@ -16,16 +16,17 @@
 # under the License.
 """Highlight printed TVM script.
 """
-import os
 
-from pygments import highlight as phl
+from typing import Union
+
+from pygments import highlight
 from pygments.lexers import Python3Lexer
 from pygments.formatters import Terminal256Formatter
 from pygments.style import Style
 from pygments.token import Keyword, Name, Comment, String, Number, Operator
 
-
-_SCRIPT_THEME = os.getenv("TVM_SCRIPT_THEME", default="LIGHT")
+from tvm.ir import IRModule
+from tvm.tir import PrimFunc
 
 
 class VSCDark(Style):
@@ -35,7 +36,6 @@ class VSCDark(Style):
         Keyword: "bold #c586c0",
         Keyword.Namespace: "#4ec9b0",
         Keyword.Type: "#82aaff",
-        Name: "#9cdcfe",
         Name.Function: "bold #dcdcaa",
         Name.Class: "bold #569cd6",
         Name.Decorator: "italic #fe4ef3",
@@ -49,9 +49,6 @@ class VSCDark(Style):
 
 class JupyterLight(Style):
     """A Jupyter-Notebook-like Pygment style configuration"""
-
-    background_color = "#f8f8f8"
-    default_style = ""
 
     styles = {
         Keyword: "bold #008000",
@@ -67,28 +64,24 @@ class JupyterLight(Style):
     }
 
 
-def highlight(text: str) -> str:
+def cprint(printable: Union[IRModule, PrimFunc], style="light") -> str:
     """
-    Highlight given TVM script string with Pygments
+    Print highlighted TVM script string with Pygments
 
     Parameters
     ----------
-    text : str
-        String of the TVM script
+    printable : Union[IRModule, PrimFunc]
+        The TVM script to be printed
+    style : str, optional
+        Style of the printed script
 
-    Returns
-    -------
-    str
-        The resulting string highlighted by ANSI escape code
+    Notes
+    -----
+    The style parameter follows the Pygments style names or Style objects. Two
+    built-in styles are extended: "light" (default) and "dark".
     """
-    style = None
-    if _SCRIPT_THEME == "LIGHT":
+    if style == "light":
         style = JupyterLight
-    elif _SCRIPT_THEME == "DARK":
+    elif style == "dark":
         style = VSCDark
-    else:
-        raise ValueError(
-            f"Unknown theme environement variable: `{_SCRIPT_THEME}`."
-            " Set TVM_SCRIPT_THEME to LIGHT or DARK"
-        )
-    return phl(text, Python3Lexer(), Terminal256Formatter(style=style))
+    print(highlight(printable.script(), Python3Lexer(), Terminal256Formatter(style=style)))

--- a/python/tvm/script/highlight.py
+++ b/python/tvm/script/highlight.py
@@ -30,7 +30,7 @@ from tvm.tir import PrimFunc
 
 
 class VSCDark(Style):
-    """A VSCode-Dark-like Pygment style configuration"""
+    """A VSCode-Dark-like Pygments style configuration"""
 
     styles = {
         Keyword: "bold #c586c0",
@@ -48,7 +48,7 @@ class VSCDark(Style):
 
 
 class JupyterLight(Style):
-    """A Jupyter-Notebook-like Pygment style configuration"""
+    """A Jupyter-Notebook-like Pygments style configuration"""
 
     styles = {
         Keyword: "bold #008000",
@@ -64,7 +64,7 @@ class JupyterLight(Style):
     }
 
 
-def cprint(printable: Union[IRModule, PrimFunc], style="light") -> str:
+def cprint(printable: Union[IRModule, PrimFunc], style="light") -> None:
     """
     Print highlighted TVM script string with Pygments
 
@@ -78,7 +78,8 @@ def cprint(printable: Union[IRModule, PrimFunc], style="light") -> str:
     Notes
     -----
     The style parameter follows the Pygments style names or Style objects. Two
-    built-in styles are extended: "light" (default) and "dark".
+    built-in styles are extended: "light" (default) and "dark". Other styles
+    can be found in https://pygments.org/styles/
     """
     if style == "light":
         style = JupyterLight

--- a/python/tvm/tir/function.py
+++ b/python/tvm/tir/function.py
@@ -25,6 +25,7 @@ import tvm._ffi
 import tvm.runtime
 from tvm.runtime import Object
 from tvm.ir import BaseFunc, Range
+from tvm.ir.highlight import highlight
 from .buffer import Buffer
 from .expr import Var, PrimExpr
 from . import _ffi_api
@@ -191,8 +192,8 @@ class PrimFunc(BaseFunc):
         script : str
             The TVM Script of the PrimFunc
         """
-        return tvm._ffi.get_global_func("script.AsTVMScript")(
-            self, tir_prefix, show_meta
+        return highlight(
+            tvm._ffi.get_global_func("script.AsTVMScript")(self, tir_prefix, show_meta)
         )  # type: ignore
 
 

--- a/python/tvm/tir/function.py
+++ b/python/tvm/tir/function.py
@@ -195,6 +195,20 @@ class PrimFunc(BaseFunc):
             self, tir_prefix, show_meta
         )  # type: ignore
 
+    def show(self, style: str = "light") -> None:
+        """
+        A sugar for print highlighted TVM script.
+
+        Parameters
+        ----------
+        style : str, optional
+            Pygements styles extended by "light" (default) and "dark", by default "light"
+        """
+        from tvm.script.highlight import cprint  # pylint: disable=import-outside-toplevel
+
+        # Use deferred import to avoid circular import while keeping cprint under tvm/script
+        cprint(self, style=style)
+
 
 @tvm._ffi.register_object("tir.TensorIntrin")
 class TensorIntrin(Object):

--- a/python/tvm/tir/function.py
+++ b/python/tvm/tir/function.py
@@ -25,7 +25,6 @@ import tvm._ffi
 import tvm.runtime
 from tvm.runtime import Object
 from tvm.ir import BaseFunc, Range
-from tvm.ir.highlight import highlight
 from .buffer import Buffer
 from .expr import Var, PrimExpr
 from . import _ffi_api
@@ -192,9 +191,7 @@ class PrimFunc(BaseFunc):
         script : str
             The TVM Script of the PrimFunc
         """
-        return highlight(
-            tvm._ffi.get_global_func("script.AsTVMScript")(self, tir_prefix, show_meta)
-        )  # type: ignore
+        return tvm._ffi.get_global_func("script.AsTVMScript")(self, tir_prefix, show_meta)  # type: ignore
 
 
 @tvm._ffi.register_object("tir.TensorIntrin")

--- a/python/tvm/tir/function.py
+++ b/python/tvm/tir/function.py
@@ -191,7 +191,9 @@ class PrimFunc(BaseFunc):
         script : str
             The TVM Script of the PrimFunc
         """
-        return tvm._ffi.get_global_func("script.AsTVMScript")(self, tir_prefix, show_meta)  # type: ignore
+        return tvm._ffi.get_global_func("script.AsTVMScript")(
+            self, tir_prefix, show_meta
+        )  # type: ignore
 
 
 @tvm._ffi.register_object("tir.TensorIntrin")

--- a/python/tvm/tir/function.py
+++ b/python/tvm/tir/function.py
@@ -202,7 +202,7 @@ class PrimFunc(BaseFunc):
         Parameters
         ----------
         style : str, optional
-            Pygements styles extended by "light" (default) and "dark", by default "light"
+            Pygments styles extended by "light" (default) and "dark", by default "light"
         """
         from tvm.script.highlight import cprint  # pylint: disable=import-outside-toplevel
 


### PR DESCRIPTION
## Demos

```python
@tvm.script.ir_module
class BatchMatmulModule:
    @T.prim_func
    def main(  # type: ignore
        a: T.handle,
        b: T.handle,
        c: T.handle,
    ) -> None:  # pylint: disable=no-self-argument
        T.func_attr({"global_symbol": "main", "tir.noalias": True})
        A = T.match_buffer(a, [16, 128, 128])
        B = T.match_buffer(b, [16, 128, 128])
        C = T.match_buffer(c, [16, 128, 128])
        for n, i, j, k in T.grid(16, 128, 128, 128):
            with T.block("matmul"):
                vn, vi, vj, vk = T.axis.remap("SSSR", [n, i, j, k])
                with T.init():
                    C[vn, vi, vj] = 0.0  # type: ignore
                C[vn, vi, vj] = C[vn, vi, vj] + A[vn, vi, vk] * B[vn, vj, vk]
```

<img width="1214" alt="Screen Shot 2022-07-23 at 3 15 37 AM" src="https://user-images.githubusercontent.com/38074777/180597179-094043ba-a681-4faf-9912-79b1c477bc50.png">

```python
@tvm.script.ir_module
class Module:
    @T.prim_func
    def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
        T.func_attr({"global_symbol": "tir_matmul"})
        k = T.var("int32")
        A = T.match_buffer(x, (32, 32))
        B = T.match_buffer(y, (32, 32))
        C = T.match_buffer(z, (32, 32))

        for (i0, j0, k0) in T.grid(32, 32, 32):
            with T.block():
                i, j, k = T.axis.remap("SSR", [i0, j0, k0])
                with T.init():
                    C[i, j] = 0.0
                C[i, j] += A[i, k] * B[j, k]

    @T.prim_func
    def tir_relu(x: T.handle, y: T.handle):
        T.func_attr({"global_symbol": "tir_relu"})
        A = T.match_buffer(x, (32, 32))
        B = T.match_buffer(y, (32, 32))
        for (i, j) in T.grid(32, 32):
            with T.block():
                vi, vj = T.axis.remap("SS", [i, j])
                B[vi, vj] = T.max(A[vi, vj], 0.0)

    @R.function
    def main(x: Tensor((32, 32), "float32"), w: Tensor((32, 32), "float32")) -> Tensor:
        with R.dataflow():
            lv0 = R.call_tir(tir_matmul, (x, w), (32, 32), dtype="float32")
            lv1 = R.call_tir(tir_relu, (lv0), (32, 32), dtype="float32")
            R.output(lv1)
        return lv1
```

<img width="1186" alt="Screen Shot 2022-07-23 at 3 14 45 AM" src="https://user-images.githubusercontent.com/38074777/180597186-667e3e03-b77d-48cb-89d5-f665432ea886.png">

## Limitation

There are a few things we can improve:

1. Pygment can only do simple token-level highlighting.  For example, vscode's dark+ theme highlights (consecutive) brackets of different depths with different colors. As another example, the tokenizer does not know if "tir_relu" is just a data variable or a function (we should highlight it as a function).
2. Later we can use [`DiffLexer`](https://pygments.org/docs/lexers/#pygments.lexers.diff.DiffLexer) to tokenize and highlight TVM-only keywords such as the "Tensor" typing.

cc: @tqchen @YuchenJin @junrushao1994 
