### PR TITLE
[Example][UX] Make the RPC timeout configurable in the `e2e_auto_tir` example

### DIFF
--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -78,6 +78,11 @@ def _parse_args():
         type=str,
         default=None,
     )
+    args.add_argument(
+        "--rpc-timeout",
+        type=int,
+        default=180
+    )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)
     parsed.input_shape = json.loads(parsed.input_shape)
@@ -90,7 +95,7 @@ def _parse_args():
             tracker_host=parsed.rpc_host,
             tracker_port=parsed.rpc_port,
             tracker_key=parsed.rpc_key,
-            session_timeout_sec=180,
+            session_timeout_sec=parsed.rpc_timeout,
         )
         parsed.workers = parsed.rpc_config.count_num_servers(allow_missing=False)
     else:

--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -79,7 +79,7 @@ def _parse_args():
         default=None,
     )
     args.add_argument(
-        "--rpc-timeout",
+        "--rpc-timeout-sec",
         type=int,
         default=180,
     )
@@ -95,7 +95,7 @@ def _parse_args():
             tracker_host=parsed.rpc_host,
             tracker_port=parsed.rpc_port,
             tracker_key=parsed.rpc_key,
-            session_timeout_sec=parsed.rpc_timeout,
+            session_timeout_sec=parsed.rpc_timeout_sec,
         )
         parsed.workers = parsed.rpc_config.count_num_servers(allow_missing=False)
     else:

--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -81,7 +81,7 @@ def _parse_args():
     args.add_argument(
         "--rpc-timeout",
         type=int,
-        default=180
+        default=180,
     )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)

--- a/tests/python/integration/test_relax_rpc_tuning.py
+++ b/tests/python/integration/test_relax_rpc_tuning.py
@@ -35,10 +35,13 @@ def test_relax_auto_tir_e2e_rpc():
     rpc_key = "Test1"
     rpc_port = 5555
 
-    Tracker(host=rpc_host, port=rpc_port)
+    # if we don't bind tracker and server to variables, they are deleted and closed
+    tracker = Tracker(host=rpc_host, port=rpc_port)  # pylint: disable=unused-variable
     # nasty hack: avoid race conditions if the server starts before the tracker
     time.sleep(1)
-    rpc.Server(host=rpc_host, key=rpc_key, tracker_addr=(rpc_host, rpc_port))
+    server = rpc.Server(
+        host=rpc_host, key=rpc_key, tracker_addr=(rpc_host, rpc_port)
+    )  # pylint: disable=unused-variable
     # also prevent the query process from firing before the server connects
     time.sleep(1)
 

--- a/tests/python/integration/test_relax_rpc_tuning.py
+++ b/tests/python/integration/test_relax_rpc_tuning.py
@@ -39,9 +39,9 @@ def test_relax_auto_tir_e2e_rpc():
     tracker = Tracker(host=rpc_host, port=rpc_port)  # pylint: disable=unused-variable
     # nasty hack: avoid race conditions if the server starts before the tracker
     time.sleep(1)
-    server = rpc.Server(
+    server = rpc.Server(  # pylint: disable=unused-variable
         host=rpc_host, key=rpc_key, tracker_addr=(rpc_host, rpc_port)
-    )  # pylint: disable=unused-variable
+    )
     # also prevent the query process from firing before the server connects
     time.sleep(1)
 

--- a/tests/python/integration/test_relax_rpc_tuning.py
+++ b/tests/python/integration/test_relax_rpc_tuning.py
@@ -91,7 +91,7 @@ def test_relax_auto_tir_e2e_rpc():
             "--work-dir",
             tuning_dir.path,
             # this can take several minutes and the default timeout is seldom enough
-            "--rpc-timeout",
+            "--rpc-timeout-sec",
             "600",
         ],
         check=False,

--- a/tests/python/integration/test_relax_rpc_tuning.py
+++ b/tests/python/integration/test_relax_rpc_tuning.py
@@ -35,10 +35,10 @@ def test_relax_auto_tir_e2e_rpc():
     rpc_key = "Test1"
     rpc_port = 5555
 
-    tracker = Tracker(host=rpc_host, port=rpc_port)
+    Tracker(host=rpc_host, port=rpc_port)
     # nasty hack: avoid race conditions if the server starts before the tracker
     time.sleep(1)
-    server = rpc.Server(host=rpc_host, key=rpc_key, tracker_addr=(rpc_host, rpc_port))
+    rpc.Server(host=rpc_host, key=rpc_key, tracker_addr=(rpc_host, rpc_port))
     # also prevent the query process from firing before the server connects
     time.sleep(1)
 

--- a/tests/python/integration/test_relax_rpc_tuning.py
+++ b/tests/python/integration/test_relax_rpc_tuning.py
@@ -20,6 +20,8 @@ import subprocess
 import time
 
 import tvm
+from tvm import rpc
+from tvm.rpc.tracker import Tracker
 from tvm.contrib import utils
 import tvm.testing
 
