### PR TITLE
[Pass] Implement legacy lowering pass that leverages relay op strategy

### DIFF
--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -105,7 +105,7 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
             # This is bit unintuitive. Can we improve this?
             def transform(self):
                 for gv, func in mod.functions.items():
-                    if isinstance(func, relax.expr.BaseFunc):
+                    if isinstance(func, relax.Function):
                         updated_func = self.visit_expr(func)
                         self.builder_.update_func(gv, updated_func)
                 return self.builder_.get()

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-argument, invalid-name, no-else-return
+"""Relax transformation passes for testing"""
+
+from __future__ import annotations
+from tvm import ir
+from tvm import relax
+from tvm.ir.module import IRModule
+from tvm.ir.transform import PassContext
+from tvm.target import Target
+from tvm.ir import transform
+from tvm.relax import ExprMutator
+from tvm.relax.expr import Call
+from tvm.relay.backend.te_compiler import select_implementation
+
+
+@ir.transform.module_pass(opt_level=0)
+class LowerWithRelayOpStrategyPass(transform.Pass):
+    """Lower Relax Op into TIR by using Relay OpStrategy.
+
+    Since operators like conv2d, add, matmul are relay-, relax- independent,
+    this pass assumes we can always find relay op equivalent for such relax ops,
+    and use Relay Op Strategy (legacy) to perform lowering and find the TOPI implementation.
+
+    Parameters
+    ----------
+    target : Target
+        target info
+
+    Returns
+    -------
+    pass : transform.Pass
+        lowering pass
+    """
+
+    def __init__(self, target: Target):
+        self.target = target
+
+    def transform_module(self, mod: IRModule, ctx: PassContext) -> IRModule:
+        target = self.target
+
+        class Lowerer(ExprMutator):
+            def visit_call_(self, call: Call):
+                # Remove "relax." prefix to deduce relay op name
+                relay_op_name = call.op.name[6:]
+                # Check if equivalent relay op exists. If not, return the original call.
+                if relay_op_name in ir.Op.list_op_names():
+                    relay_op = ir.Op.get(relay_op_name)
+
+                    te_inputs = [relax.expr.te_tensor(arg) for arg in call.args]
+                    best_impl, outputs = select_implementation(
+                        relay_op,
+                        call.attrs,
+                        te_inputs,
+                        call.checked_type,
+                        target,
+                        use_autotvm=False,
+                    )
+                    compute_func = best_impl.compute
+                    name_hint = relay_op_name.split(".")[-1]
+
+                    return self.builder_.emit_te(
+                        compute_func,
+                        call.attrs,
+                        call.args,
+                        call.attrs,
+                        primfunc_name_hint=name_hint,
+                    )
+                else:
+                    return call
+
+            # TOOD(@team): Currently, this is necessary to include TIR functions and bit unintuitive.
+            # Can we improve this?
+            def transform(self):
+                for gv, func in mod.functions.items():
+                    if isinstance(func, relax.expr.BaseFunc):
+                        updated_func = self.visit_expr(func)
+                        self.builder_.update_func(gv, updated_func)
+                return self.builder_.get()
+
+        return Lowerer().transform()

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -91,7 +91,7 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
                     compute_func = best_impl_tuple[0].compute
                     name_hint = relay_op_name.split(".")[-1]
 
-                    return self.builder_.emit_te(
+                    return self.builder_.call_te(
                         compute_func,
                         call_node.attrs,
                         call_node.args,

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -101,8 +101,8 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
                 else:
                     return call_node
 
-            # TOOD(@team): Currently, this is necessary to include TIR functions.
-            # This is bit unintuitive. Can we improve this?
+            # TOOD(@team): transform() wapper is necessary to include TIR functions.
+            # IMO, this is bit unintuitive. Can we improve this?
             def transform(self):
                 for gv, func in mod.functions.items():
                     if isinstance(func, relax.Function):

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -73,7 +73,8 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
             """Mutator that performs lowering."""
 
             def visit_call_(self, call_node: Call):
-                # Remove "relax." prefix to deduce relay op name
+                # Current relax op name simply adds "relax." prefix to relay op name.
+                # Thus, remove "relax." prefix to deduce relay op name.
                 relay_op_name = call_node.op.name[6:]
                 # Check if equivalent relay op exists. If not, return the original call.
                 if relay_op_name in ir.Op.list_op_names():
@@ -89,6 +90,8 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
                         use_autotvm=False,
                     )
                     compute_func = best_impl_tuple[0].compute
+                    # Extract the name of the operator without the prefix
+                    # e.g., for relay op "nn.conv2d", name_hint would be conv2d
                     name_hint = relay_op_name.split(".")[-1]
 
                     return self.builder_.call_te(

--- a/tests/python/relax/test_transform_codegen_pass.py
+++ b/tests/python/relax/test_transform_codegen_pass.py
@@ -106,10 +106,7 @@ def test_single_annot_func():
     tmp = np0 + np1
     out1 = tmp + tmp
     expected = out1 + tmp
-
-    check_executable(ex0, dev, [data0, data1], expected)
-    # TODO: Check if serialization works and the correctness of both original and deserialized execs.
-    # check_roundtrip(ex0, dev, [data0, data1], expected)
+    check_roundtrip(ex0, dev, [data0, data1], expected)
 
     # If the annotation does not match with the target codegen, do not perform the codegen process.
     new_mod = relax.transform.RunCodegen(target_codegens=["INVALID_CODEGEN"])(mod)

--- a/tests/python/relax/test_transform_lower_with_op_strategy.py
+++ b/tests/python/relax/test_transform_lower_with_op_strategy.py
@@ -49,9 +49,9 @@ def build_and_run(mod, target, dev, np_inputs):
             config=ms.TuneConfig(
                 strategy="evolutionary",
                 task_scheduler="round_robin",
-                num_trials_per_iter=4,
-                max_trials_per_task=8,
-                max_trials_global=8,
+                num_trials_per_iter=30,
+                max_trials_per_task=200,
+                max_trials_global=200,
             ),
             work_dir=work_dir,
         )
@@ -78,7 +78,7 @@ def test_lowering_cpu(target_str="llvm --num-cores=16"):
 
 
 @tvm.testing.requires_gpu
-def test_lowering_gpu(target_str="nvidia/geforce-rtx-3070"):
+def test_lowering_gpu(target_str="nvidia/nvidia-t4"):
     _test_lowering(Target(target_str), tvm.cuda())
 
 

--- a/tests/python/relax/test_transform_lower_with_op_strategy.py
+++ b/tests/python/relax/test_transform_lower_with_op_strategy.py
@@ -63,11 +63,9 @@ def build_and_run(mod, target, dev, np_inputs):
     vm["main"](*inputs)
 
 
-def _test_lowering(target_str):
+def _test_lowering(target, dev):
     mod = InputModule
     assert mod
-    target = Target(target_str)
-    dev = tvm.device(target_str, dev_id=0)
 
     with tvm.transform.PassContext(opt_level=3):
         out_mod = transform.LowerWithRelayOpStrategyPass(target)(mod)
@@ -81,15 +79,12 @@ def _test_lowering(target_str):
 
 
 def test_lowering_cpu(target_str="llvm --num-cores=16"):
-    _test_lowering(target_str)
+    _test_lowering(Target(target_str), tvm.cpu())
 
 
-# TODO(@sunggg): revisit later.
-# Error: ValueError: Check failed: (max_threads_per_block.defined()) is false: missing attribute `max_threads_per_block` in the target
-@pytest.mark.skip(reason="Error in MS. Revisit later")
 @tvm.testing.requires_gpu
-def test_lowering_gpu(target_str="cuda"):
-    _test_lowering(target_str)
+def test_lowering_gpu(target_str="nvidia/geforce-rtx-3070"):
+    _test_lowering(Target(target_str), tvm.cuda())
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_transform_lower_with_op_strategy.py
+++ b/tests/python/relax/test_transform_lower_with_op_strategy.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+import pytest
+import numpy as np
+import tempfile
+
+import tvm
+import tvm.script
+from tvm import relax
+from tvm.target import Target
+from tvm.ir.transform import PassContext
+from tvm.relax.testing import transform
+from tvm.script import relax as R
+from tvm import meta_schedule as ms
+from test_relay_translator import create_database
+
+
+@tvm.script.ir_module
+class InputModule:
+    @R.function
+    def main(
+        x: Tensor((16, 16), "float32"), w: Tensor((16, 16), "float32")
+    ) -> Tensor((16, 16), "float32"):
+        gv0 = R.multiply(x, w)
+        gv1 = R.add(x, gv0)
+        return gv1
+
+
+def build_and_run(mod, target, dev, np_inputs):
+    dirpath = "relax_tmp"
+    db = create_database(f"{dirpath}/workload.json", f"{dirpath}/record.json")
+    inputs = [tvm.nd.array(np_input, dev) for np_input in np_inputs]
+    with tempfile.TemporaryDirectory() as work_dir:
+        ex = ms.tune_relax(
+            mod=mod,
+            target=target,
+            config=ms.TuneConfig(
+                strategy="evolutionary",
+                num_trials_per_iter=2,
+                max_trials_per_task=4,
+                max_trials_global=4,
+            ),
+            work_dir=work_dir,
+            database=db,
+        )
+    vm = relax.VirtualMachine(ex, dev)
+    vm["main"](*inputs)
+
+
+def _test_lowering(target_str):
+    mod = InputModule
+    assert mod
+    target = Target(target_str)
+    dev = tvm.device(target_str, dev_id=0)
+
+    with tvm.transform.PassContext(opt_level=3):
+        out_mod = transform.LowerWithRelayOpStrategyPass(target)(mod)
+
+    input_shape = (16, 16)
+    np_inputs = [
+        np.random.rand(*input_shape).astype(np.float32),
+        np.random.rand(*input_shape).astype(np.float32),
+    ]
+    build_and_run(out_mod, target, dev, np_inputs)
+
+
+def test_lowering_cpu(target_str="llvm --num-cores=16"):
+    _test_lowering(target_str)
+
+
+# TODO(@sunggg): revisit later.
+# Error: ValueError: Check failed: (max_threads_per_block.defined()) is false: missing attribute `max_threads_per_block` in the target
+@pytest.mark.skip(reason="Error in MS. Revisit later")
+@tvm.testing.requires_gpu
+def test_lowering_gpu(target_str="cuda"):
+    _test_lowering(target_str)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/relax/test_transform_lower_with_op_strategy.py
+++ b/tests/python/relax/test_transform_lower_with_op_strategy.py
@@ -49,9 +49,9 @@ def build_and_run(mod, target, dev, np_inputs):
             config=ms.TuneConfig(
                 strategy="evolutionary",
                 task_scheduler="round_robin",
-                num_trials_per_iter=30,
-                max_trials_per_task=200,
-                max_trials_global=200,
+                num_trials_per_iter=20,
+                max_trials_per_task=20,
+                max_trials_global=20,
             ),
             work_dir=work_dir,
         )