@@ -31,95 +33,69 @@ def test_relax_auto_tir_e2e_rpc():
     """
     rpc_host = "127.0.0.1"
     rpc_key = "Test1"
-    rpc_port = "5555"
+    rpc_port = 5555
+
+    tracker = Tracker(host=rpc_host, port=rpc_port)
+    # nasty hack: avoid race conditions if the server starts before the tracker
+    time.sleep(1)
+    server = rpc.Server(host=rpc_host, key=rpc_key, tracker_addr=(rpc_host, rpc_port))
+    # also prevent the query process from firing before the server connects
+    time.sleep(1)
+
+    # Timeout is set to 5 because the script tries again every 5s if it fails;
+    # we will only permit it one try.
+    # (We could use `rpc.connect_tracker` directly but that doesn't have a timeout.)
+    check = subprocess.run(
+        [
+            "python3",
+            "-m",
+            "tvm.exec.query_rpc_tracker",
+            "--host",
+            rpc_host,
+            "--port",
+            str(rpc_port),
+        ],
+        check=True,
+        timeout=5,
+        capture_output=True,
+    )
+    # if the key isn't in the printed message, then they didn't connect
+    check_output = str(check.stdout)
+    assert "Test1" in check_output, check_output
 
     tuning_dir = utils.tempdir()
-
-    try:
-        tracker_proc = subprocess.Popen(
-            [
-                "python3",
-                "-m",
-                "tvm.exec.rpc_tracker",
-                "--host",
-                rpc_host,
-                "--port",
-                rpc_port,
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        # dirty hack, ensure that the tracker has time to start before starting the server
-        time.sleep(1)
-        server_proc = subprocess.Popen(
-            [
-                "python3",
-                "-m",
-                "tvm.exec.rpc_server",
-                "--key",
-                rpc_key,
-                "--tracker",
-                f"{rpc_host}:{rpc_port}",
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        time.sleep(1)
-        # timeout is set to 5 because the script tries again every 5s if it fails;
-        # we will only permit it one try
-        check = subprocess.run(
-            [
-                "python3",
-                "-m",
-                "tvm.exec.query_rpc_tracker",
-                "--host",
-                rpc_host,
-                "--port",
-                rpc_port,
-            ],
-            check=True,
-            timeout=5,
-            capture_output=True,
-        )
-        # if the key isn't in the printed message, then they didn't connect
-        check_output = str(check.stdout)
-        assert "Test1" in check_output, check_output
-
-        run_script = subprocess.run(
-            [
-                "python3",
-                os.path.join(os.environ["TVM_HOME"], "apps", "relax_examples", "e2e_auto_tir.py"),
-                "--workload",
-                "resnet_50",
-                "--target",
-                # metascheduler requires specifying the number of cores;
-                # this uses 16 because that is what is used in the other tuning tests
-                "llvm -num-cores 16",
-                "--input-shape",
-                "[1, 3, 224, 224]",
-                # 0 trials so there is no tuning, just testing
-                "--num-trials",
-                "0",
-                "--rpc-host",
-                rpc_host,
-                "--rpc-port",
-                rpc_port,
-                "--rpc-key",
-                rpc_key,
-                "--work-dir",
-                tuning_dir.path,
-                # this can take several minutes and the default timeout is seldom enough
-                "--rpc-timeout",
-                "600",
-            ],
-            check=False,
-            capture_output=True,
-        )
-        # just checking that it completes successfully
-        assert run_script.returncode == 0, (run_script.stdout, run_script.stderr)
-    finally:
-        tracker_proc.terminate()
-        server_proc.terminate()
+    run_script = subprocess.run(
+        [
+            "python3",
+            os.path.join(os.environ["TVM_HOME"], "apps", "relax_examples", "e2e_auto_tir.py"),
+            "--workload",
+            "resnet_50",
+            "--target",
+            # metascheduler requires specifying the number of cores;
+            # this uses 16 because that is what is used in the other tuning tests
+            "llvm -num-cores 16",
+            "--input-shape",
+            "[1, 3, 224, 224]",
+            # 0 trials so there is no tuning, just testing
+            "--num-trials",
+            "0",
+            "--rpc-host",
+            rpc_host,
+            "--rpc-port",
+            str(rpc_port),
+            "--rpc-key",
+            rpc_key,
+            "--work-dir",
+            tuning_dir.path,
+            # this can take several minutes and the default timeout is seldom enough
+            "--rpc-timeout",
+            "600",
+        ],
+        check=False,
+        capture_output=True,
+    )
+    # just checking that it completes successfully
+    assert run_script.returncode == 0, (run_script.stdout, run_script.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/python/integration/test_relax_rpc_tuning.py
+++ b/tests/python/integration/test_relax_rpc_tuning.py
@@ -1,0 +1,123 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test tuning a model in Relax over RPC, end-to-end."""
+import pytest
+import os
+import subprocess
+import time
+
+import tvm
+from tvm.contrib import utils
+import tvm.testing
+
+
+@tvm.testing.slow
+def test_relax_auto_tir_e2e_rpc():
+    rpc_host = "127.0.0.1"
+    rpc_key = "Test1"
+    rpc_port = "5555"
+
+    tuning_dir = utils.tempdir()
+
+    try:
+        tracker_proc = subprocess.Popen(
+            [
+                "python3",
+                "-m",
+                "tvm.exec.rpc_tracker",
+                "--host",
+                rpc_host,
+                "--port",
+                rpc_port,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # dirty hack, ensure that the tracker has time to start before starting the server
+        time.sleep(1)
+        server_proc = subprocess.Popen(
+            [
+                "python3",
+                "-m",
+                "tvm.exec.rpc_server",
+                "--key",
+                rpc_key,
+                "--tracker",
+                f"{rpc_host}:{rpc_port}",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1)
+        # timeout is set to 5 because the script tries again every 5s if it fails;
+        # we will only permit it one try
+        check = subprocess.run(
+            [
+                "python3",
+                "-m",
+                "tvm.exec.query_rpc_tracker",
+                "--host",
+                rpc_host,
+                "--port",
+                rpc_port,
+            ],
+            check=True,
+            timeout=5,
+            capture_output=True,
+        )
+        # if the key isn't in the printed message, then they didn't connect
+        check_output = str(check.stdout)
+        assert "Test1" in check_output, check_output
+
+        run_script = subprocess.run(
+            [
+                "python3",
+                os.path.join(os.environ["TVM_HOME"], "apps", "relax_examples", "e2e_auto_tir.py"),
+                "--workload",
+                "resnet_50",
+                "--target",
+                # metascheduler requires specifying the number of cores;
+                # this uses 16 because that is what is used in the other tuning tests
+                "llvm -num-cores 16",
+                "--input-shape",
+                "[1, 3, 224, 224]",
+                # 0 trials so there is no tuning, just testing
+                "--num-trials",
+                "0",
+                "--rpc-host",
+                rpc_host,
+                "--rpc-port",
+                rpc_port,
+                "--rpc-key",
+                rpc_key,
+                "--work-dir",
+                tuning_dir.path,
+                # this can take several minutes and the default timeout is seldom enough
+                "--rpc-timeout",
+                "600",
+            ],
+            capture_output=True,
+        )
+        # just checking that it completes successfully
+        assert run_script.returncode == 0, (run_script.stdout, run_script.stderr)
+    finally:
+        tracker_proc.terminate()
+        server_proc.terminate()
+
+
+if __name__ == "__main__":
+    test_relax_auto_tir_e2e_rpc()

--- a/tests/python/integration/test_relax_rpc_tuning.py
+++ b/tests/python/integration/test_relax_rpc_tuning.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Test tuning a model in Relax over RPC, end-to-end."""
-import pytest
 import os
 import subprocess
 import time
@@ -27,6 +26,9 @@ import tvm.testing
 
 @tvm.testing.slow
 def test_relax_auto_tir_e2e_rpc():
+    """
+    Run the e2e_auto_tir Relax example script over RPC on localhost.
+    """
     rpc_host = "127.0.0.1"
     rpc_key = "Test1"
     rpc_port = "5555"
@@ -110,6 +112,7 @@ def test_relax_auto_tir_e2e_rpc():
                 "--rpc-timeout",
                 "600",
             ],
+            check=False,
             capture_output=True,
         )
         # just checking that it completes successfully
@@ -120,4 +123,4 @@ def test_relax_auto_tir_e2e_rpc():
 
 
 if __name__ == "__main__":
-    test_relax_auto_tir_e2e_rpc()
+    tvm.testing.main()

--- a/tests/python/integration/test_relax_rpc_tuning.py
+++ b/tests/python/integration/test_relax_rpc_tuning.py
@@ -69,12 +69,13 @@ def connect_server(host: str, port: int, key: str) -> rpc.Server:
 
     Subsequently checks if the connection succeeded.
     """
-    server = rpc.Server(  # pylint: disable=unused-variable
+    server = rpc.Server(
         host=host, key=key, tracker_addr=(host, port)
     )
     # retry in case we check before the connection comes in
     if not retry_with_backoff(lambda: check_connection(host, port, key)):
         raise Exception("Failed to connect")
+    return server
 
 
 @tvm.testing.slow

--- a/tests/python/integration/test_relax_rpc_tuning.py
+++ b/tests/python/integration/test_relax_rpc_tuning.py
@@ -69,9 +69,7 @@ def connect_server(host: str, port: int, key: str) -> rpc.Server:
 
     Subsequently checks if the connection succeeded.
     """
-    server = rpc.Server(
-        host=host, key=key, tracker_addr=(host, port)
-    )
+    server = rpc.Server(host=host, key=key, tracker_addr=(host, port))
     # retry in case we check before the connection comes in
     if not retry_with_backoff(lambda: check_connection(host, port, key)):
         raise Exception("Failed to connect")


### PR DESCRIPTION
Running the `e2e_auto_tir` example over RPC can run into issues due to timeouts because some models can take a long time to run on some machines. This PR makes the RPC timeout configurable to more easily address these issues.

On a side note, do we want unit tests for this file in CI? It can take a long time to run, so I don't know if we always want those tests running in CI.