--- a/tests/python/relax/test_transform_lower_with_op_strategy.py
+++ b/tests/python/relax/test_transform_lower_with_op_strategy.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import pytest
 import numpy as np
 import tempfile
+import shutil
 
 import tvm
 import tvm.script
@@ -52,15 +53,18 @@ def build_and_run(mod, target, dev, np_inputs):
             target=target,
             config=ms.TuneConfig(
                 strategy="evolutionary",
-                num_trials_per_iter=2,
-                max_trials_per_task=4,
-                max_trials_global=4,
+                num_trials_per_iter=4,
+                max_trials_per_task=8,
+                max_trials_global=8,
             ),
             work_dir=work_dir,
             database=db,
         )
     vm = relax.VirtualMachine(ex, dev)
     vm["main"](*inputs)
+
+    # cleanup
+    shutil.rmtree(dirpath)
 
 
 def _test_lowering(target, dev):
@@ -88,4 +92,6 @@ def test_lowering_gpu(target_str="nvidia/geforce-rtx-3070"):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    test_lowering_cpu()
+    test_lowering_gpu()
+    # pytest.main([__file__])


### PR DESCRIPTION
This PR implements Relax Op lowering that leverages existing Relay Op Strategy (legacy). 
As ops like conv2d, matmul are relay-, relax- independent, this pass assumes that we can always find relay op equivalents for such relax ops and use their info to leverage the relay op strategy. 

cc. @ganler @YuchenJin 
