### PR TITLE
[Pass] New Python ExprVisitor/ExprMutator!

### DIFF
--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -71,7 +71,7 @@ class ExprFunctor;
     if (it != operator->()->map_.end())           \
       it->second(T(op));                          \
     else                                          \
-      operator->()->visitor_->DEFAULT(op);        \
+      ExprVisitor::DEFAULT(op);                   \
   }
 
 #define PY_EXPR_MUTATOR_DEFAULT(T, F)          \
@@ -367,7 +367,7 @@ class PyExprVisitorNode : public Object {
 
 TVM_REGISTER_NODE_TYPE(PyExprVisitorNode);
 
-class PyExprVisitor : public ObjectRef {
+class PyExprVisitor : public ObjectRef, public ExprVisitor {
  public:
   TVM_DLL PyExprVisitor(std::unordered_map<std::string, PackedFunc> map, ExprVisitor* visitor) {
     ObjectPtr<PyExprVisitorNode> n = make_object<PyExprVisitorNode>();
@@ -408,7 +408,6 @@ class PyExprVisitor : public ObjectRef {
 
   void VisitBinding_(const VarBindingNode* op)
       PY_EXPR_VISITOR_DEFAULT(GetRef<VarBinding>, "visit_var_binding_", VisitBinding_);
-
   void VisitBinding_(const MatchShapeNode* op)
       PY_EXPR_VISITOR_DEFAULT(GetRef<MatchShape>, "visit_match_shape_", VisitBinding_);
 

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -534,9 +534,9 @@ class PyExprVisitor : public ObjectRef {
    * \param f_visit_var_ The packed function of `VisitExpr_(const VarNode* op)`.
    * \param f_visit_dataflow_var_ The packed function of `VisitExpr_(const DataflowVarNode* op)`.
    * \param f_visit_shape_expr_ The packed function of `VisitExpr_(const ShapeExprNode* op)`.
-   * \param f_visit_runtime_dep_shape_ The packed function of `VisitExpr_(const RuntimeDepShapeNode* op)`.
-   * \param f_visit_extern_func_ The packed function of `VisitExpr_(const ExternFuncNode* op)`.
-   * \param f_visit_global_var_ The packed function of `VisitExpr_(const GlobalVarNode* op)`.
+   * \param f_visit_runtime_dep_shape_ The packed function of `VisitExpr_(const RuntimeDepShapeNode*
+   * op)`. \param f_visit_extern_func_ The packed function of `VisitExpr_(const ExternFuncNode*
+   * op)`. \param f_visit_global_var_ The packed function of `VisitExpr_(const GlobalVarNode* op)`.
    * \param f_visit_function_ The packed function of `VisitExpr_(const FunctionNode* op)`.
    * \param f_visit_call_ The packed function of `VisitExpr_(const CallNode* op)`.
    * \param f_visit_seq_expr_ The packed function of `VisitExpr_(const SeqExprNode* op)`.
@@ -544,17 +544,17 @@ class PyExprVisitor : public ObjectRef {
    * \param f_visit_op_ The packed function of `VisitExpr_(const OpNode* op)`.
    * \param f_visit_tuple_getitem_ The packed function of `VisitExpr_(const TupleGetItemNode* op)`.
    * \param f_visit_binding The packed function of `VisitBinding(const Binding& binding)`.
-   * \param f_visit_var_binding_ The packed function of `VisitBinding_(const VarBindingNode* binding)`.
-   * \param f_visit_match_shape_ The packed function of `VisitBinding_(const MatchShapeNode* binding)`.
-   * \param f_visit_binding_block The packed function of `VisitBindingBlock(const BindingBlock& block)`.
-   * \param f_visit_binding_block_ The packed function of `VisitBindingBlock_(const BindingBlockNode* block)`.
-   * \param f_visit_dataflow_block_ The packed function of `VisitBindingBlock_(const DataflowBlockNode* block)`.
-   * \param f_visit_var_def The packed function of `VisitVarDef(const Var& var)`.
-   * \param f_visit_var_def_ The packed function of `VisitVarDef_(const VarNode* var)`.
-   * \param f_visit_dataflow_var_def_ The packed function of `VisitVarDef_(const DataflowVarNode* var)`.
-   * \param f_visit_type The packed function of `VisitType(const Type& t)`.
-   * \param f_visit_span The packed function of `VisitSpan(const Span& span)`.
-   * \return The PyVisitor created.
+   * \param f_visit_var_binding_ The packed function of `VisitBinding_(const VarBindingNode*
+   * binding)`. \param f_visit_match_shape_ The packed function of `VisitBinding_(const
+   * MatchShapeNode* binding)`. \param f_visit_binding_block The packed function of
+   * `VisitBindingBlock(const BindingBlock& block)`. \param f_visit_binding_block_ The packed
+   * function of `VisitBindingBlock_(const BindingBlockNode* block)`. \param f_visit_dataflow_block_
+   * The packed function of `VisitBindingBlock_(const DataflowBlockNode* block)`. \param
+   * f_visit_var_def The packed function of `VisitVarDef(const Var& var)`. \param f_visit_var_def_
+   * The packed function of `VisitVarDef_(const VarNode* var)`. \param f_visit_dataflow_var_def_ The
+   * packed function of `VisitVarDef_(const DataflowVarNode* var)`. \param f_visit_type The packed
+   * function of `VisitType(const Type& t)`. \param f_visit_span The packed function of
+   * `VisitSpan(const Span& span)`. \return The PyVisitor created.
    */
   TVM_DLL static PyExprVisitor MakePyExprVisitor(
       PackedFunc f_visit_expr, PackedFunc f_visit_constant_, PackedFunc f_visit_tuple_,
@@ -792,7 +792,7 @@ TVM_REGISTER_NODE_TYPE(PyExprMutatorNode);
  */
 class PyExprMutator : public ObjectRef {
  public:
- /*!
+  /*!
    * \brief Create a PyExprMutator with customized methods on the python-side.
    * \param f_visit_expr The packed function of `VisitExpr(const Expr& expr)`.
    * \param f_visit_constant_ The packed function of `VisitExpr_(const ConstantNode* op)`.
@@ -800,9 +800,9 @@ class PyExprMutator : public ObjectRef {
    * \param f_visit_var_ The packed function of `VisitExpr_(const VarNode* op)`.
    * \param f_visit_dataflow_var_ The packed function of `VisitExpr_(const DataflowVarNode* op)`.
    * \param f_visit_shape_expr_ The packed function of `VisitExpr_(const ShapeExprNode* op)`.
-   * \param f_visit_runtime_dep_shape_ The packed function of `VisitExpr_(const RuntimeDepShapeNode* op)`.
-   * \param f_visit_extern_func_ The packed function of `VisitExpr_(const ExternFuncNode* op)`.
-   * \param f_visit_global_var_ The packed function of `VisitExpr_(const GlobalVarNode* op)`.
+   * \param f_visit_runtime_dep_shape_ The packed function of `VisitExpr_(const RuntimeDepShapeNode*
+   * op)`. \param f_visit_extern_func_ The packed function of `VisitExpr_(const ExternFuncNode*
+   * op)`. \param f_visit_global_var_ The packed function of `VisitExpr_(const GlobalVarNode* op)`.
    * \param f_visit_function_ The packed function of `VisitExpr_(const FunctionNode* op)`.
    * \param f_visit_call_ The packed function of `VisitExpr_(const CallNode* op)`.
    * \param f_visit_seq_expr_ The packed function of `VisitExpr_(const SeqExprNode* op)`.
@@ -810,22 +810,22 @@ class PyExprMutator : public ObjectRef {
    * \param f_visit_op_ The packed function of `VisitExpr_(const OpNode* op)`.
    * \param f_visit_tuple_getitem_ The packed function of `VisitExpr_(const TupleGetItemNode* op)`.
    * \param f_visit_binding The packed function of `VisitBinding(const Binding& binding)`.
-   * \param f_visit_var_binding_ The packed function of `VisitBinding_(const VarBindingNode* binding)`.
-   * \param f_visit_match_shape_ The packed function of `VisitBinding_(const MatchShapeNode* binding)`.
-   * \param f_visit_binding_block The packed function of `VisitBindingBlock(const BindingBlock& block)`.
-   * \param f_visit_binding_block_ The packed function of `VisitBindingBlock_(const BindingBlockNode* block)`.
-   * \param f_visit_dataflow_block_ The packed function of `VisitBindingBlock_(const DataflowBlockNode* block)`.
-   * \param f_visit_var_def The packed function of `VisitVarDef(const Var& var)`.
-   * \param f_visit_var_def_ The packed function of `VisitVarDef_(const VarNode* var)`.
-   * \param f_visit_dataflow_var_def_ The packed function of `VisitVarDef_(const DataflowVarNode* var)`.
-   * \param f_visit_type The packed function of `VisitType(const Type& t)`.
-   * \param f_visit_span The packed function of `VisitSpan(const Span& span)`.
-   * \param f_rewrite_constant_post_order The packed function to post order visit Constant.
-   * \param f_rewrite_tuple_post_order The packed function to post order visit Tuple.
-   * \param f_rewrite_var_post_order The packed function to post order visit Var.
-   * \param f_rewrite_dataflow_var_post_order The packed function to post order visit DataflowVar.
-   * \param f_rewrite_shape_expr_post_order The packed function to post order visit ShapeExpr.
-   * \param f_rewrite_runtime_dep_shape_post_order The packed function to post order visit RuntimeDepShape.
+   * \param f_visit_var_binding_ The packed function of `VisitBinding_(const VarBindingNode*
+   * binding)`. \param f_visit_match_shape_ The packed function of `VisitBinding_(const
+   * MatchShapeNode* binding)`. \param f_visit_binding_block The packed function of
+   * `VisitBindingBlock(const BindingBlock& block)`. \param f_visit_binding_block_ The packed
+   * function of `VisitBindingBlock_(const BindingBlockNode* block)`. \param f_visit_dataflow_block_
+   * The packed function of `VisitBindingBlock_(const DataflowBlockNode* block)`. \param
+   * f_visit_var_def The packed function of `VisitVarDef(const Var& var)`. \param f_visit_var_def_
+   * The packed function of `VisitVarDef_(const VarNode* var)`. \param f_visit_dataflow_var_def_ The
+   * packed function of `VisitVarDef_(const DataflowVarNode* var)`. \param f_visit_type The packed
+   * function of `VisitType(const Type& t)`. \param f_visit_span The packed function of
+   * `VisitSpan(const Span& span)`. \param f_rewrite_constant_post_order The packed function to post
+   * order visit Constant. \param f_rewrite_tuple_post_order The packed function to post order visit
+   * Tuple. \param f_rewrite_var_post_order The packed function to post order visit Var. \param
+   * f_rewrite_dataflow_var_post_order The packed function to post order visit DataflowVar. \param
+   * f_rewrite_shape_expr_post_order The packed function to post order visit ShapeExpr. \param
+   * f_rewrite_runtime_dep_shape_post_order The packed function to post order visit RuntimeDepShape.
    * \param f_rewrite_extern_func_post_order The packed function to post order visit ExternFunc.
    * \param f_rewrite_global_var_post_order The packed function to post order visit GlobalVar.
    * \param f_rewrite_function_post_order The packed function to post order visit Function.

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -78,8 +78,9 @@ class ExprFunctor;
     if (PY_FUNC != nullptr) {                                       \
       RET_TYPE ret = PY_FUNC(N);                                    \
       return ret;                                                   \
-    } else                                                          \
+    } else {                                                        \
       return DEFAULT_FUNC;                                          \
+    }                                                               \
   }
 
 #define PY_EXPR_VISITOR_DISPATCH(OP, PY_FUNC)                            \
@@ -102,8 +103,9 @@ class ExprFunctor;
       if (self->PY_FUNC != nullptr) {                                                        \
         Expr expr = self->PY_FUNC(n);                                                        \
         return expr;                                                                         \
-      } else                                                                                 \
+      } else {                                                                               \
         return self->VisitExpr_(static_cast<const OP*>(n.get()));                            \
+      }                                                                                      \
     }                                                                                        \
   });
 
@@ -448,9 +450,9 @@ class PyExprVisitorNode : public Object, public ExprVisitor {
   PackedFunc f_visit_span{nullptr};
 
   void VisitExpr(const Expr& expr) {
-    if (f_visit_expr != nullptr)
+    if (f_visit_expr != nullptr) {
       f_visit_expr(expr);
-    else {
+    } else {
       // Need to init the overloaded VTable
       static FType vtable = InitVTable();
       vtable(expr, this);
@@ -694,9 +696,9 @@ class PyExprMutatorNode : public Object, public ExprMutator {
   PackedFunc f_rewrite_tuple_getitem_post_order{nullptr};
 
   Expr VisitExpr(const Expr& expr) {
-    if (f_visit_expr != nullptr)
+    if (f_visit_expr != nullptr) {
       return builder_->Normalize(f_visit_expr(expr));
-    else {
+    } else {
       static FType vtable = InitVTable();
       return builder_->Normalize(vtable(expr, this));
     }
@@ -707,21 +709,21 @@ class PyExprMutatorNode : public Object, public ExprMutator {
       f_visit_binding(binding);
     else
       ExprMutator::VisitBinding(binding);
-  };
+  }
 
   void VisitBinding_(const VarBindingNode* binding) {
     if (f_visit_var_binding_ != nullptr)
       f_visit_var_binding_(GetRef<VarBinding>(binding));
     else
       ExprMutator::VisitBinding_(binding);
-  };
+  }
 
   void VisitBinding_(const MatchShapeNode* binding) {
     if (f_visit_match_shape_ != nullptr)
       f_visit_match_shape_(GetRef<MatchShape>(binding));
     else
       ExprMutator::VisitBinding_(binding);
-  };
+  }
 
   BindingBlock VisitBindingBlock(const BindingBlock& block)
       PY_EXPR_MUTATOR_DEFAULT(block, f_visit_binding_block, ExprMutator::VisitBindingBlock(block),

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -92,7 +92,10 @@ def derived_object(cls: type) -> type:
     assert isinstance(cls.__base__, type)
     if hasattr(cls, "_type") and cls._type == "TVMDerivedObject":
         raise TypeError(
-            f"Inheritance from a decorated object `{cls.__name__}` is not allowed. Please inherit from `{cls.__name__}._cls`."
+            (
+                f"Inheritance from a decorated object `{cls.__name__}` is not allowed. ",
+                f"Please inherit from `{cls.__name__}._cls`.",
+            )
         )
     assert hasattr(
         cls, "_tvm_metadata"

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -112,7 +112,6 @@ def derived_object(cls: type) -> type:
             # using weakref to avoid cyclic dependency
             self._inst._outer = weakref.ref(self)
 
-
         def __getattr__(self, name):
             # fall back to instance attribute if there is not any
             # return self._inst.__getattribute__(name)

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -112,13 +112,11 @@ def derived_object(cls: type) -> type:
             # using weakref to avoid cyclic dependency
             self._inst._outer = weakref.ref(self)
 
-        # def __getattr__(self, name: str):
-        #     """Bridge the attribute function."""
-        #     return self._inst.__getattribute__(name)
+
         def __getattr__(self, name):
             # fall back to instance attribute if there is not any
             # return self._inst.__getattribute__(name)
-            import inspect
+            import inspect  # pylint: disable=import-outside-toplevel
 
             result = self._inst.__getattribute__(name)
             if inspect.ismethod(result):
@@ -126,6 +124,7 @@ def derived_object(cls: type) -> type:
                 def method(*args, **kwargs):
                     return result(*args, **kwargs)
 
+                # set __own__ to aviod implicit deconstruction
                 setattr(method, "__own__", self)
                 return method
 

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -76,14 +76,24 @@ def derived_object(cls: type) -> type:
         def method(*args, **kwargs):
             return getattr(inst, name)(*args, **kwargs)
 
-        if getattr(base, name) is getattr(cls, name) and name != "__str__":
-            # for task scheduler return None means calling default function
-            # otherwise it will trigger a TVMError of method not implemented
-            # on the c++ side when you call the method, __str__ not required
-            return None
-        return method
+        for inherit_cls, base_cls in zip(cls.__mro__, cls.__mro__[1:]):
+            # extract functions that differ from the base class
+            if not hasattr(base_cls, name):
+                continue
+            if getattr(base_cls, name) is getattr(inherit_cls, name) and name != "__str__":
+                continue
+            return method
+
+        # for task scheduler return None means calling default function
+        # otherwise it will trigger a TVMError of method not implemented
+        # on the c++ side when you call the method, __str__ not required
+        return None
 
     assert isinstance(cls.__base__, type)
+    if hasattr(cls, "_type") and cls._type == "TVMDerivedObject":
+        raise TypeError(
+            f"Inheritance from a decorated object `{cls.__name__}` is not allowed. Please inherit from `{cls.__name__}._cls`."
+        )
     assert hasattr(
         cls, "_tvm_metadata"
     ), "Please use the user-facing method overiding class, i.e., PyRunner."
@@ -95,6 +105,9 @@ def derived_object(cls: type) -> type:
 
     class TVMDerivedObject(metadata["cls"]):  # type: ignore
         """The derived object to avoid cyclic dependency."""
+
+        _cls = cls
+        _type = "TVMDerivedObject"
 
         def __init__(self, *args, **kwargs):
             """Constructor."""

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -93,8 +93,8 @@ def derived_object(cls: type) -> type:
     if hasattr(cls, "_type") and cls._type == "TVMDerivedObject":
         raise TypeError(
             (
-                f"Inheritance from a decorated object `{cls.__name__}` is not allowed. ",
-                f"Please inherit from `{cls.__name__}._cls`.",
+                f"Inheritance from a decorated object `{cls.__name__}` is not allowed. "
+                f"Please inherit from `{cls.__name__}._cls`."
             )
         )
     assert hasattr(

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -112,9 +112,24 @@ def derived_object(cls: type) -> type:
             # using weakref to avoid cyclic dependency
             self._inst._outer = weakref.ref(self)
 
-        def __getattr__(self, name: str):
-            """Bridge the attribute function."""
-            return self._inst.__getattribute__(name)
+        # def __getattr__(self, name: str):
+        #     """Bridge the attribute function."""
+        #     return self._inst.__getattribute__(name)
+        def __getattr__(self, name):
+            # fall back to instance attribute if there is not any
+            # return self._inst.__getattribute__(name)
+            import inspect
+
+            result = self._inst.__getattribute__(name)
+            if inspect.ismethod(result):
+
+                def method(*args, **kwargs):
+                    return result(*args, **kwargs)
+
+                setattr(method, "__own__", self)
+                return method
+
+            return result
 
         def __setattr__(self, name, value):
             if name not in ["_inst", "key", "handle"]:

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -77,6 +77,3 @@ BlockBuilder = block_builder.BlockBuilder
 # ExprFunctor
 PyExprVisitor = expr_functor.PyExprVisitor
 PyExprMutator = expr_functor.PyExprMutator
-
-visitor = expr_functor.visitor
-mutator = expr_functor.mutator

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -79,3 +79,5 @@ ExprFunctor = expr_functor.ExprFunctor
 ExprVisitor = expr_functor.ExprVisitor
 ExprMutatorBase = expr_functor.ExprMutatorBase
 ExprMutator = expr_functor.ExprMutator
+
+visitor = expr_functor.visitor

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -75,5 +75,6 @@ from .op.op_attrs import VMAllocStorageAttrs, VMAllocTensorAttrs
 BlockBuilder = block_builder.BlockBuilder
 
 # ExprFunctor
+ExprFunctor = expr_functor.ExprFunctor
 PyExprVisitor = expr_functor.PyExprVisitor
 PyExprMutator = expr_functor.PyExprMutator

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -79,5 +79,8 @@ ExprFunctor = expr_functor.ExprFunctor
 ExprVisitor = expr_functor.ExprVisitor
 ExprMutatorBase = expr_functor.ExprMutatorBase
 ExprMutator = expr_functor.ExprMutator
+PyExprVisitor = expr_functor.PyExprVisitor
+PyExprMutator = expr_functor.PyExprMutator
 
 visitor = expr_functor.visitor
+mutator = expr_functor.mutator

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -75,10 +75,6 @@ from .op.op_attrs import VMAllocStorageAttrs, VMAllocTensorAttrs
 BlockBuilder = block_builder.BlockBuilder
 
 # ExprFunctor
-ExprFunctor = expr_functor.ExprFunctor
-ExprVisitor = expr_functor.ExprVisitor
-ExprMutatorBase = expr_functor.ExprMutatorBase
-ExprMutator = expr_functor.ExprMutator
 PyExprVisitor = expr_functor.PyExprVisitor
 PyExprMutator = expr_functor.PyExprMutator
 

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -113,6 +113,133 @@ Example
 """
 
 
+class ExprFunctor:
+    """
+    An abstract visitor defined over Expr.
+    Defines the default dispatch over expressions, and
+    implements memoization.
+    """
+
+    def visit_expr(self, expr):
+        """Apply the visitor to an expression."""
+        if isinstance(expr, Constant):
+            ret = self.visit_constant_(expr)
+        elif isinstance(expr, Tuple):
+            ret = self.visit_tuple_(expr)
+        elif isinstance(expr, DataflowVar):
+            ret = self.visit_dataflow_var_(expr)
+        elif isinstance(expr, Var):
+            ret = self.visit_var_(expr)
+        elif isinstance(expr, ShapeExpr):
+            ret = self.visit_shape_expr_(expr)
+        elif isinstance(expr, RuntimeDepShape):
+            ret = self.visit_runtime_dep_shape_(expr)
+        elif isinstance(expr, ExternFunc):
+            ret = self.visit_extern_func_(expr)
+        elif isinstance(expr, GlobalVar):
+            ret = self.visit_global_var_(expr)
+        elif isinstance(expr, Function):
+            ret = self.visit_function_(expr)
+        elif isinstance(expr, Call):
+            ret = self.visit_call_(expr)
+        elif isinstance(expr, SeqExpr):
+            ret = self.visit_seq_expr_(expr)
+        elif isinstance(expr, If):
+            ret = self.visit_if_(expr)
+        elif isinstance(expr, Op):
+            ret = self.visit_op_(expr)
+        elif isinstance(expr, TupleGetItem):
+            ret = self.visit_tuple_getitem_(expr)
+        else:
+            raise TypeError("Invalid type: {0}".format(type(expr)))
+
+        return ret
+
+    def visit_constant_(self, op: Constant):
+        raise NotImplementedError()
+
+    def visit_tuple_(self, op: Tuple):
+        raise NotImplementedError()
+
+    def visit_dataflow_var_(self, op: DataflowVar):
+        raise NotImplementedError()
+
+    def visit_var_(self, op: Var):
+        raise NotImplementedError()
+
+    def visit_shape_expr_(self, op: ShapeExpr):
+        raise NotImplementedError()
+
+    def visit_runtime_dep_shape_(self, op: RuntimeDepShape):
+        raise NotImplementedError()
+
+    def visit_extern_func_(self, op: ExternFunc):
+        raise NotImplementedError()
+
+    def visit_global_var_(self, op: GlobalVar):
+        raise NotImplementedError()
+
+    def visit_function_(self, op: Function):
+        raise NotImplementedError()
+
+    def visit_call_(self, op: Call):
+        raise NotImplementedError()
+
+    def visit_seq_expr_(self, op: SeqExpr):
+        raise NotImplementedError()
+
+    def visit_if_(self, op: If):
+        raise NotImplementedError()
+
+    def visit_op_(self, op: Op):
+        raise NotImplementedError()
+
+    def visit_tuple_getitem_(self, op: TupleGetItem):
+        raise NotImplementedError()
+
+    def visit_var_binding_(self, binding: VarBinding) -> None:
+        raise NotImplementedError()
+
+    def visit_match_shape_(self, binding: MatchShape) -> None:
+        raise NotImplementedError()
+
+    def visit_binding_block_(self, block: BindingBlock) -> None:
+        raise NotImplementedError()
+
+    def visit_dataflow_block_(self, block: DataflowBlock) -> None:
+        raise NotImplementedError()
+
+    def visit_var_def_(self, var: Var) -> None:
+        raise NotImplementedError()
+
+    def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
+        raise NotImplementedError()
+
+    def visit_binding(self, binding: Binding) -> None:
+        if isinstance(binding, MatchShape):
+            self.visit_match_shape_(binding)
+        elif isinstance(binding, VarBinding):
+            self.visit_var_binding_(binding)
+        else:
+            raise TypeError("Invalid type: {0}".format(type(binding)))
+
+    def visit_binding_block(self, block: BindingBlock) -> None:
+        if isinstance(block, DataflowBlock):
+            self.visit_dataflow_block_(block)
+        elif isinstance(block, BindingBlock):
+            self.visit_binding_block_(block)
+        else:
+            raise TypeError("Invalid type: {0}".format(type(block)))
+
+    def visit_var_def(self, var: Var):
+        if isinstance(var, DataflowVar):
+            self.visit_dataflow_var_def_(var)
+        elif isinstance(var, Var):
+            self.visit_var_def_(var)
+        else:
+            raise TypeError("Invalid type: {0}".format(type(var)))
+
+
 @tvm._ffi.register_object("expr_functor.PyExprVisitor")
 class _PyExprVisitor(Object):
     """

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -101,10 +101,13 @@ def _wrap_visitor(visitor_cls):
                     packed_value.append(func_name)
                     packed_value.append(getattr(inst, func_name))
 
-            print(packed_value)
+            # print(packed_value)
             self.__init_handle_by_constructor__(
                 _ffi_api.MakeExprVisitor, *packed_value  # packed_funcs, packed_func_names
             )
+
+        def visit_expr(self, expr: Expr) -> None:
+            return _ffi_api.PyExprVisitorVisitExpr(self, expr)
 
     return PyVisitor
 

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -19,7 +19,6 @@
 from typing import Optional, Callable
 
 import tvm
-from ..ir.module import IRModule
 from tvm.runtime import Object
 from tvm.ir import Op
 from tvm.meta_schedule.utils import derived_object
@@ -33,6 +32,7 @@ from .expr import Call, If, TupleGetItem
 from .expr import Binding, MatchShape, VarBinding
 from .expr import BindingBlock, DataflowBlock
 from ..relay import Id
+from ..ir.module import IRModule
 from .block_builder import BlockBuilder
 from . import _ffi_api
 

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -337,7 +337,8 @@ class PyExprVisitor:
         op : Constant
             The Constant to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_tuple_(self, op: Tuple) -> None:
         """Visit Tuple.
@@ -349,7 +350,8 @@ class PyExprVisitor:
         op : Tuple
             The Tuple to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_var_(self, op: Var) -> None:
         """Visit Var.
@@ -361,7 +363,8 @@ class PyExprVisitor:
         op : Var
             The Var to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_dataflow_var_(self, op: DataflowVar) -> None:
         """Visit DataflowVar.
@@ -373,7 +376,8 @@ class PyExprVisitor:
         op : DataflowVar
             The DataflowVar to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_shape_expr_(self, op: ShapeExpr) -> None:
         """Visit ShapeExpr.
@@ -385,7 +389,8 @@ class PyExprVisitor:
         op : ShapeExpr
             The ShapeExpr to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
         """Visit RuntimeDepShape.
@@ -397,7 +402,8 @@ class PyExprVisitor:
         op : RuntimeDepShape
             The RuntimeDepShape to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_extern_func_(self, op: ExternFunc) -> None:
         """Visit ExternFunc.
@@ -409,7 +415,8 @@ class PyExprVisitor:
         op : ExternFunc
             The ExternFunc to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_global_var_(self, op: GlobalVar) -> None:
         """Visit GlobalVar.
@@ -421,7 +428,8 @@ class PyExprVisitor:
         op : GlobalVar
             The GlobalVar to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_function_(self, op: Function) -> None:
         """Visit Function.
@@ -433,7 +441,8 @@ class PyExprVisitor:
         op : Function
             The Function to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_call_(self, op: Call) -> None:
         """Visit Call.
@@ -445,7 +454,8 @@ class PyExprVisitor:
         op : Call
             The Call to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_seq_expr_(self, op: SeqExpr) -> None:
         """Visit SeqExpr.
@@ -457,7 +467,8 @@ class PyExprVisitor:
         op : SeqExpr
             The SeqExpr to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_if_(self, op: If) -> None:
         """Visit If.
@@ -469,7 +480,8 @@ class PyExprVisitor:
         op : If
             The If to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_op_(self, op: Op) -> None:
         """Visit Op.
@@ -481,7 +493,8 @@ class PyExprVisitor:
         op : Op
             The Op to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
         """Visit TupleGetItem.
@@ -493,7 +506,8 @@ class PyExprVisitor:
         op : TupleGetItem
             The TupleGetItem to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
         """Visit VarBinding.
@@ -630,20 +644,6 @@ class _PyExprMutator(Object):
         f_visit_dataflow_var_def_: Callable = None,
         f_visit_type: Callable = None,
         f_visit_span: Callable = None,
-        f_rewrite_constant_post_order: Callable = None,
-        f_rewrite_tuple_post_order: Callable = None,
-        f_rewrite_var_post_order: Callable = None,
-        f_rewrite_dataflow_var_post_order: Callable = None,
-        f_rewrite_shape_expr_post_order: Callable = None,
-        f_rewrite_runtime_dep_shape_post_order: Callable = None,
-        f_rewrite_extern_func_post_order: Callable = None,
-        f_rewrite_global_var_post_order: Callable = None,
-        f_rewrite_function_post_order: Callable = None,
-        f_rewrite_call_post_order: Callable = None,
-        f_rewrite_seq_expr_post_order: Callable = None,
-        f_rewrite_if_post_order: Callable = None,
-        f_rewrite_op_post_order: Callable = None,
-        f_rewrite_tuple_getitem_post_order: Callable = None,
     ) -> None:
         """Constructor."""
 
@@ -676,20 +676,6 @@ class _PyExprMutator(Object):
             f_visit_dataflow_var_def_,
             f_visit_type,
             f_visit_span,
-            f_rewrite_constant_post_order,
-            f_rewrite_tuple_post_order,
-            f_rewrite_var_post_order,
-            f_rewrite_dataflow_var_post_order,
-            f_rewrite_shape_expr_post_order,
-            f_rewrite_runtime_dep_shape_post_order,
-            f_rewrite_extern_func_post_order,
-            f_rewrite_global_var_post_order,
-            f_rewrite_function_post_order,
-            f_rewrite_call_post_order,
-            f_rewrite_seq_expr_post_order,
-            f_rewrite_if_post_order,
-            f_rewrite_op_post_order,
-            f_rewrite_tuple_getitem_post_order,
         )
 
     def visit_expr(self, expr: Expr) -> Expr:
@@ -796,20 +782,6 @@ class PyExprMutator:
             "visit_dataflow_var_def_",
             "visit_type",
             "visit_span",
-            "rewrite_constant_post_order",
-            "rewrite_tuple_post_order",
-            "rewrite_var_post_order",
-            "rewrite_dataflow_var_post_order",
-            "rewrite_shape_expr_post_order",
-            "rewrite_runtime_dep_shape_post_order",
-            "rewrite_extern_func_post_order",
-            "rewrite_global_var_post_order",
-            "rewrite_function_post_order",
-            "rewrite_call_post_order",
-            "rewrite_seq_expr_post_order",
-            "rewrite_if_post_order",
-            "rewrite_op_post_order",
-            "rewrite_tuple_getitem_post_order",
         ],
     }
 
@@ -898,7 +870,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_tuple_(self, op: Tuple) -> Expr:
         """Visit Tuple.
@@ -915,7 +888,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_var_(self, op: Var) -> Expr:
         """Visit Var.
@@ -932,7 +906,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
         """Visit DataflowVar.
@@ -949,7 +924,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_shape_expr_(self, op: ShapeExpr) -> Expr:
         """Visit ShapeExpr.
@@ -966,7 +942,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> Expr:
         """Visit RuntimeDepShape.
@@ -983,7 +960,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_extern_func_(self, op: ExternFunc) -> Expr:
         """Visit ExternFunc.
@@ -1000,7 +978,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_global_var_(self, op: GlobalVar) -> Expr:
         """Visit GlobalVar.
@@ -1017,7 +996,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_function_(self, op: Function) -> Expr:
         """Visit Function.
@@ -1034,7 +1014,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_call_(self, op: Call) -> Expr:
         """Visit Call.
@@ -1051,7 +1032,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_seq_expr_(self, op: SeqExpr) -> Expr:
         """Visit SeqExpr.
@@ -1068,7 +1050,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_if_(self, op: If) -> Expr:
         """Visit If.
@@ -1085,7 +1068,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_op_(self, op: Op) -> Expr:
         """Visit Op.
@@ -1102,7 +1086,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
         """Visit TupleGetItem.
@@ -1119,7 +1104,8 @@ class PyExprMutator:
         result : Expr
             The Expr after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
         """Visit VarBinding.
@@ -1245,313 +1231,20 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_constant_post_order(self, op: Constant) -> Expr:
-        """Rewrite Constant after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const ConstantNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
+    def visit_expr_post_order(self, expr: Expr) -> Expr:
+        """Post-order rewrite an Expr and normalize.
 
         Parameters
         ----------
-        op : Constant
-            The Constant to be rewritten, also the return value from the post-order visit.
+        expr : Expr
+            The Expr to be rewritten.
 
         Returns
         -------
         result : Expr
-            The Expr after rewritten.
+            The Expr after post-order rewritten.
         """
-        raise NotImplementedError
-
-    def rewrite_tuple_post_order(self, op: Tuple) -> Expr:
-        """Rewrite Tuple after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const TupleNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : Tuple
-            The Tuple to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_var_post_order(self, op: Var) -> Expr:
-        """Rewrite Var after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const VarNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : Var
-            The Var to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_dataflow_var_post_order(self, op: DataflowVar) -> Expr:
-        """Rewrite DataflowVar after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const DataflowVarNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : DataflowVar
-            The DataflowVar to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_shape_expr_post_order(self, op: ShapeExpr) -> Expr:
-        """Rewrite ShapeExpr after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const ShapeExprNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : ShapeExpr
-            The ShapeExpr to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_runtime_dep_shape_post_order(self, op: RuntimeDepShape) -> Expr:
-        """Rewrite RuntimeDepShape after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const RuntimeDepShapeNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : RuntimeDepShape
-            The RuntimeDepShape to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_extern_func_post_order(self, op: ExternFunc) -> Expr:
-        """Rewrite ExternFunc after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const ExternFuncNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : ExternFunc
-            The ExternFunc to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_global_var_post_order(self, op: GlobalVar) -> Expr:
-        """Rewrite GlobalVar after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const GlobalVarNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : GlobalVar
-            The GlobalVar to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_function_post_order(self, op: Function) -> Expr:
-        """Rewrite Function after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const FunctionNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : Function
-            The Function to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_call_post_order(self, op: Call) -> Expr:
-        """Rewrite Call after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const CallNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : Call
-            The Call to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_seq_expr_post_order(self, op: SeqExpr) -> Expr:
-        """Rewrite SeqExpr after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const SeqExprNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : SeqExpr
-            The SeqExpr to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_if_post_order(self, op: If) -> Expr:
-        """Rewrite If after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const IfNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : If
-            The If to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_op_post_order(self, op: Op) -> Expr:
-        """Rewrite Op after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const OpNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : Op
-            The Op to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
-
-    def rewrite_tuple_getitem_post_order(self, op: TupleGetItem) -> Expr:
-        """Rewrite TupleGetItem after post-order visit the node.
-        The customization will work as
-        .. code-block:: c++
-            Expr VisitExpr_(const TupleGetItemNode* op){
-                Expr expr = self->VisitExprPostOrder_(op);
-                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
-                return expr;
-            }
-
-        Parameters
-        ----------
-        op : TupleGetItem
-            The TupleGetItem to be rewritten, also the return value from the post-order visit.
-
-        Returns
-        -------
-        result : Expr
-            The Expr after rewritten.
-        """
-        raise NotImplementedError
+        return _ffi_api.PyExprMutatorVisitExprPostOrder(self._outer(), expr)
 
     def set_var_remap(self, vid: Id, var: Var) -> None:
         """Remap a var to a new var in use-site.

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -19,6 +19,7 @@
 from typing import Optional, Callable
 
 import tvm
+from ..ir.module import IRModule
 from tvm.runtime import Object
 from tvm.ir import Op
 from tvm.meta_schedule.utils import derived_object
@@ -913,9 +914,9 @@ class PyExprMutator:
         ],
     }
 
-    def __init__(self) -> None:
+    def __init__(self, mod: Optional[IRModule] = None) -> None:
         """Constructor"""
-        self.builder_ = BlockBuilder()
+        self.builder_ = BlockBuilder(mod)
 
     def visit_expr(self, expr: Expr) -> Expr:
         """Generic dispatcher for Expr.

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -234,12 +234,12 @@ class PyExprVisitor:
     _tvm_metadata discribes the class to inherit("cls"), the methods
     that users can overload("methods").
 
-    Note: @derived_object is required for proper usage of any inherited class.
+    Note: @relax.expr_functor.visitor is required for proper usage of any inherited class.
 
     See also: visitor, _PyExprVisitor
 
     Example:
-        @derived_object
+        @relax.expr_functor.visitor
         def MyExprVisitor(PyExprVisitor):
             ...
     """
@@ -754,12 +754,12 @@ class PyExprMutator:
     _tvm_metadata discribes the class to inherit("cls"), the methods that users can
     overload("methods"), the constructor's parameters("fields")
 
-    Note: @derived_object is required for proper usage of any inherited class.
+    Note: @relax.expr_functor.mutator is required for proper usage of any inherited class.
 
     See also: visitor, _PyExprVisitor
 
     Example:
-        @derived_object
+        @relax.expr_functor.mutator
         def MyExprMutator(PyExprMutator):
             ...
     """

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -519,7 +519,8 @@ class PyExprVisitor:
         binding : VarBinding
             The VarBinding to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
         """Visit MatchShape.
@@ -531,7 +532,8 @@ class PyExprVisitor:
         binding : MatchShape
             The MatchShape to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)
 
     def visit_binding_block_(self, block: BindingBlock) -> None:
         """Visit BindingBlock.
@@ -543,7 +545,8 @@ class PyExprVisitor:
         block : BindingBlock
             The BindingBlock to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitBindingBlock(self._outer(), block)
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> None:
         """Visit DataflowBlock.
@@ -555,7 +558,8 @@ class PyExprVisitor:
         block : DataflowBlock
             The DataflowBlock to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitBindingBlock(self._outer(), block)
 
     def visit_var_def_(self, var: Var) -> None:
         """Visit the Var definition site.
@@ -567,7 +571,8 @@ class PyExprVisitor:
         var : Var
             The Var to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitVarDef(self._outer(), var)
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
         """Visit the DataflowVar definition site.
@@ -579,7 +584,8 @@ class PyExprVisitor:
         var : DataflowVar
             The DataflowVar to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitVarDef(self._outer(), var)
 
     def visit_type(self, t: Type) -> None:
         """Visit Type.
@@ -590,7 +596,8 @@ class PyExprVisitor:
         t : Type
             The Type to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitType(self._outer(), t)
 
     def visit_span(self, span: Span) -> None:
         """Visit Span.
@@ -601,7 +608,8 @@ class PyExprVisitor:
         span : Span
             The Span to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprVisitor
+        return _ffi_api.ExprVisitorVisitSpan(self._outer(), span)
 
 
 @tvm._ffi.register_object("expr_functor.PyExprMutator")
@@ -1117,7 +1125,8 @@ class PyExprMutator:
         binding : VarBinding
             The VarBinding to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
         """Visit MatchShape.
@@ -1129,7 +1138,8 @@ class PyExprMutator:
         binding : MatchShape
             The MatchShape to be visited.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)
 
     def visit_binding_block_(self, block: BindingBlock) -> BindingBlock:
         """Visit BindingBlock.
@@ -1146,7 +1156,8 @@ class PyExprMutator:
         result : BindingBlock
             The binding block after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitBindingBlock(self._outer(), block)
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> BindingBlock:
         """Visit DataflowBlock.
@@ -1163,7 +1174,8 @@ class PyExprMutator:
         result : BindingBlock
             The binding block after transformation
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitBindingBlock(self._outer(), block)
 
     def visit_var_def_(self, var: Var) -> Var:
         """Visit the Var definition site.
@@ -1180,7 +1192,8 @@ class PyExprMutator:
         result : Var
             The var after post-order rewritten.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitVarDef(self._outer(), var)
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> Var:
         """Visit the DataflowVar definition site.
@@ -1197,7 +1210,8 @@ class PyExprMutator:
         result : Var
             The var after post-order rewritten.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitVarDef(self._outer(), var)
 
     def visit_type(self, t: Type) -> Type:
         """Visit Type.
@@ -1213,7 +1227,8 @@ class PyExprMutator:
         result : Type
             The type after transformation.
         """
-        raise NotImplementedError
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.ExprMutatorVisitType(self._outer(), t)
 
     def visit_span(self, span: Span) -> Span:
         """Visit Span.

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -18,6 +18,7 @@
 """The expression functor of Relax."""
 import tvm
 from typing import Optional, Callable
+from tvm.runtime import Object
 from tvm.ir import Op
 from tvm.meta_schedule.utils import derived_object
 
@@ -34,12 +35,91 @@ from .block_builder import BlockBuilder
 from . import _ffi_api
 
 visitor = derived_object
+"""
+A decorator to wrap user-customized PyExprVisitor as TVM object _PyExprVisitor.
+
+Parameters
+----------
+visitor_cls : PyExprVisitor
+    The user-customized PyExprVisitor.
+
+Returns
+-------
+cls : _PyExprVisitor
+    The decorated TVM object _PyExprVisitor(ExprVisitor on the C++ side).
+
+Example
+-------
+.. code-block:: python
+
+    @relax.expr_functor.visitor
+    class MyExprVisitor(PyExprVisitor):
+        # customize visit function
+        def visit_call_(self, op: Call) -> None:
+            # just for demo purposes
+            ...
+    # myvisitor is now a special visitor that visit every Call with 
+    # user-customized visit_call_
+    myvisitor = MyExprVisitor()
+    # apply myvisitor to Expr/Binding/BindingBlock/VarDef
+    myvisitor.visit_expr(expr)
+    myvisitor.visit_binding(binding)
+    myvisitor.visit_binding_block(bindingblock)
+    myvisitor.visit_var_def(var)
+"""
+
 mutator = derived_object
+"""
+A decorator to wrap user-customized PyExprMutator as TVM object _PyExprMutator.
+
+Parameters
+----------
+mutator_cls : PyExprMutator
+    The user-customized PyExprMutator.
+
+Returns
+-------
+cls : _PyExprMutator
+    The decorated TVM object _PyExprMutator(ExprMutator on the C++ side).
+
+Example
+-------
+.. code-block:: python
+
+    @relax.expr_functor.mutator
+    class MyExprMutator(PyExprMutator):
+        # customize rewrite function
+        def visit_tuple_(self, op: Tuple) -> Expr:
+            # just for demo purposes
+            ...
+
+        # customize post-order rewrite function
+        def rewrite_var_post_order(self, op: Expr) -> Expr:
+            # just for demo purposes
+            ...
+
+    # mymutator is now a special mutator that rewrite every Tuple with 
+    # user-customized visit_tuple_, and rewrite every Var with user-customized
+    # rewrite_var_post_order in the post order.
+    mymutator = MyExprMutator()
+    # apply mymutator to Expr/Binding/BindingBlock/VarDef
+    mymutator.visit_expr(expr)
+    mymutator.visit_binding(binding)
+    mymutator.visit_binding_block(bindingblock)
+    mymutator.visit_var_def(var)
+"""
 
 
 @tvm._ffi.register_object("expr_functor.PyExprVisitor")
-class _PyExprVisitor(tvm.runtime.Object):
-    """TODO"""
+class _PyExprVisitor(Object):
+    """
+    A TVM object to support customization of ExprVisitor on the python side.
+    This is the decorated result returned from visitor decorator.
+
+    WARNING: This is NOT the user facing class for method overloading inheritance.
+
+    See also: visitor, PyExprVisitor
+    """
 
     def __init__(
         self,
@@ -103,19 +183,63 @@ class _PyExprVisitor(tvm.runtime.Object):
         )
 
     def visit_expr(self, expr: Expr) -> None:
+        """Generic dispatcher for Expr.
+
+        Parameters
+        ----------
+        expr : Expr
+            The expr to be visited.
+        """
         return _ffi_api.PyExprVisitorVisitExpr(self, expr)
 
     def visit_binding(self, binding: Binding) -> None:
+        """Generic dispatcher for Binding.
+
+        Parameters
+        ----------
+        binding : Binding
+            The binding to be visited.
+        """
         return _ffi_api.PyExprVisitorVisitBinding(self, binding)
 
     def visit_binding_block(self, block: BindingBlock) -> None:
+        """Generic dispatcher for BindingBlock.
+
+        Parameters
+        ----------
+        block : BindingBlock
+            The block to be visited.
+        """
         return _ffi_api.PyExprVisitorVisitBindingBlock(self, block)
 
     def visit_var_def(self, var: Var) -> None:
+        """Generic dispatcher for visiting the var definition site.
+        Note that visit_var_() will only visit the usage site of an Var.
+
+        Parameters
+        ----------
+        var : Var
+            The var to be visited.
+        """
         return _ffi_api.PyExprVisitorVisitVarDef(self, var)
 
 
 class PyExprVisitor:
+    """
+    An abstract ExprVisitor with customized methods on the python-side.
+    This is the user facing class for method overloading inheritance.
+    _tvm_metadata discribes the class to inherit("cls"), the methods that users can overload("methods").
+
+    Note: @derived_object is required for proper usage of any inherited class.
+
+    See also: visitor, _PyExprVisitor
+
+    Example:
+        @derived_object
+        def MyExprVisitor(PyExprVisitor):
+            ...
+    """
+
     _tvm_metadata = {
         "cls": _PyExprVisitor,
         "methods": [
@@ -149,89 +273,307 @@ class PyExprVisitor:
     }
 
     def visit_expr(self, expr: Expr) -> None:
+        """Generic dispatcher for Expr.
+        Users can customized this function to overload VisitExpr(const Expr& expr) on the C++ side.
+
+        Parameters
+        ----------
+        expr : Expr
+            The expr to be visited.
+        """
+        # Using self._outer() to ref _PyExprVisitor
         return _ffi_api.PyExprVisitorVisitExpr(self._outer(), expr)
 
     def visit_binding(self, binding: Binding) -> None:
+        """Generic dispatcher for Binding.
+        Users can customized this function to overload VisitBinding(const Binding& binding) on the C++ side.
+
+        Parameters
+        ----------
+        binding : Binding
+            The binding to be visited.
+        """
+        # Using self._outer() to ref _PyExprVisitor
         return _ffi_api.PyExprVisitorVisitBinding(self._outer(), binding)
 
     def visit_binding_block(self, block: BindingBlock) -> None:
+        """Generic dispatcher for BindingBlock.
+        Users can customized this function to overload VisitBindingBlock(const BindingBlock& block) on the C++ side.
+
+        Parameters
+        ----------
+        block : BindingBlock
+            The block to be visited.
+        """
+        # Using self._outer() to ref _PyExprVisitor
         return _ffi_api.PyExprVisitorVisitBindingBlock(self._outer(), block)
 
     def visit_var_def(self, var: Var) -> None:
+        """Generic dispatcher for visiting the var definition site.
+        Users can customized this function to overload VisitVarDef(const Var& var) on the C++ side.
+        Note that visit_var_() will only visit the usage site of an Var.
+
+        Parameters
+        ----------
+        var : Var
+            The var to be visited.
+        """
+        # Using self._outer() to ref _PyExprVisitor
         return _ffi_api.PyExprVisitorVisitVarDef(self._outer(), var)
 
     def visit_constant_(self, op: Constant) -> None:
+        """Visit Constant.
+        Users can customized this function to overload VisitExpr_(const ConstantNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Constant
+            The Constant to be visited.
+        """
         raise NotImplementedError
 
     def visit_tuple_(self, op: Tuple) -> None:
+        """Visit Tuple.
+        Users can customized this function to overload VisitExpr_(const TupleNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Tuple
+            The Tuple to be visited.
+        """
         raise NotImplementedError
 
     def visit_var_(self, op: Var) -> None:
+        """Visit Var.
+        Users can customized this function to overload VisitExpr_(const VarNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Var
+            The Var to be visited.
+        """
         raise NotImplementedError
 
     def visit_dataflow_var_(self, op: DataflowVar) -> None:
+        """Visit DataflowVar.
+        Users can customized this function to overload VisitExpr_(const DataflowVarNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : DataflowVar
+            The DataflowVar to be visited.
+        """
         raise NotImplementedError
 
     def visit_shape_expr_(self, op: ShapeExpr) -> None:
+        """Visit ShapeExpr.
+        Users can customized this function to overload VisitExpr_(const ShapeExprNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : ShapeExpr
+            The ShapeExpr to be visited.
+        """
         raise NotImplementedError
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
+        """Visit RuntimeDepShape.
+        Users can customized this function to overload VisitExpr_(const RuntimeDepShapeNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : RuntimeDepShape
+            The RuntimeDepShape to be visited.
+        """
         raise NotImplementedError
 
     def visit_extern_func_(self, op: ExternFunc) -> None:
+        """Visit ExternFunc.
+        Users can customized this function to overload VisitExpr_(const ExternFuncNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : ExternFunc
+            The ExternFunc to be visited.
+        """
         raise NotImplementedError
 
     def visit_global_var_(self, op: GlobalVar) -> None:
+        """Visit GlobalVar.
+        Users can customized this function to overload VisitExpr_(const GlobalVarNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : GlobalVar
+            The GlobalVar to be visited.
+        """
         raise NotImplementedError
 
     def visit_function_(self, op: Function) -> None:
+        """Visit Function.
+        Users can customized this function to overload VisitExpr_(const FunctionNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Function
+            The Function to be visited.
+        """
         raise NotImplementedError
 
     def visit_call_(self, op: Call) -> None:
+        """Visit Call.
+        Users can customized this function to overload VisitExpr_(const CallNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Call
+            The Call to be visited.
+        """
         raise NotImplementedError
 
     def visit_seq_expr_(self, op: SeqExpr) -> None:
+        """Visit SeqExpr.
+        Users can customized this function to overload VisitExpr_(const SeqExprNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : SeqExpr
+            The SeqExpr to be visited.
+        """
         raise NotImplementedError
 
     def visit_if_(self, op: If) -> None:
+        """Visit If.
+        Users can customized this function to overload VisitExpr_(const IfNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : If
+            The If to be visited.
+        """
         raise NotImplementedError
 
     def visit_op_(self, op: Op) -> None:
+        """Visit Op.
+        Users can customized this function to overload VisitExpr_(const OpNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Op
+            The Op to be visited.
+        """
         raise NotImplementedError
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
+        """Visit TupleGetItem.
+        Users can customized this function to overload VisitExpr_(const TupleGetItemNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : TupleGetItem
+            The TupleGetItem to be visited.
+        """
         raise NotImplementedError
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
+        """Visit VarBinding.
+        Users can customized this function to overload VisitBinding_(const VarBindingNode* binding) on the C++ side.
+
+        Parameters
+        ----------
+        binding : VarBinding
+            The VarBinding to be visited.
+        """
         raise NotImplementedError
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
+        """Visit MatchShape.
+        Users can customized this function to overload VisitBinding_(const MatchShapeNode* binding) on the C++ side.
+
+        Parameters
+        ----------
+        binding : MatchShape
+            The MatchShape to be visited.
+        """
         raise NotImplementedError
 
     def visit_binding_block_(self, block: BindingBlock) -> None:
+        """Visit BindingBlock.
+        Users can customized this function to overload VisitBindingBlock_(const BindingBlockNode* block) on the C++ side.
+
+        Parameters
+        ----------
+        block : BindingBlock
+            The BindingBlock to be visited.
+        """
         raise NotImplementedError
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> None:
+        """Visit DataflowBlock.
+        Users can customized this function to overload VisitBindingBlock_(const DataflowBlockNode* block) on the C++ side.
+
+        Parameters
+        ----------
+        block : DataflowBlock
+            The DataflowBlock to be visited.
+        """
         raise NotImplementedError
 
     def visit_var_def_(self, var: Var) -> None:
+        """Visit the Var definition site.
+        Users can customized this function to overload VisitVarDef_(const VarNode* var) on the C++ side.
+
+        Parameters
+        ----------
+        var : Var
+            The Var to be visited.
+        """
         raise NotImplementedError
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
+        """Visit the DataflowVar definition site.
+        Users can customized this function to overload VisitVarDef_(const DataflowVarNode* var) on the C++ side.
+
+        Parameters
+        ----------
+        var : DataflowVar
+            The DataflowVar to be visited.
+        """
         raise NotImplementedError
 
     def visit_type(self, t: Type) -> None:
+        """Visit Type.
+        Users can customized this function to overload VisitType(const Type& t) on the C++ side.
+
+        Parameters
+        ----------
+        t : Type
+            The Type to be visited.
+        """
         raise NotImplementedError
 
     def visit_span(self, span: Span) -> None:
+        """Visit Span.
+        Users can customized this function to overload VisitSpan(const Span& span) on the C++ side.
+
+        Parameters
+        ----------
+        span : Span
+            The Span to be visited.
+        """
         raise NotImplementedError
 
 
 @tvm._ffi.register_object("expr_functor.PyExprMutator")
-class _PyExprMutator(tvm.runtime.Object):
-    """TODO"""
+class _PyExprMutator(Object):
+    """
+    A TVM object to support customization of ExprMutator on the python side.
+    This is the decorated result returned from mutator decorator.
 
-    builder_: BlockBuilder
+    WARNING: This is NOT the user facing class for method overloading inheritance.
+
+    See also: mutator, PyExprmutator
+    """
 
     def __init__(
         self,
@@ -277,6 +619,8 @@ class _PyExprMutator(tvm.runtime.Object):
         f_rewrite_op_post_order: Callable = None,
         f_rewrite_tuple_getitem_post_order: Callable = None,
     ) -> None:
+        """Constructor."""
+
         self.__init_handle_by_constructor__(
             _ffi_api.MakePyExprMutator,
             builder,
@@ -323,19 +667,78 @@ class _PyExprMutator(tvm.runtime.Object):
         )
 
     def visit_expr(self, expr: Expr) -> Expr:
+        """Generic dispatcher for Expr.
+
+        Parameters
+        ----------
+        expr : Expr
+            The expr to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation.
+        """
         return _ffi_api.PyExprMutatorVisitExpr(self, expr)
 
     def visit_binding(self, binding: Binding) -> None:
+        """Generic dispatcher for Binding.
+
+        Parameters
+        ----------
+        binding : Binding
+            The binding to be visited.
+        """
         return _ffi_api.PyExprMutatorVisitBinding(self, binding)
 
     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
+        """Generic dispatcher for BindingBlock.
+
+        Parameters
+        ----------
+        block : BindingBlock
+            The block to be visited.
+
+        Returns
+        -------
+        result : BindingBlock
+            The binding block after transformation.
+        """
         return _ffi_api.PyExprMutatorVisitBindingBlock(self, block)
 
     def visit_var_def(self, var: Var) -> Var:
+        """Generic dispatcher for visiting the var definition site.
+        Note that visit_var_() will only visit the usage site of an Var.
+
+        Parameters
+        ----------
+        var : Var
+            The var to be visited.
+
+        Returns
+        -------
+        result : Var
+            The var after post-order rewritten.
+        """
         return _ffi_api.PyExprMutatorVisitVarDef(self, var)
 
 
 class PyExprMutator:
+    """
+    An abstract ExprMutator with customized methods on the python-side.
+    This is the user facing class for method overloading inheritance.
+    _tvm_metadata discribes the class to inherit("cls"), the methods that users can overload("methods"), the constructor's parameters("fields")
+
+    Note: @derived_object is required for proper usage of any inherited class.
+
+    See also: visitor, _PyExprVisitor
+
+    Example:
+        @derived_object
+        def MyExprMutator(PyExprMutator):
+            ...
+    """
+
     _tvm_metadata = {
         "cls": _PyExprMutator,
         "fields": ["builder_"],
@@ -384,139 +787,802 @@ class PyExprMutator:
     }
 
     def __init__(self) -> None:
+        """Constructor"""
         self.builder_ = BlockBuilder()
 
-    def set_var_remap(self, id: Id, var: Var) -> None:
-        return _ffi_api.PyExprMutatorSetVarRemap(self._outer(), id, var)
-
-    def get_var_remap(self, id: Id) -> Var:
-        return _ffi_api.PyExprMutatorGetVarRemap(self._outer(), id)
-
     def visit_expr(self, expr: Expr) -> Expr:
+        """Generic dispatcher for Expr.
+        Users can customized this function to overload VisitExpr(const Expr& expr) on the C++ side.
+
+        Parameters
+        ----------
+        expr : Expr
+            The expr to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation.
+        """
+        # Using self._outer() to ref _PyExprMutator
         return _ffi_api.PyExprMutatorVisitExpr(self._outer(), expr)
 
     def visit_binding(self, binding: Binding) -> None:
+        """Generic dispatcher for Binding.
+        Users can customized this function to overload VisitBinding(const Binding& binding) on the C++ side.
+
+        Parameters
+        ----------
+        binding : Binding
+            The binding to be visited.
+        """
+        # Using self._outer() to ref _PyExprMutator
         return _ffi_api.PyExprMutatorVisitBinding(self._outer(), binding)
 
     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
+        """Generic dispatcher for BindingBlock.
+        Users can customized this function to overload VisitBindingBlock(const BindingBlock& block) on the C++ side.
+
+        Parameters
+        ----------
+        block : BindingBlock
+            The block to be visited.
+
+        Returns
+        -------
+        result : BindingBlock
+            The binding block after transformation.
+        """
+        # Using self._outer() to ref _PyExprMutator
         return _ffi_api.PyExprMutatorVisitBindingBlock(self._outer(), block)
 
     def visit_var_def(self, var: Var) -> Var:
+        """Generic dispatcher for visiting the var definition site.
+        Users can customized this function to overload VisitVarDef(const Var& var) on the C++ side.
+        Note that visit_var_() will only visit the usage site of an Var.
+
+        Parameters
+        ----------
+        var : Var
+            The var to be visited.
+
+        Returns
+        -------
+        result: Var
+            The var after post-order rewritten.
+        """
+        # Using self._outer() to ref _PyExprMutator
         return _ffi_api.PyExprMutatorVisitVarDef(self._outer(), var)
 
     def visit_constant_(self, op: Constant) -> Expr:
+        """Visit Constant.
+        Users can customized this function to overload VisitExpr_(const ConstantNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Constant
+            The Constant to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_tuple_(self, op: Tuple) -> Expr:
+        """Visit Tuple.
+        Users can customized this function to overload VisitExpr_(const TupleNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Tuple
+            The Tuple to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_var_(self, op: Var) -> Expr:
+        """Visit Var.
+        Users can customized this function to overload VisitExpr_(const VarNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Var
+            The Var to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
+        """Visit DataflowVar.
+        Users can customized this function to overload VisitExpr_(const DataflowVarNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : DataflowVar
+            The DataflowVar to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_shape_expr_(self, op: ShapeExpr) -> Expr:
+        """Visit ShapeExpr.
+        Users can customized this function to overload VisitExpr_(const ShapeExprNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : ShapeExpr
+            The ShapeExpr to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> Expr:
+        """Visit RuntimeDepShape.
+        Users can customized this function to overload VisitExpr_(const RuntimeDepShapeNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : RuntimeDepShape
+            The RuntimeDepShape to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_extern_func_(self, op: ExternFunc) -> Expr:
+        """Visit ExternFunc.
+        Users can customized this function to overload VisitExpr_(const ExternFuncNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : ExternFunc
+            The ExternFunc to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_global_var_(self, op: GlobalVar) -> Expr:
+        """Visit GlobalVar.
+        Users can customized this function to overload VisitExpr_(const GlobalVarNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : GlobalVar
+            The GlobalVar to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_function_(self, op: Function) -> Expr:
+        """Visit Function.
+        Users can customized this function to overload VisitExpr_(const FunctionNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Function
+            The Function to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_call_(self, op: Call) -> Expr:
+        """Visit Call.
+        Users can customized this function to overload VisitExpr_(const CallNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Call
+            The Call to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_seq_expr_(self, op: SeqExpr) -> Expr:
+        """Visit SeqExpr.
+        Users can customized this function to overload VisitExpr_(const SeqExprNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : SeqExpr
+            The SeqExpr to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_if_(self, op: If) -> Expr:
+        """Visit If.
+        Users can customized this function to overload VisitExpr_(const IfNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : If
+            The If to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_op_(self, op: Op) -> Expr:
+        """Visit Op.
+        Users can customized this function to overload VisitExpr_(const OpNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : Op
+            The Op to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
+        """Visit TupleGetItem.
+        Users can customized this function to overload VisitExpr_(const TupleGetItemNode* op) on the C++ side.
+
+        Parameters
+        ----------
+        op : TupleGetItem
+            The TupleGetItem to be visited.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after transformation
+        """
         raise NotImplementedError
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
+        """Visit VarBinding.
+        Users can customized this function to overload VisitBinding_(const VarBindingNode* binding) on the C++ side.
+
+        Parameters
+        ----------
+        binding : VarBinding
+            The VarBinding to be visited.
+        """
         raise NotImplementedError
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
+        """Visit MatchShape.
+        Users can customized this function to overload VisitBinding_(const MatchShapeNode* binding) on the C++ side.
+
+        Parameters
+        ----------
+        binding : MatchShape
+            The MatchShape to be visited.
+        """
         raise NotImplementedError
 
     def visit_binding_block_(self, block: BindingBlock) -> BindingBlock:
+        """Visit BindingBlock.
+        Users can customized this function to overload VisitBindingBlock_(const BindingBlockNode* block) on the C++ side.
+
+        Parameters
+        ----------
+        block : BindingBlock
+            The BindingBlock to be visited.
+
+        Returns
+        -------
+        result : BindingBlock
+            The binding block after transformation
+        """
         raise NotImplementedError
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> BindingBlock:
+        """Visit DataflowBlock.
+        Users can customized this function to overload VisitBindingBlock_(const DataflowBlockNode* block) on the C++ side.
+
+        Parameters
+        ----------
+        block : DataflowBlock
+            The DataflowBlock to be visited.
+
+        Returns
+        -------
+        result : BindingBlock
+            The binding block after transformation
+        """
         raise NotImplementedError
 
     def visit_var_def_(self, var: Var) -> Var:
+        """Visit the Var definition site.
+        Users can customized this function to overload VisitVarDef_(const VarNode* var) on the C++ side.
+
+        Parameters
+        ----------
+        var : Var
+            The Var to be visited.
+
+        Returns
+        -------
+        result : Var
+            The var after post-order rewritten.
+        """
         raise NotImplementedError
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> Var:
+        """Visit the DataflowVar definition site.
+        Users can customized this function to overload VisitVarDef_(const DataflowVarNode* var) on the C++ side.
+
+        Parameters
+        ----------
+        var : DataflowVar
+            The DataflowVar to be visited.
+
+        Returns
+        -------
+        result : Var
+            The var after post-order rewritten.
+        """
         raise NotImplementedError
 
     def visit_type(self, t: Type) -> Type:
+        """Visit Type.
+        Users can customized this function to overload VisitType(const Type& t) on the C++ side.
+
+        Parameters
+        ----------
+        t : Type
+            The Type to be visited.
+
+        Returns
+        -------
+        result : Type
+            The type after transformation.
+        """
         raise NotImplementedError
 
     def visit_span(self, span: Span) -> Span:
+        """Visit Span.
+        Users can customized this function to overload VisitSpan(const Span& span) on the C++ side.
+
+        Parameters
+        ----------
+        span : Span
+            The Span to be visited.
+
+        Returns
+        -------
+        result : Span
+            The span after transformation.
+        """
         raise NotImplementedError
 
-    def rewrite_constant_post_order(self, op: Constant) -> Expr:
+    def rewrite_constant_post_order(self, op: Expr) -> Expr:
+        """Rewrite Constant after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const ConstantNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_tuple_post_order(self, op: Constant) -> Expr:
+    def rewrite_tuple_post_order(self, op: Expr) -> Expr:
+        """Rewrite Tuple after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const TupleNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_var_post_order(self, op: Constant) -> Expr:
+    def rewrite_var_post_order(self, op: Expr) -> Expr:
+        """Rewrite Var after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const VarNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_dataflow_var_post_order(self, op: Constant) -> Expr:
+    def rewrite_dataflow_var_post_order(self, op: Expr) -> Expr:
+        """Rewrite DataflowVar after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const DataflowVarNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_shape_expr_post_order(self, op: Constant) -> Expr:
+    def rewrite_shape_expr_post_order(self, op: Expr) -> Expr:
+        """Rewrite ShapeExpr after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const ShapeExprNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_runtime_dep_shape_post_order(self, op: Constant) -> Expr:
+    def rewrite_runtime_dep_shape_post_order(self, op: Expr) -> Expr:
+        """Rewrite RuntimeDepShape after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const RuntimeDepShapeNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_extern_func_post_order(self, op: Constant) -> Expr:
+    def rewrite_extern_func_post_order(self, op: Expr) -> Expr:
+        """Rewrite ExternFunc after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const ExternFuncNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_global_var_post_order(self, op: Constant) -> Expr:
+    def rewrite_global_var_post_order(self, op: Expr) -> Expr:
+        """Rewrite GlobalVar after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const GlobalVarNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_function_post_order(self, op: Constant) -> Expr:
+    def rewrite_function_post_order(self, op: Expr) -> Expr:
+        """Rewrite Function after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const FunctionNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_call_post_order(self, op: Constant) -> Expr:
+    def rewrite_call_post_order(self, op: Expr) -> Expr:
+        """Rewrite Call after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const CallNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_seq_expr_post_order(self, op: Constant) -> Expr:
+    def rewrite_seq_expr_post_order(self, op: Expr) -> Expr:
+        """Rewrite SeqExpr after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const SeqExprNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_if_post_order(self, op: Constant) -> Expr:
+    def rewrite_if_post_order(self, op: Expr) -> Expr:
+        """Rewrite If after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const IfNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_op_post_order(self, op: Constant) -> Expr:
+    def rewrite_op_post_order(self, op: Expr) -> Expr:
+        """Rewrite Op after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const OpNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
 
-    def rewrite_tuple_getitem_post_order(self, op: Constant) -> Expr:
+    def rewrite_tuple_getitem_post_order(self, op: Expr) -> Expr:
+        """Rewrite TupleGetItem after post-order visit the node.
+        The customization will work as
+        .. code-block:: c++
+            Expr VisitExpr_(const TupleGetItemNode* op){
+                Expr expr = self->VisitExprPostOrder_(op);
+                expr = USER_CUSTOMIZED_REWRITE_FUNC(expr);
+                return expr;
+            }
+
+        Parameters
+        ----------
+        op : Expr
+            The Expr to be rewritten, also the return value from the post-order visit.
+
+        Returns
+        -------
+        result : Expr
+            The Expr after rewritten.
+        """
         raise NotImplementedError
+
+    def set_var_remap(self, id: Id, var: Var) -> None:
+        """Remap a var to a new var in use-site.
+
+        Parameters
+        ----------
+        id : Id
+            The vid of the old var.
+        var : Var
+            The new var.
+        """
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.PyExprMutatorSetVarRemap(self._outer(), id, var)
+
+    def get_var_remap(self, id: Id) -> Var:
+        """Remap a var to a new var in use-site.
+
+        Parameters
+        ----------
+        id : Id
+            The vid of the old var
+
+        Returns
+        -------
+        var : Var
+            The remapped var.
+        """
+        # Using self._outer() to ref _PyExprMutator
+        return _ffi_api.PyExprMutatorGetVarRemap(self._outer(), id)
 
     def visit_with_new_scope(self, expr: Expr) -> Expr:
+        """Rewrite the expr with a new scope, used in a Function's body and the branches of If.
+
+        Parameters
+        ----------
+        expr : Expr
+            The expr to be visited.
+
+        Returns
+        -------
+        var : Var
+            The expr after visiting.
+        """
+        # Using self._outer() to ref _PyExprMutator
         return _ffi_api.PyExprMutatorVisitWithNewScope(self._outer(), expr)
 
     def lookup_binding(self, var: Var) -> Optional[Expr]:
+        """Look up the value bound to a variable.
+        Note: For function parameters, this function returns NullOpt.
+
+        Parameters
+        ----------
+        var : Var
+            The var to be looked up.
+
+        Returns
+        -------
+        var : Var
+            The value bound to the input var.
+        """
+        # Using self._outer() to ref _PyExprMutator
         return _ffi_api.PyExprMutatorLookupBinding(self._outer(), var)
 
-    def with_shape_and_type(self, var: Var, shape: None, t: Type) -> Var:  # TODO: shape anno
+    def with_shape_and_type(self, var: Var, shape: Optional[Object], t: Type) -> Var:
+        """Create a new var with specified shape and type if the original var's shape or type does
+        not match with the specified ones.
+
+        Parameters
+        ----------
+        var : Var
+            The var to be updated.
+        shape : Optional[Object]
+            The specified shape.
+        t : Type
+            The specified type.
+
+        Returns
+        -------
+        var : Var
+            The var filled with shape and type.
+        """
+        # Using self._outer() to ref _PyExprMutator
         return _ffi_api.PyExprMutatorWithShapeAndType(self._outer(), var, shape, t)

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=no-else-return, unidiomatic-typecheck, invalid-name, arguments-differ
 """The expression functor of Relax."""
+import tvm
 from typing import Optional
 from tvm.ir import Op
 from tvm.ir.base import structural_equal
@@ -31,684 +32,768 @@ from .expr import Binding, MatchShape, VarBinding
 from .expr import BindingBlock, DataflowBlock
 from .expr import _update_shape, _update_type
 from .block_builder import BlockBuilder
+from . import _ffi_api
 
 
-class ExprFunctor:
-    """
-    An abstract visitor defined over Expr.
-
-    Defines the default dispatch over expressions, and
-    implements memoization.
-    """
-
-    def visit_expr(self, expr):
-        """Apply the visitor to an expression."""
-        if isinstance(expr, Constant):
-            ret = self.visit_constant_(expr)
-        elif isinstance(expr, Tuple):
-            ret = self.visit_tuple_(expr)
-        elif isinstance(expr, DataflowVar):
-            ret = self.visit_dataflow_var_(expr)
-        elif isinstance(expr, Var):
-            ret = self.visit_var_(expr)
-        elif isinstance(expr, ShapeExpr):
-            ret = self.visit_shape_expr_(expr)
-        elif isinstance(expr, RuntimeDepShape):
-            ret = self.visit_runtime_dep_shape_(expr)
-        elif isinstance(expr, ExternFunc):
-            ret = self.visit_extern_func_(expr)
-        elif isinstance(expr, GlobalVar):
-            ret = self.visit_global_var_(expr)
-        elif isinstance(expr, Function):
-            ret = self.visit_function_(expr)
-        elif isinstance(expr, Call):
-            ret = self.visit_call_(expr)
-        elif isinstance(expr, SeqExpr):
-            ret = self.visit_seq_expr_(expr)
-        elif isinstance(expr, If):
-            ret = self.visit_if_(expr)
-        elif isinstance(expr, Op):
-            ret = self.visit_op_(expr)
-        elif isinstance(expr, TupleGetItem):
-            ret = self.visit_tuple_getitem_(expr)
-        else:
-            raise TypeError("Invalid type: {0}".format(type(expr)))
-
-        return ret
-
-    def visit_constant_(self, op: Constant):
-        raise NotImplementedError()
-
-    def visit_tuple_(self, op: Tuple):
-        raise NotImplementedError()
-
-    def visit_dataflow_var_(self, op: DataflowVar):
-        raise NotImplementedError()
-
-    def visit_var_(self, op: Var):
-        raise NotImplementedError()
-
-    def visit_shape_expr_(self, op: ShapeExpr):
-        raise NotImplementedError()
-
-    def visit_runtime_dep_shape_(self, op: RuntimeDepShape):
-        raise NotImplementedError()
-
-    def visit_extern_func_(self, op: ExternFunc):
-        raise NotImplementedError()
-
-    def visit_global_var_(self, op: GlobalVar):
-        raise NotImplementedError()
-
-    def visit_function_(self, op: Function):
-        raise NotImplementedError()
-
-    def visit_call_(self, op: Call):
-        raise NotImplementedError()
-
-    def visit_seq_expr_(self, op: SeqExpr):
-        raise NotImplementedError()
-
-    def visit_if_(self, op: If):
-        raise NotImplementedError()
-
-    def visit_op_(self, op: Op):
-        raise NotImplementedError()
-
-    def visit_tuple_getitem_(self, op: TupleGetItem):
-        raise NotImplementedError()
+# @tvm._ffi.register_object("relax.ExprFunctor")
+class ExprFunctor(tvm.runtime.Object):
+    """TODO"""
 
 
+# @tvm._ffi.register_object("relax.ExprVisitor")
 class ExprVisitor(ExprFunctor):
-    """
-    A visitor over Expr.
-
-    The default behavior recursively traverses the AST.
-    """
-
-    def visit_expr(self, expr: Expr) -> None:
-        ExprFunctor.visit_expr(self, expr)
-
-    def visit_constant_(self, op: Constant) -> None:
-        self.visit_span(op.span)
-
-        if op.shape_:
-            self.visit_expr(op.shape_)
-
-    def visit_global_var_(self, op: GlobalVar) -> None:
-        self.visit_span(op.span)
-
-    def visit_tuple_(self, op: Tuple) -> None:
-        self.visit_span(op.span)
-        for field in op.fields:
-            self.visit_expr(field)
-
-        if op.shape_:
-            self.visit_expr(op.shape_)
-
-    def visit_var_(self, op: Var) -> None:
-        self.visit_span(op.span)
-
-    def visit_dataflow_var_(self, op: DataflowVar) -> None:
-        self.visit_span(op.span)
-
-    def visit_function_(self, op: Function) -> None:
-        self.visit_span(op.span)
-        for param in op.params:
-            self.visit_var_def(param)
-
-        self.visit_expr(op.body)
-
-    def visit_call_(self, op: Call) -> None:
-        self.visit_span(op.span)
-        self.visit_expr(op.op)
-
-        for ty_arg in op.type_args:
-            self.visit_type(ty_arg)
-
-        for arg in op.args:
-            self.visit_expr(arg)
-
-        if op.shape_:
-            self.visit_expr(op.shape_)
-
-    def visit_if_(self, op: If) -> None:
-        self.visit_span(op.span)
-        self.visit_expr(op.cond)
-        self.visit_expr(op.true_branch)
-        self.visit_expr(op.false_branch)
-
-    def visit_op_(self, op: Op) -> None:
-        pass
-
-    def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
-        self.visit_span(op.span)
-        self.visit_expr(op.tuple_value)
-
-    def visit_shape_expr_(self, op: ShapeExpr) -> None:
-        self.visit_span(op.span)
-
-    def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
-        self.visit_span(op.span)
-
-    def visit_extern_func_(self, op: ExternFunc) -> None:
-        self.visit_span(op.span)
-
-    def visit_seq_expr_(self, op: SeqExpr) -> None:
-        self.visit_span(op.span)
-        for block in op.blocks:
-            self.visit_binding_block(block)
-        self.visit_expr(op.body)
-
-    def visit_type(self, t: Type) -> None:
-        pass
-
-    def visit_span(self, span: Span) -> None:
-        pass
-
-    def visit_var_binding_(self, binding: VarBinding) -> None:
-        self.visit_expr(binding.value)
-        self.visit_var_def(binding.var)
-
-    def visit_match_shape_(self, binding: MatchShape) -> None:
-        self.visit_expr(binding.value)
-        self.visit_expr(ShapeExpr(binding.pattern))
-        if binding.var:
-            self.visit_var_def(binding.var)
-
-    def visit_binding_block_(self, block: BindingBlock) -> None:
-        for binding in block.bindings:
-            self.visit_binding(binding)
-
-    def visit_dataflow_block_(self, block: DataflowBlock) -> None:
-        for binding in block.bindings:
-            self.visit_binding(binding)
-
-    def visit_var_def_(self, var: Var) -> None:
-        self.visit_span(var.span)
-
-        if var.shape_:
-            self.visit_expr(var.shape_)
-
-    def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
-        self.visit_span(var.span)
-
-        if var.shape_:
-            self.visit_expr(var.shape_)
-
-    def visit_binding(self, binding: Binding) -> None:
-        if isinstance(binding, MatchShape):
-            self.visit_match_shape_(binding)
-        elif isinstance(binding, VarBinding):
-            self.visit_var_binding_(binding)
-        else:
-            raise TypeError("Invalid type: {0}".format(type(binding)))
-
-    def visit_binding_block(self, block: BindingBlock) -> None:
-        if isinstance(block, DataflowBlock):
-            self.visit_dataflow_block_(block)
-        elif isinstance(block, BindingBlock):
-            self.visit_binding_block_(block)
-        else:
-            raise TypeError("Invalid type: {0}".format(type(block)))
-
-    def visit_var_def(self, var: Var):
-        if isinstance(var, DataflowVar):
-            self.visit_dataflow_var_def_(var)
-        elif isinstance(var, Var):
-            self.visit_var_def_(var)
-        else:
-            raise TypeError("Invalid type: {0}".format(type(var)))
-
-
-class ExprMutatorBase(ExprFunctor):
-    """
-    A mutator works in unnormalized form.
-
-    ExprMutatorBase expects input AST to be in the unnormalized form,
-    i.e., _checked_type_ and shape_ of expressions can be None,
-    and the expressions may nest (and as a result the AST is not in ANF).
-    """
-
-    def visit_expr(self, expr: Expr) -> Expr:
-        return ExprFunctor.visit_expr(self, expr)
-
-    def visit_constant_(self, op: Constant) -> Expr:
-        return op
-
-    def visit_global_var_(self, op: GlobalVar) -> Expr:
-        return op
-
-    def visit_tuple_(self, op: Tuple) -> Expr:
-        unchanged = True
-        fields = []
-        for field in op.fields:
-            new_field = self.visit_expr(field)
-            fields.append(new_field)
-            unchanged &= field.same_as(new_field)
-
-        if unchanged:
-            return op
-        else:
-            return Tuple(fields, op.span)
-
-    def visit_var_(self, op: Var) -> Expr:
-        return op
-
-    def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
-        return op
-
-    def visit_function_(self, op: Function) -> Expr:
-        body = self.visit_expr(op.body)
-
-        if op.body.same_as(body):
-            return op
-        else:
-            return Function(op.params, body, op.ret_type, op.attrs, op.span)
-
-    def visit_call_(self, call_node: Call) -> Expr:
-        new_op = self.visit_expr(call_node.op)
-        unchanged = call_node.op.same_as(new_op)
-
-        ty_args = []
-        for ty_arg in call_node.type_args:
-            new_ty_arg = self.visit_type(ty_arg)
-            ty_args.append(new_ty_arg)
-            unchanged &= ty_arg.same_as(new_ty_arg)
-
-        call_args = []
-        for arg in call_node.args:
-            new_arg = self.visit_expr(arg)
-            call_args.append(new_arg)
-            unchanged &= arg.same_as(new_arg)
-
-        if unchanged:
-            return call_node
-        else:
-            return Call(new_op, call_args, call_node.attrs, ty_args, call_node.span)
-
-    def visit_if_(self, op: If) -> Expr:
-        guard = self.visit_expr(op.cond)
-        true_b = self.visit_expr(op.true_branch)
-        false_b = self.visit_expr(op.false_branch)
-        if (
-            op.cond.same_as(guard)
-            and op.true_branch.same_as(true_b)
-            and op.false_branch.same_as(false_b)
-        ):
-            return op
-        else:
-            return If(guard, true_b, false_b, op.span)
-
-    def visit_op_(self, op: Op) -> Expr:
-        return op
-
-    def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
-        t = self.visit_expr(op.tuple_value)
-        if op.tuple_value.same_as(t):
-            return op
-        else:
-            return TupleGetItem(t, op.index)
-
-    def visit_shape_expr_(self, op: ShapeExpr) -> Expr:
-        return op
-
-    def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> Expr:
-        return op
-
-    def visit_extern_func_(self, op: ExternFunc) -> Expr:
-        return op
-
-    def visit_seq_expr_(self, op: SeqExpr) -> Expr:
-        all_blocks_unchanged = True
-        blocks = []
-        for block in op.blocks:
-            new_block = self.visit_binding_block(block)
-            if new_block.bindings:
-                blocks.append(new_block)
-            all_blocks_unchanged &= block.same_as(new_block)
-
-        body = self.visit_expr(op.body)
-        if all_blocks_unchanged and op.body.same_as(body):
-            return op
-        else:
-            return SeqExpr(blocks, body, op.span)
-
-    def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
-        """Mutate BindingBlock.
-
-        Parameters
-        ----------
-        block: BindingBlock
-            The binding block to be visited.
-
-        Returns
-        -------
-        block: BindingBlock
-            The binding block after transformation.
-        """
-        bindings = []
-        if isinstance(block, BindingBlock):
-            for binding in block.bindings:
-                if isinstance(binding, VarBinding):
-                    new_value = self.visit_expr(binding.value)
-                    bindings.append(VarBinding(binding.var, new_value, binding.span))
-                elif isinstance(binding, MatchShape):
-                    new_value = self.visit_expr(binding.value)
-                    bindings.append(
-                        MatchShape(new_value, binding.pattern, binding.var, binding.span)
-                    )
-                else:
-                    raise TypeError("Invalid type: {0}".format(type(block)))
-        else:
-            raise TypeError("Invalid type: {0}".format(type(block)))
-        if isinstance(block, DataflowBlock):
-            return DataflowBlock(bindings)
-        else:
-            return BindingBlock(bindings)
-
-    def visit_type(self, t: Type) -> Type:
-        return t
-
-
-class ExprMutator(ExprMutatorBase):
-    """
-    A mutator works in normal form.
-
-    ExprMutator expects input AST to be in the normal form, i.e., the expressions are normalized(no
-    nesting and hence the AST is in ANF), and all checked_type_ and shape_ of expressions are
-    available. Note: We can use relax.transform.Normalize()(mod) to transform relax IR into
-    the normal form.
-    """
-
-    def __init__(self, mod: Optional[IRModule] = None) -> None:
-        super().__init__()
-        self.builder_ = BlockBuilder(mod)
-        self.var_remap_ = dict()
-
-    def visit_expr(self, expr) -> Expr:
-        return self.builder_.normalize(ExprFunctor.visit_expr(self, expr))
-
-    def visit_tuple_(self, op: Tuple) -> Expr:
-        unchanged = True
-        fields = []
-        for field in op.fields:
-            new_field = self.visit_expr(field)
-            fields.append(new_field)
-            unchanged &= field.same_as(new_field)
-
-        if unchanged:
-            return op
-        else:
-            new_tuple = Tuple(fields, op.span)
-            return new_tuple
-
-    def visit_var_(self, op: Var) -> Expr:
-        if op.vid in self.var_remap_:
-            return self.var_remap_[op.vid]
-
-        return op
-
-    def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
-        if op.vid in self.var_remap_:
-            return self.var_remap_[op.vid]
-
-        return op
-
-    def visit_function_(self, op: Function) -> Expr:
-        params = []
-        all_params_unchanged = True
-        for param in op.params:
-            new_param = self.visit_var_def(param)
-            params.append(new_param)
-            all_params_unchanged &= param.same_as(new_param)
-
-        ret_type = self.visit_type(op.ret_type)
-        body = self.visit_with_new_scope(op.body)
-
-        # TODO(@lesheng): op.ret_type.same_as(ret_type) after Type.same_as is fixed
-        if all_params_unchanged and (op.ret_type == ret_type) and op.body.same_as(body):
-            return op
-        else:
-            return Function(params, body, ret_type, op.attrs, op.span)
-
-    def visit_if_(self, op: If) -> Expr:
-        guard = self.visit_expr(op.cond)
-        true_b = self.visit_with_new_scope(op.true_branch)
-        false_b = self.visit_with_new_scope(op.false_branch)
-        if (
-            op.cond.same_as(guard)
-            and op.true_branch.same_as(true_b)
-            and op.false_branch.same_as(false_b)
-        ):
-            return op
-        else:
-            return If(guard, true_b, false_b, op.span)
-
-    def visit_seq_expr_(self, op: SeqExpr) -> Expr:
-        all_blocks_unchanged = True
-        blocks = []
-        for block in op.blocks:
-            new_block = self.visit_binding_block(block)
-            if new_block.bindings:
-                blocks.append(new_block)
-            all_blocks_unchanged &= block.same_as(new_block)
-
-        self.builder_._begin_binding_block()
-        body = self.visit_expr(op.body)
-        prologue = self.builder_._end_block()
-        if prologue.bindings:
-            blocks.append(prologue)
-            all_blocks_unchanged = False
-
-        if all_blocks_unchanged and op.body.same_as(body):
-            return op
-        else:
-            return SeqExpr(blocks, body, op.span)
-
-    def visit_var_binding_(self, binding: VarBinding) -> None:
-        """Visit VarBinding, a new VarBinding will be emitted
-
-        Parameters
-        ----------
-        binding: VarBinding
-            The VarBinding to be visited.
-        """
-        new_value = self.visit_expr(binding.value)
-        new_var = self.visit_var_def(binding.var)
-
-        def emit(b: VarBinding):
-            if self.builder_.current_block_is_dataflow() and not isinstance(b.var, DataflowVar):
-                self.builder_.emit_output_var_binding(b)
-            else:
-                self.builder_.emit_var_binding(b)
-
-        if binding.var.same_as(new_var) and binding.value.same_as(new_value):
-            emit(binding)
-            return
-
-        temp = self.with_shape_and_type(new_var, new_value.shape_, new_value._checked_type_)
-        if not temp.same_as(new_var):
-            new_var = temp
-            self.var_remap_[binding.var.vid] = new_var
-
-        emit(VarBinding(new_var, new_value))
-
-    def visit_match_shape_(self, binding: MatchShape) -> None:
-        """Visit MatchShape, a new MatchShape will be emitted
-
-        Parameters
-        ----------
-        binding: MatchShape
-            The MatchShape binding to be visited.
-        """
-        new_value = self.visit_expr(binding.value)
-        new_pattern = self.visit_expr(ShapeExpr(binding.pattern))
-
-        if binding.var:
-            new_shape = None
-            if new_value._checked_type_ and isinstance(new_value._checked_type_, DynTensorType):
-                new_shape = new_pattern
-            new_var = self.visit_var_def(binding.var)
-            temp = self.with_shape_and_type(new_var, new_shape, new_value._checked_type_)
-            if not temp.same_as(new_var):
-                new_var = temp
-                self.var_remap_[binding.var.vid] = new_var
-
-        if binding.value.same_as(new_value) and binding.pattern.same_as(new_pattern):
-            if not binding.var or (binding.var and binding.var.same_as(new_var)):
-                self.builder_.match_shape_binding(binding)
-                return
-
-        self.builder_.match_shape_binding(MatchShape(new_value, new_pattern.values, new_var))
-
-    def visit_binding_block_(self, block: BindingBlock) -> BindingBlock:
-        self.builder_._begin_binding_block()
-        for binding in block.bindings:
-            self.visit_binding(binding)
-        return self.builder_._end_block()
-
-    def visit_dataflow_block_(self, block: DataflowBlock) -> BindingBlock:
-        self.builder_._begin_dataflow_block()
-        for binding in block.bindings:
-            self.visit_binding(binding)
-        return self.builder_._end_block()
-
-    def visit_dataflow_var_def_(self, var: DataflowVar) -> Var:
-        """Rewrite the dataflow var definition site.
-
-        Parameters
-        ----------
-        var: DataflowVar
-            The dataflow var to be visited.
-
-        Returns
-        -------
-        var: Dataflowvar
-            The dataflow var after post-order rewritten.
-        """
-        shape_unchanged = True
-        new_shape = None
-        if var.shape_:
-            new_shape = self.visit_expr(var.shape_)
-            shape_unchanged &= var.shape_.same_as(new_shape)
-
-        if shape_unchanged:
-            return var
-        else:
-            new_var = DataflowVar(var.vid, None, var._checked_type_, var.span)
-            _update_shape(new_var, new_shape)
-
-            self.var_remap_[var.vid] = new_var
-            return new_var
-
-    def visit_var_def_(self, var: Var) -> Var:
-        """Rewrite the var definition site.
-
-        Parameters
-        ----------
-        var: Var
-            The var to be visited.
-
-        Returns
-        -------
-        var: Var
-            The var after post-order rewritten.
-        """
-        shape_unchanged = True
-        new_shape = None
-        if var.shape_:
-            new_shape = self.visit_expr(var.shape_)
-            shape_unchanged &= var.shape_.same_as(new_shape)
-
-        if shape_unchanged:
-            return var
-        else:
-            new_var = Var(var.vid, None, var._checked_type_, var.span)
-            _update_shape(new_var, new_shape)
-
-            self.var_remap_[var.vid] = new_var
-            return new_var
-
-    def visit_binding(self, binding: Binding) -> None:
-        if isinstance(binding, MatchShape):
-            self.visit_match_shape_(binding)
-        elif isinstance(binding, VarBinding):
-            self.visit_var_binding_(binding)
-        else:
-            raise TypeError("Invalid type: {0}".format(type(binding)))
-
-    def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
-        if isinstance(block, DataflowBlock):
-            ret = self.visit_dataflow_block_(block)
-        elif isinstance(block, BindingBlock):
-            ret = self.visit_binding_block_(block)
-        else:
-            raise TypeError("Invalid type: {0}".format(type(block)))
-
-        return ret
-
-    def visit_var_def(self, var: Var) -> Var:
-        ret = None
-        if isinstance(var, DataflowVar):
-            ret = self.visit_dataflow_var_def_(var)
-        elif isinstance(var, Var):
-            ret = self.visit_var_def_(var)
-        else:
-            raise TypeError("Invalid type: {0}".format(type(var)))
-        return ret
-
-    def visit_with_new_scope(self, expr: Expr) -> Expr:
-        self.builder_._begin_binding_block()
-        ret = self.visit_expr(expr)
-        prologue = self.builder_._end_block()
-        if prologue.bindings:
-            ret = SeqExpr([prologue], ret)
-        return ret
-
-    def with_shape_and_type(self, var: Var, shape: Optional[Expr], t: Type) -> Var:
-        """Create a new var with specified shape and type if the original var's shape or type
-        does not match with the specified ones.
-
-        Parameters
-        ----------
-        var: Var
-            The var to be updated.
-        shape: Optional[Expr]
-            The specified shape.
-        t: Type
-            The specified type.
-
-        Returns
-        -------
-        var: Var
-            The var filled with shape and type.
-        """
-        shape_changed = (var.shape_ is not None) ^ (shape is not None)
-        shape_changed |= (
-            var.shape_ and shape and not self.builder_.can_prove_shape_equal(var.shape_, shape)
-        )
-
-        type_changed = (var._checked_type_ is not None) ^ (t is not None)
-        type_changed |= var._checked_type_ and t and not structural_equal(var._checked_type_, t)
-
-        if shape_changed or type_changed:
-            new_var = (
-                DataflowVar(var.vid, None, None, var.span)
-                if isinstance(var, DataflowVar)
-                else Var(var.vid, None, None, var.span)
+    """TODO"""
+
+
+# @tvm._ffi.register_object("relax.ExprMutatorBase")
+class ExprMutatorBase:
+    """TODO"""
+
+
+# @tvm._ffi.register_object("relax.ExprMutator")
+class ExprMutator:
+    """TODO"""
+
+
+def _wrap_visitor(visitor_cls):
+    class PyVisitor(tvm.runtime.Object):
+        def __init__(self) -> None:
+            self.handle = None
+
+            all_func_names = [
+                "visit_expr",
+                "visit_constant_",
+                "visit_tuple_",
+                "visit_var_",
+                "visit_dataflow_var_",
+                "visit_shape_expr_",
+                "visit_runtime_dep_shape_",
+                "visit_extern_func_",
+                "visit_global_var_",
+                "visit_function_",
+                "visit_call_",
+                "visit_seq_expr_",
+                "visit_if_",
+                "visit_op_",
+                "visit_tuple_getitem_",
+                "visit_binding",
+                "visit_var_binding_",
+                "visit_match_shape_",
+                "visit_binding_block",
+                "visit_binding_block_",
+                "visit_dataflow_block_",
+                "visit_var_def",
+                "visit_var_def_",
+                "visit_dataflow_var_def_",
+                "visit_type",
+                "visit_span",
+            ]
+            # packed_funcs = []
+            # packed_func_names = []
+            packed_value = []
+
+            inst = visitor_cls()
+
+            for func_name in all_func_names:
+                if hasattr(inst, func_name):
+                    # packed_funcs.append(visitor_cls.getattr[func_name])
+                    # packed_func_names.append(func_name)
+                    packed_value.append(func_name)
+                    packed_value.append(getattr(inst, func_name))
+
+            print(packed_value)
+            self.__init_handle_by_constructor__(
+                _ffi_api.MakeExprVisitor, *packed_value  # packed_funcs, packed_func_names
             )
-            _update_shape(new_var, var.shape_)
-            _update_type(new_var, var._checked_type_)
-            var = new_var
 
-        if shape_changed:
-            var.shape_ = shape
+    return PyVisitor
 
-        if type_changed:
-            var._checked_type_ = t
 
-        return var
+def visitor(visitor_cls=None):
+    def create_visitor(visitor_cls):
+        return _wrap_visitor(visitor_cls)
 
-    def lookup_binding(self, var: Var) -> Optional[Expr]:
-        return self.builder_.lookup_binding(var)
+    if visitor_cls:
+        return create_visitor(visitor_cls)
+    return create_visitor
+
+
+# class ExprFunctor:
+#     """
+#     An abstract visitor defined over Expr.
+
+#     Defines the default dispatch over expressions, and
+#     implements memoization.
+#     """
+
+#     def visit_expr(self, expr):
+#         """Apply the visitor to an expression."""
+#         if isinstance(expr, Constant):
+#             ret = self.visit_constant_(expr)
+#         elif isinstance(expr, Tuple):
+#             ret = self.visit_tuple_(expr)
+#         elif isinstance(expr, DataflowVar):
+#             ret = self.visit_dataflow_var_(expr)
+#         elif isinstance(expr, Var):
+#             ret = self.visit_var_(expr)
+#         elif isinstance(expr, ShapeExpr):
+#             ret = self.visit_shape_expr_(expr)
+#         elif isinstance(expr, RuntimeDepShape):
+#             ret = self.visit_runtime_dep_shape_(expr)
+#         elif isinstance(expr, ExternFunc):
+#             ret = self.visit_extern_func_(expr)
+#         elif isinstance(expr, GlobalVar):
+#             ret = self.visit_global_var_(expr)
+#         elif isinstance(expr, Function):
+#             ret = self.visit_function_(expr)
+#         elif isinstance(expr, Call):
+#             ret = self.visit_call_(expr)
+#         elif isinstance(expr, SeqExpr):
+#             ret = self.visit_seq_expr_(expr)
+#         elif isinstance(expr, If):
+#             ret = self.visit_if_(expr)
+#         elif isinstance(expr, Op):
+#             ret = self.visit_op_(expr)
+#         elif isinstance(expr, TupleGetItem):
+#             ret = self.visit_tuple_getitem_(expr)
+#         else:
+#             raise TypeError("Invalid type: {0}".format(type(expr)))
+
+#         return ret
+
+#     def visit_constant_(self, op: Constant):
+#         raise NotImplementedError()
+
+#     def visit_tuple_(self, op: Tuple):
+#         raise NotImplementedError()
+
+#     def visit_dataflow_var_(self, op: DataflowVar):
+#         raise NotImplementedError()
+
+#     def visit_var_(self, op: Var):
+#         raise NotImplementedError()
+
+#     def visit_shape_expr_(self, op: ShapeExpr):
+#         raise NotImplementedError()
+
+#     def visit_runtime_dep_shape_(self, op: RuntimeDepShape):
+#         raise NotImplementedError()
+
+#     def visit_extern_func_(self, op: ExternFunc):
+#         raise NotImplementedError()
+
+#     def visit_global_var_(self, op: GlobalVar):
+#         raise NotImplementedError()
+
+#     def visit_function_(self, op: Function):
+#         raise NotImplementedError()
+
+#     def visit_call_(self, op: Call):
+#         raise NotImplementedError()
+
+#     def visit_seq_expr_(self, op: SeqExpr):
+#         raise NotImplementedError()
+
+#     def visit_if_(self, op: If):
+#         raise NotImplementedError()
+
+#     def visit_op_(self, op: Op):
+#         raise NotImplementedError()
+
+#     def visit_tuple_getitem_(self, op: TupleGetItem):
+#         raise NotImplementedError()
+
+
+# class ExprVisitor(ExprFunctor):
+#     """
+#     A visitor over Expr.
+
+#     The default behavior recursively traverses the AST.
+#     """
+
+#     def visit_expr(self, expr: Expr) -> None:
+#         ExprFunctor.visit_expr(self, expr)
+
+#     def visit_constant_(self, op: Constant) -> None:
+#         self.visit_span(op.span)
+
+#         if op.shape_:
+#             self.visit_expr(op.shape_)
+
+#     def visit_global_var_(self, op: GlobalVar) -> None:
+#         self.visit_span(op.span)
+
+#     def visit_tuple_(self, op: Tuple) -> None:
+#         self.visit_span(op.span)
+#         for field in op.fields:
+#             self.visit_expr(field)
+
+#         if op.shape_:
+#             self.visit_expr(op.shape_)
+
+#     def visit_var_(self, op: Var) -> None:
+#         self.visit_span(op.span)
+
+#     def visit_dataflow_var_(self, op: DataflowVar) -> None:
+#         self.visit_span(op.span)
+
+#     def visit_function_(self, op: Function) -> None:
+#         self.visit_span(op.span)
+#         for param in op.params:
+#             self.visit_var_def(param)
+
+#         self.visit_expr(op.body)
+
+#     def visit_call_(self, op: Call) -> None:
+#         self.visit_span(op.span)
+#         self.visit_expr(op.op)
+
+#         for ty_arg in op.type_args:
+#             self.visit_type(ty_arg)
+
+#         for arg in op.args:
+#             self.visit_expr(arg)
+
+#         if op.shape_:
+#             self.visit_expr(op.shape_)
+
+#     def visit_if_(self, op: If) -> None:
+#         self.visit_span(op.span)
+#         self.visit_expr(op.cond)
+#         self.visit_expr(op.true_branch)
+#         self.visit_expr(op.false_branch)
+
+#     def visit_op_(self, op: Op) -> None:
+#         pass
+
+#     def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
+#         self.visit_span(op.span)
+#         self.visit_expr(op.tuple_value)
+
+#     def visit_shape_expr_(self, op: ShapeExpr) -> None:
+#         self.visit_span(op.span)
+
+#     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
+#         self.visit_span(op.span)
+
+#     def visit_extern_func_(self, op: ExternFunc) -> None:
+#         self.visit_span(op.span)
+
+#     def visit_seq_expr_(self, op: SeqExpr) -> None:
+#         self.visit_span(op.span)
+#         for block in op.blocks:
+#             self.visit_binding_block(block)
+#         self.visit_expr(op.body)
+
+#     def visit_type(self, t: Type) -> None:
+#         pass
+
+#     def visit_span(self, span: Span) -> None:
+#         pass
+
+#     def visit_var_binding_(self, binding: VarBinding) -> None:
+#         self.visit_expr(binding.value)
+#         self.visit_var_def(binding.var)
+
+#     def visit_match_shape_(self, binding: MatchShape) -> None:
+#         self.visit_expr(binding.value)
+#         self.visit_expr(ShapeExpr(binding.pattern))
+#         if binding.var:
+#             self.visit_var_def(binding.var)
+
+#     def visit_binding_block_(self, block: BindingBlock) -> None:
+#         for binding in block.bindings:
+#             self.visit_binding(binding)
+
+#     def visit_dataflow_block_(self, block: DataflowBlock) -> None:
+#         for binding in block.bindings:
+#             self.visit_binding(binding)
+
+#     def visit_var_def_(self, var: Var) -> None:
+#         self.visit_span(var.span)
+
+#         if var.shape_:
+#             self.visit_expr(var.shape_)
+
+#     def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
+#         self.visit_span(var.span)
+
+#         if var.shape_:
+#             self.visit_expr(var.shape_)
+
+#     def visit_binding(self, binding: Binding) -> None:
+#         if isinstance(binding, MatchShape):
+#             self.visit_match_shape_(binding)
+#         elif isinstance(binding, VarBinding):
+#             self.visit_var_binding_(binding)
+#         else:
+#             raise TypeError("Invalid type: {0}".format(type(binding)))
+
+#     def visit_binding_block(self, block: BindingBlock) -> None:
+#         if isinstance(block, DataflowBlock):
+#             self.visit_dataflow_block_(block)
+#         elif isinstance(block, BindingBlock):
+#             self.visit_binding_block_(block)
+#         else:
+#             raise TypeError("Invalid type: {0}".format(type(block)))
+
+#     def visit_var_def(self, var: Var):
+#         if isinstance(var, DataflowVar):
+#             self.visit_dataflow_var_def_(var)
+#         elif isinstance(var, Var):
+#             self.visit_var_def_(var)
+#         else:
+#             raise TypeError("Invalid type: {0}".format(type(var)))
+
+
+# class ExprMutatorBase(ExprFunctor):
+#     """
+#     A mutator works in unnormalized form.
+
+#     ExprMutatorBase expects input AST to be in the unnormalized form,
+#     i.e., _checked_type_ and shape_ of expressions can be None,
+#     and the expressions may nest (and as a result the AST is not in ANF).
+#     """
+
+#     def visit_expr(self, expr: Expr) -> Expr:
+#         return ExprFunctor.visit_expr(self, expr)
+
+#     def visit_constant_(self, op: Constant) -> Expr:
+#         return op
+
+#     def visit_global_var_(self, op: GlobalVar) -> Expr:
+#         return op
+
+#     def visit_tuple_(self, op: Tuple) -> Expr:
+#         unchanged = True
+#         fields = []
+#         for field in op.fields:
+#             new_field = self.visit_expr(field)
+#             fields.append(new_field)
+#             unchanged &= field.same_as(new_field)
+
+#         if unchanged:
+#             return op
+#         else:
+#             return Tuple(fields, op.span)
+
+#     def visit_var_(self, op: Var) -> Expr:
+#         return op
+
+#     def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
+#         return op
+
+#     def visit_function_(self, op: Function) -> Expr:
+#         body = self.visit_expr(op.body)
+
+#         if op.body.same_as(body):
+#             return op
+#         else:
+#             return Function(op.params, body, op.ret_type, op.attrs, op.span)
+
+#     def visit_call_(self, call_node: Call) -> Expr:
+#         new_op = self.visit_expr(call_node.op)
+#         unchanged = call_node.op.same_as(new_op)
+
+#         ty_args = []
+#         for ty_arg in call_node.type_args:
+#             new_ty_arg = self.visit_type(ty_arg)
+#             ty_args.append(new_ty_arg)
+#             unchanged &= ty_arg.same_as(new_ty_arg)
+
+#         call_args = []
+#         for arg in call_node.args:
+#             new_arg = self.visit_expr(arg)
+#             call_args.append(new_arg)
+#             unchanged &= arg.same_as(new_arg)
+
+#         if unchanged:
+#             return call_node
+#         else:
+#             return Call(new_op, call_args, call_node.attrs, ty_args, call_node.span)
+
+#     def visit_if_(self, op: If) -> Expr:
+#         guard = self.visit_expr(op.cond)
+#         true_b = self.visit_expr(op.true_branch)
+#         false_b = self.visit_expr(op.false_branch)
+#         if (
+#             op.cond.same_as(guard)
+#             and op.true_branch.same_as(true_b)
+#             and op.false_branch.same_as(false_b)
+#         ):
+#             return op
+#         else:
+#             return If(guard, true_b, false_b, op.span)
+
+#     def visit_op_(self, op: Op) -> Expr:
+#         return op
+
+#     def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
+#         t = self.visit_expr(op.tuple_value)
+#         if op.tuple_value.same_as(t):
+#             return op
+#         else:
+#             return TupleGetItem(t, op.index)
+
+#     def visit_shape_expr_(self, op: ShapeExpr) -> Expr:
+#         return op
+
+#     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> Expr:
+#         return op
+
+#     def visit_extern_func_(self, op: ExternFunc) -> Expr:
+#         return op
+
+#     def visit_seq_expr_(self, op: SeqExpr) -> Expr:
+#         all_blocks_unchanged = True
+#         blocks = []
+#         for block in op.blocks:
+#             new_block = self.visit_binding_block(block)
+#             if new_block.bindings:
+#                 blocks.append(new_block)
+#             all_blocks_unchanged &= block.same_as(new_block)
+
+#         body = self.visit_expr(op.body)
+#         if all_blocks_unchanged and op.body.same_as(body):
+#             return op
+#         else:
+#             return SeqExpr(blocks, body, op.span)
+
+#     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
+#         """Mutate BindingBlock.
+
+#         Parameters
+#         ----------
+#         block: BindingBlock
+#             The binding block to be visited.
+
+#         Returns
+#         -------
+#         block: BindingBlock
+#             The binding block after transformation.
+#         """
+#         bindings = []
+#         if isinstance(block, BindingBlock):
+#             for binding in block.bindings:
+#                 if isinstance(binding, VarBinding):
+#                     new_value = self.visit_expr(binding.value)
+#                     bindings.append(VarBinding(binding.var, new_value, binding.span))
+#                 elif isinstance(binding, MatchShape):
+#                     new_value = self.visit_expr(binding.value)
+#                     bindings.append(
+#                         MatchShape(new_value, binding.pattern, binding.var, binding.span)
+#                     )
+#                 else:
+#                     raise TypeError("Invalid type: {0}".format(type(block)))
+#         else:
+#             raise TypeError("Invalid type: {0}".format(type(block)))
+#         if isinstance(block, DataflowBlock):
+#             return DataflowBlock(bindings)
+#         else:
+#             return BindingBlock(bindings)
+
+#     def visit_type(self, t: Type) -> Type:
+#         return t
+
+
+# class ExprMutator(ExprMutatorBase):
+#     """
+#     A mutator works in normal form.
+
+#     ExprMutator expects input AST to be in the normal form, i.e., the expressions are normalized(no
+#     nesting and hence the AST is in ANF), and all checked_type_ and shape_ of expressions are
+#     available. Note: We can use relax.transform.Normalize()(mod) to transform relax IR into
+#     the normal form.
+#     """
+
+#     def __init__(self, mod: Optional[IRModule] = None) -> None:
+#         super().__init__()
+#         self.builder_ = BlockBuilder(mod)
+#         self.var_remap_ = dict()
+
+#     def visit_expr(self, expr) -> Expr:
+#         return self.builder_.normalize(ExprFunctor.visit_expr(self, expr))
+
+#     def visit_tuple_(self, op: Tuple) -> Expr:
+#         unchanged = True
+#         fields = []
+#         for field in op.fields:
+#             new_field = self.visit_expr(field)
+#             fields.append(new_field)
+#             unchanged &= field.same_as(new_field)
+
+#         if unchanged:
+#             return op
+#         else:
+#             new_tuple = Tuple(fields, op.span)
+#             return new_tuple
+
+#     def visit_var_(self, op: Var) -> Expr:
+#         if op.vid in self.var_remap_:
+#             return self.var_remap_[op.vid]
+
+#         return op
+
+#     def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
+#         if op.vid in self.var_remap_:
+#             return self.var_remap_[op.vid]
+
+#         return op
+
+#     def visit_function_(self, op: Function) -> Expr:
+#         params = []
+#         all_params_unchanged = True
+#         for param in op.params:
+#             new_param = self.visit_var_def(param)
+#             params.append(new_param)
+#             all_params_unchanged &= param.same_as(new_param)
+
+#         ret_type = self.visit_type(op.ret_type)
+#         body = self.visit_with_new_scope(op.body)
+
+#         # TODO(@lesheng): op.ret_type.same_as(ret_type) after Type.same_as is fixed
+#         if all_params_unchanged and (op.ret_type == ret_type) and op.body.same_as(body):
+#             return op
+#         else:
+#             return Function(params, body, ret_type, op.attrs, op.span)
+
+#     def visit_if_(self, op: If) -> Expr:
+#         guard = self.visit_expr(op.cond)
+#         true_b = self.visit_with_new_scope(op.true_branch)
+#         false_b = self.visit_with_new_scope(op.false_branch)
+#         if (
+#             op.cond.same_as(guard)
+#             and op.true_branch.same_as(true_b)
+#             and op.false_branch.same_as(false_b)
+#         ):
+#             return op
+#         else:
+#             return If(guard, true_b, false_b, op.span)
+
+#     def visit_seq_expr_(self, op: SeqExpr) -> Expr:
+#         all_blocks_unchanged = True
+#         blocks = []
+#         for block in op.blocks:
+#             new_block = self.visit_binding_block(block)
+#             if new_block.bindings:
+#                 blocks.append(new_block)
+#             all_blocks_unchanged &= block.same_as(new_block)
+
+#         self.builder_._begin_binding_block()
+#         body = self.visit_expr(op.body)
+#         prologue = self.builder_._end_block()
+#         if prologue.bindings:
+#             blocks.append(prologue)
+#             all_blocks_unchanged = False
+
+#         if all_blocks_unchanged and op.body.same_as(body):
+#             return op
+#         else:
+#             return SeqExpr(blocks, body, op.span)
+
+#     def visit_var_binding_(self, binding: VarBinding) -> None:
+#         """Visit VarBinding, a new VarBinding will be emitted
+
+#         Parameters
+#         ----------
+#         binding: VarBinding
+#             The VarBinding to be visited.
+#         """
+#         new_value = self.visit_expr(binding.value)
+#         new_var = self.visit_var_def(binding.var)
+
+#         def emit(b: VarBinding):
+#             if self.builder_.current_block_is_dataflow() and not isinstance(b.var, DataflowVar):
+#                 self.builder_.emit_output_var_binding(b)
+#             else:
+#                 self.builder_.emit_var_binding(b)
+
+#         if binding.var.same_as(new_var) and binding.value.same_as(new_value):
+#             emit(binding)
+#             return
+
+#         temp = self.with_shape_and_type(new_var, new_value.shape_, new_value._checked_type_)
+#         if not temp.same_as(new_var):
+#             new_var = temp
+#             self.var_remap_[binding.var.vid] = new_var
+
+#         emit(VarBinding(new_var, new_value))
+
+#     def visit_match_shape_(self, binding: MatchShape) -> None:
+#         """Visit MatchShape, a new MatchShape will be emitted
+
+#         Parameters
+#         ----------
+#         binding: MatchShape
+#             The MatchShape binding to be visited.
+#         """
+#         new_value = self.visit_expr(binding.value)
+#         new_pattern = self.visit_expr(ShapeExpr(binding.pattern))
+
+#         if binding.var:
+#             new_shape = None
+#             if new_value._checked_type_ and isinstance(new_value._checked_type_, DynTensorType):
+#                 new_shape = new_pattern
+#             new_var = self.visit_var_def(binding.var)
+#             temp = self.with_shape_and_type(new_var, new_shape, new_value._checked_type_)
+#             if not temp.same_as(new_var):
+#                 new_var = temp
+#                 self.var_remap_[binding.var.vid] = new_var
+
+#         if binding.value.same_as(new_value) and binding.pattern.same_as(new_pattern):
+#             if not binding.var or (binding.var and binding.var.same_as(new_var)):
+#                 self.builder_.match_shape_binding(binding)
+#                 return
+
+#         self.builder_.match_shape_binding(MatchShape(new_value, new_pattern.values, new_var))
+
+#     def visit_binding_block_(self, block: BindingBlock) -> BindingBlock:
+#         self.builder_._begin_binding_block()
+#         for binding in block.bindings:
+#             self.visit_binding(binding)
+#         return self.builder_._end_block()
+
+#     def visit_dataflow_block_(self, block: DataflowBlock) -> BindingBlock:
+#         self.builder_._begin_dataflow_block()
+#         for binding in block.bindings:
+#             self.visit_binding(binding)
+#         return self.builder_._end_block()
+
+#     def visit_dataflow_var_def_(self, var: DataflowVar) -> Var:
+#         """Rewrite the dataflow var definition site.
+
+#         Parameters
+#         ----------
+#         var: DataflowVar
+#             The dataflow var to be visited.
+
+#         Returns
+#         -------
+#         var: Dataflowvar
+#             The dataflow var after post-order rewritten.
+#         """
+#         shape_unchanged = True
+#         new_shape = None
+#         if var.shape_:
+#             new_shape = self.visit_expr(var.shape_)
+#             shape_unchanged &= var.shape_.same_as(new_shape)
+
+#         if shape_unchanged:
+#             return var
+#         else:
+#             new_var = DataflowVar(var.vid, None, var._checked_type_, var.span)
+#             _update_shape(new_var, new_shape)
+
+#             self.var_remap_[var.vid] = new_var
+#             return new_var
+
+#     def visit_var_def_(self, var: Var) -> Var:
+#         """Rewrite the var definition site.
+
+#         Parameters
+#         ----------
+#         var: Var
+#             The var to be visited.
+
+#         Returns
+#         -------
+#         var: Var
+#             The var after post-order rewritten.
+#         """
+#         shape_unchanged = True
+#         new_shape = None
+#         if var.shape_:
+#             new_shape = self.visit_expr(var.shape_)
+#             shape_unchanged &= var.shape_.same_as(new_shape)
+
+#         if shape_unchanged:
+#             return var
+#         else:
+#             new_var = Var(var.vid, None, var._checked_type_, var.span)
+#             _update_shape(new_var, new_shape)
+
+#             self.var_remap_[var.vid] = new_var
+#             return new_var
+
+#     def visit_binding(self, binding: Binding) -> None:
+#         if isinstance(binding, MatchShape):
+#             self.visit_match_shape_(binding)
+#         elif isinstance(binding, VarBinding):
+#             self.visit_var_binding_(binding)
+#         else:
+#             raise TypeError("Invalid type: {0}".format(type(binding)))
+
+#     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
+#         if isinstance(block, DataflowBlock):
+#             ret = self.visit_dataflow_block_(block)
+#         elif isinstance(block, BindingBlock):
+#             ret = self.visit_binding_block_(block)
+#         else:
+#             raise TypeError("Invalid type: {0}".format(type(block)))
+
+#         return ret
+
+#     def visit_var_def(self, var: Var) -> Var:
+#         ret = None
+#         if isinstance(var, DataflowVar):
+#             ret = self.visit_dataflow_var_def_(var)
+#         elif isinstance(var, Var):
+#             ret = self.visit_var_def_(var)
+#         else:
+#             raise TypeError("Invalid type: {0}".format(type(var)))
+#         return ret
+
+#     def visit_with_new_scope(self, expr: Expr) -> Expr:
+#         self.builder_._begin_binding_block()
+#         ret = self.visit_expr(expr)
+#         prologue = self.builder_._end_block()
+#         if prologue.bindings:
+#             ret = SeqExpr([prologue], ret)
+#         return ret
+
+#     def with_shape_and_type(self, var: Var, shape: Optional[Expr], t: Type) -> Var:
+#         """Create a new var with specified shape and type if the original var's shape or type
+#         does not match with the specified ones.
+
+#         Parameters
+#         ----------
+#         var: Var
+#             The var to be updated.
+#         shape: Optional[Expr]
+#             The specified shape.
+#         t: Type
+#             The specified type.
+
+#         Returns
+#         -------
+#         var: Var
+#             The var filled with shape and type.
+#         """
+#         shape_changed = (var.shape_ is not None) ^ (shape is not None)
+#         shape_changed |= (
+#             var.shape_ and shape and not self.builder_.can_prove_shape_equal(var.shape_, shape)
+#         )
+
+#         type_changed = (var._checked_type_ is not None) ^ (t is not None)
+#         type_changed |= var._checked_type_ and t and not structural_equal(var._checked_type_, t)
+
+#         if shape_changed or type_changed:
+#             new_var = (
+#                 DataflowVar(var.vid, None, None, var.span)
+#                 if isinstance(var, DataflowVar)
+#                 else Var(var.vid, None, None, var.span)
+#             )
+#             _update_shape(new_var, var.shape_)
+#             _update_type(new_var, var._checked_type_)
+#             var = new_var
+
+#         if shape_changed:
+#             var.shape_ = shape
+
+#         if type_changed:
+#             var._checked_type_ = t
+
+#         return var
+
+#     def lookup_binding(self, var: Var) -> Optional[Expr]:
+#         return self.builder_.lookup_binding(var)

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -71,6 +71,7 @@ Example
 mutator = derived_object
 """
 A decorator to wrap user-customized PyExprMutator as TVM object _PyExprMutator.
+Note:  Cannot override visit function and post-order rewrite at the same time.
 
 Parameters
 ----------
@@ -107,6 +108,7 @@ Example
     mymutator.visit_binding(binding)
     mymutator.visit_binding_block(bindingblock)
     mymutator.visit_var_def(var)
+    # Note: In this case, we cannot override rewrite_tuple_post_order in MyExprMutator.
 """
 
 
@@ -1196,7 +1198,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_constant_post_order(self, op: Expr) -> Expr:
+    def rewrite_constant_post_order(self, op: Constant) -> Expr:
         """Rewrite Constant after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1208,8 +1210,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : Constant
+            The Constant to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1218,7 +1220,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_tuple_post_order(self, op: Expr) -> Expr:
+    def rewrite_tuple_post_order(self, op: Tuple) -> Expr:
         """Rewrite Tuple after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1230,8 +1232,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : Tuple
+            The Tuple to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1240,7 +1242,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_var_post_order(self, op: Expr) -> Expr:
+    def rewrite_var_post_order(self, op: Var) -> Expr:
         """Rewrite Var after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1252,8 +1254,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : Var
+            The Var to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1262,7 +1264,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_dataflow_var_post_order(self, op: Expr) -> Expr:
+    def rewrite_dataflow_var_post_order(self, op: DataflowVar) -> Expr:
         """Rewrite DataflowVar after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1274,8 +1276,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : DataflowVar
+            The DataflowVar to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1284,7 +1286,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_shape_expr_post_order(self, op: Expr) -> Expr:
+    def rewrite_shape_expr_post_order(self, op: ShapeExpr) -> Expr:
         """Rewrite ShapeExpr after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1296,8 +1298,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : ShapeExpr
+            The ShapeExpr to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1306,7 +1308,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_runtime_dep_shape_post_order(self, op: Expr) -> Expr:
+    def rewrite_runtime_dep_shape_post_order(self, op: RuntimeDepShape) -> Expr:
         """Rewrite RuntimeDepShape after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1318,8 +1320,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : RuntimeDepShape
+            The RuntimeDepShape to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1328,7 +1330,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_extern_func_post_order(self, op: Expr) -> Expr:
+    def rewrite_extern_func_post_order(self, op: ExternFunc) -> Expr:
         """Rewrite ExternFunc after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1340,8 +1342,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : ExternFunc
+            The ExternFunc to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1350,7 +1352,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_global_var_post_order(self, op: Expr) -> Expr:
+    def rewrite_global_var_post_order(self, op: GlobalVar) -> Expr:
         """Rewrite GlobalVar after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1362,8 +1364,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : GlobalVar
+            The GlobalVar to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1372,7 +1374,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_function_post_order(self, op: Expr) -> Expr:
+    def rewrite_function_post_order(self, op: Function) -> Expr:
         """Rewrite Function after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1384,8 +1386,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : Function
+            The Function to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1394,7 +1396,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_call_post_order(self, op: Expr) -> Expr:
+    def rewrite_call_post_order(self, op: Call) -> Expr:
         """Rewrite Call after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1406,8 +1408,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : Call
+            The Call to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1416,7 +1418,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_seq_expr_post_order(self, op: Expr) -> Expr:
+    def rewrite_seq_expr_post_order(self, op: SeqExpr) -> Expr:
         """Rewrite SeqExpr after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1428,8 +1430,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : SeqExpr
+            The SeqExpr to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1438,7 +1440,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_if_post_order(self, op: Expr) -> Expr:
+    def rewrite_if_post_order(self, op: If) -> Expr:
         """Rewrite If after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1450,8 +1452,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : If
+            The If to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1460,7 +1462,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_op_post_order(self, op: Expr) -> Expr:
+    def rewrite_op_post_order(self, op: Op) -> Expr:
         """Rewrite Op after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1472,8 +1474,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : Op
+            The Op to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------
@@ -1482,7 +1484,7 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def rewrite_tuple_getitem_post_order(self, op: Expr) -> Expr:
+    def rewrite_tuple_getitem_post_order(self, op: TupleGetItem) -> Expr:
         """Rewrite TupleGetItem after post-order visit the node.
         The customization will work as
         .. code-block:: c++
@@ -1494,8 +1496,8 @@ class PyExprMutator:
 
         Parameters
         ----------
-        op : Expr
-            The Expr to be rewritten, also the return value from the post-order visit.
+        op : TupleGetItem
+            The TupleGetItem to be rewritten, also the return value from the post-order visit.
 
         Returns
         -------

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -31,6 +31,7 @@ from .expr import Call, If, TupleGetItem
 from .expr import Binding, MatchShape, VarBinding
 from .expr import BindingBlock, DataflowBlock
 from .expr import _update_shape, _update_type
+from ..relay import Id
 from .block_builder import BlockBuilder
 from . import _ffi_api
 
@@ -92,6 +93,18 @@ class ExprMutator:
 class _PyExprVisitor(tvm.runtime.Object):
     """TODO"""
 
+    def visit_expr(self, expr: Expr) -> None:
+        return _ffi_api.PyExprVisitorVisitExpr(self, expr)
+
+    def visit_binding(self, binding: Binding) -> None:
+        return _ffi_api.PyExprVisitorVisitBinding(self, binding)
+
+    def visit_binding_block(self, block: BindingBlock) -> None:
+        return _ffi_api.PyExprVisitorVisitBindingBlock(self, block)
+
+    def visit_var_def(self, var: Var) -> None:
+        return _ffi_api.PyExprVisitorVisitVarDef(self, var)
+
 
 class PyExprVisitor(_PyExprVisitor):
     def visit_expr(self, expr: Expr) -> None:
@@ -111,8 +124,55 @@ class PyExprVisitor(_PyExprVisitor):
 class _PyExprMutator(tvm.runtime.Object):
     """TODO"""
 
+    builder_: BlockBuilder
 
-class PyExprMutator(_PyExprMutator):
+    def __init__(self, packed_value) -> None:
+        self.__init_handle_by_constructor__(_ffi_api.MakeExprMutator, *packed_value)
+
+    def set_var_remap(self, id: Id, var: Var) -> None:
+        return _ffi_api.PyExprMutatorSetVarRemap(self, id, var)
+
+    def get_var_remap(self, id: Id) -> Var:
+        return _ffi_api.PyExprMutatorGetVarRemap(self, id)
+
+    def visit_expr(self, expr: Expr) -> Expr:
+        return _ffi_api.PyExprMutatorVisitExpr(self, expr)
+
+    def visit_binding(self, binding: Binding) -> None:
+        return _ffi_api.PyExprMutatorVisitBinding(self, binding)
+
+    def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
+        return _ffi_api.PyExprMutatorVisitBindingBlock(self, block)
+
+    def visit_var_def(self, var: Var) -> Var:
+        return _ffi_api.PyExprMutatorVisitVarDef(self, var)
+
+    def visit_with_new_scope(self, expr: Expr) -> Expr:
+        return _ffi_api.PyExprMutatorVisitWithNewScope(self, expr)
+
+    def lookup_binding(self, var: Var) -> Optional[Expr]:
+        return _ffi_api.PyExprMutatorLookupBinding(self, var)
+
+    def with_shape_and_type(self, var: Var, shape: None, t: Type) -> Var:  # TODO: shape anno
+        return _ffi_api.PyExprMutatorWithShapeAndType(self, var, shape, t)
+
+
+class PyExprMutator:
+    def __init__(self) -> None:
+        """"""
+
+    def __getattr__(self, name):
+        if name in ["builder_"]:
+            return getattr(self._outer(), name)
+        else:
+            return self.__getattribute__(name)
+
+    def set_var_remap(self, id: Id, var: Var) -> None:
+        return _ffi_api.PyExprMutatorSetVarRemap(self._outer(), id, var)
+
+    def get_var_remap(self, id: Id) -> Var:
+        return _ffi_api.PyExprMutatorGetVarRemap(self._outer(), id)
+
     def visit_expr(self, expr: Expr) -> Expr:
         return _ffi_api.PyExprMutatorVisitExpr(self._outer(), expr)
 
@@ -124,6 +184,15 @@ class PyExprMutator(_PyExprMutator):
 
     def visit_var_def(self, var: Var) -> Var:
         return _ffi_api.PyExprMutatorVisitVarDef(self._outer(), var)
+
+    def visit_with_new_scope(self, expr: Expr) -> Expr:
+        return _ffi_api.PyExprMutatorVisitWithNewScope(self._outer(), expr)
+
+    def lookup_binding(self, var: Var) -> Optional[Expr]:
+        return _ffi_api.PyExprMutatorLookupBinding(self._outer(), var)
+
+    def with_shape_and_type(self, var: Var, shape: None, t: Type) -> Var:  # TODO: shape anno
+        return _ffi_api.PyExprMutatorWithShapeAndType(self._outer(), var, shape, t)
 
 
 def visitor(visitor_cls=None):
@@ -210,9 +279,10 @@ def mutator(mutator_cls=None):
                     packed_value.append(func_name)
                     packed_value.append(_extract(self._inst, func_name))
 
-            self.__init_handle_by_constructor__(_ffi_api.MakeExprMutator, *packed_value)
+            super().__init__(packed_value)
 
             self._inst._outer = weakref.ref(self)
+            self.builder_ = super().__getattr__("builder_")
 
         def __getattr__(self, name):
             # fall back to instance attribute if there is not any
@@ -230,684 +300,3 @@ def mutator(mutator_cls=None):
     PyMutator.__doc__ = mutator_cls.__doc__
     PyMutator.__module__ = mutator_cls.__module__
     return PyMutator
-
-
-# class ExprFunctor:
-#     """
-#     An abstract visitor defined over Expr.
-
-#     Defines the default dispatch over expressions, and
-#     implements memoization.
-#     """
-
-#     def visit_expr(self, expr):
-#         """Apply the visitor to an expression."""
-#         if isinstance(expr, Constant):
-#             ret = self.visit_constant_(expr)
-#         elif isinstance(expr, Tuple):
-#             ret = self.visit_tuple_(expr)
-#         elif isinstance(expr, DataflowVar):
-#             ret = self.visit_dataflow_var_(expr)
-#         elif isinstance(expr, Var):
-#             ret = self.visit_var_(expr)
-#         elif isinstance(expr, ShapeExpr):
-#             ret = self.visit_shape_expr_(expr)
-#         elif isinstance(expr, RuntimeDepShape):
-#             ret = self.visit_runtime_dep_shape_(expr)
-#         elif isinstance(expr, ExternFunc):
-#             ret = self.visit_extern_func_(expr)
-#         elif isinstance(expr, GlobalVar):
-#             ret = self.visit_global_var_(expr)
-#         elif isinstance(expr, Function):
-#             ret = self.visit_function_(expr)
-#         elif isinstance(expr, Call):
-#             ret = self.visit_call_(expr)
-#         elif isinstance(expr, SeqExpr):
-#             ret = self.visit_seq_expr_(expr)
-#         elif isinstance(expr, If):
-#             ret = self.visit_if_(expr)
-#         elif isinstance(expr, Op):
-#             ret = self.visit_op_(expr)
-#         elif isinstance(expr, TupleGetItem):
-#             ret = self.visit_tuple_getitem_(expr)
-#         else:
-#             raise TypeError("Invalid type: {0}".format(type(expr)))
-
-#         return ret
-
-#     def visit_constant_(self, op: Constant):
-#         raise NotImplementedError()
-
-#     def visit_tuple_(self, op: Tuple):
-#         raise NotImplementedError()
-
-#     def visit_dataflow_var_(self, op: DataflowVar):
-#         raise NotImplementedError()
-
-#     def visit_var_(self, op: Var):
-#         raise NotImplementedError()
-
-#     def visit_shape_expr_(self, op: ShapeExpr):
-#         raise NotImplementedError()
-
-#     def visit_runtime_dep_shape_(self, op: RuntimeDepShape):
-#         raise NotImplementedError()
-
-#     def visit_extern_func_(self, op: ExternFunc):
-#         raise NotImplementedError()
-
-#     def visit_global_var_(self, op: GlobalVar):
-#         raise NotImplementedError()
-
-#     def visit_function_(self, op: Function):
-#         raise NotImplementedError()
-
-#     def visit_call_(self, op: Call):
-#         raise NotImplementedError()
-
-#     def visit_seq_expr_(self, op: SeqExpr):
-#         raise NotImplementedError()
-
-#     def visit_if_(self, op: If):
-#         raise NotImplementedError()
-
-#     def visit_op_(self, op: Op):
-#         raise NotImplementedError()
-
-#     def visit_tuple_getitem_(self, op: TupleGetItem):
-#         raise NotImplementedError()
-
-
-# class ExprVisitor(ExprFunctor):
-#     """
-#     A visitor over Expr.
-
-#     The default behavior recursively traverses the AST.
-#     """
-
-#     def visit_expr(self, expr: Expr) -> None:
-#         ExprFunctor.visit_expr(self, expr)
-
-#     def visit_constant_(self, op: Constant) -> None:
-#         self.visit_span(op.span)
-
-#         if op.shape_:
-#             self.visit_expr(op.shape_)
-
-#     def visit_global_var_(self, op: GlobalVar) -> None:
-#         self.visit_span(op.span)
-
-#     def visit_tuple_(self, op: Tuple) -> None:
-#         self.visit_span(op.span)
-#         for field in op.fields:
-#             self.visit_expr(field)
-
-#         if op.shape_:
-#             self.visit_expr(op.shape_)
-
-#     def visit_var_(self, op: Var) -> None:
-#         self.visit_span(op.span)
-
-#     def visit_dataflow_var_(self, op: DataflowVar) -> None:
-#         self.visit_span(op.span)
-
-#     def visit_function_(self, op: Function) -> None:
-#         self.visit_span(op.span)
-#         for param in op.params:
-#             self.visit_var_def(param)
-
-#         self.visit_expr(op.body)
-
-#     def visit_call_(self, op: Call) -> None:
-#         self.visit_span(op.span)
-#         self.visit_expr(op.op)
-
-#         for ty_arg in op.type_args:
-#             self.visit_type(ty_arg)
-
-#         for arg in op.args:
-#             self.visit_expr(arg)
-
-#         if op.shape_:
-#             self.visit_expr(op.shape_)
-
-#     def visit_if_(self, op: If) -> None:
-#         self.visit_span(op.span)
-#         self.visit_expr(op.cond)
-#         self.visit_expr(op.true_branch)
-#         self.visit_expr(op.false_branch)
-
-#     def visit_op_(self, op: Op) -> None:
-#         pass
-
-#     def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
-#         self.visit_span(op.span)
-#         self.visit_expr(op.tuple_value)
-
-#     def visit_shape_expr_(self, op: ShapeExpr) -> None:
-#         self.visit_span(op.span)
-
-#     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
-#         self.visit_span(op.span)
-
-#     def visit_extern_func_(self, op: ExternFunc) -> None:
-#         self.visit_span(op.span)
-
-#     def visit_seq_expr_(self, op: SeqExpr) -> None:
-#         self.visit_span(op.span)
-#         for block in op.blocks:
-#             self.visit_binding_block(block)
-#         self.visit_expr(op.body)
-
-#     def visit_type(self, t: Type) -> None:
-#         pass
-
-#     def visit_span(self, span: Span) -> None:
-#         pass
-
-#     def visit_var_binding_(self, binding: VarBinding) -> None:
-#         self.visit_expr(binding.value)
-#         self.visit_var_def(binding.var)
-
-#     def visit_match_shape_(self, binding: MatchShape) -> None:
-#         self.visit_expr(binding.value)
-#         self.visit_expr(ShapeExpr(binding.pattern))
-#         if binding.var:
-#             self.visit_var_def(binding.var)
-
-#     def visit_binding_block_(self, block: BindingBlock) -> None:
-#         for binding in block.bindings:
-#             self.visit_binding(binding)
-
-#     def visit_dataflow_block_(self, block: DataflowBlock) -> None:
-#         for binding in block.bindings:
-#             self.visit_binding(binding)
-
-#     def visit_var_def_(self, var: Var) -> None:
-#         self.visit_span(var.span)
-
-#         if var.shape_:
-#             self.visit_expr(var.shape_)
-
-#     def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
-#         self.visit_span(var.span)
-
-#         if var.shape_:
-#             self.visit_expr(var.shape_)
-
-#     def visit_binding(self, binding: Binding) -> None:
-#         if isinstance(binding, MatchShape):
-#             self.visit_match_shape_(binding)
-#         elif isinstance(binding, VarBinding):
-#             self.visit_var_binding_(binding)
-#         else:
-#             raise TypeError("Invalid type: {0}".format(type(binding)))
-
-#     def visit_binding_block(self, block: BindingBlock) -> None:
-#         if isinstance(block, DataflowBlock):
-#             self.visit_dataflow_block_(block)
-#         elif isinstance(block, BindingBlock):
-#             self.visit_binding_block_(block)
-#         else:
-#             raise TypeError("Invalid type: {0}".format(type(block)))
-
-#     def visit_var_def(self, var: Var):
-#         if isinstance(var, DataflowVar):
-#             self.visit_dataflow_var_def_(var)
-#         elif isinstance(var, Var):
-#             self.visit_var_def_(var)
-#         else:
-#             raise TypeError("Invalid type: {0}".format(type(var)))
-
-
-# class ExprMutatorBase(ExprFunctor):
-#     """
-#     A mutator works in unnormalized form.
-
-#     ExprMutatorBase expects input AST to be in the unnormalized form,
-#     i.e., _checked_type_ and shape_ of expressions can be None,
-#     and the expressions may nest (and as a result the AST is not in ANF).
-#     """
-
-#     def visit_expr(self, expr: Expr) -> Expr:
-#         return ExprFunctor.visit_expr(self, expr)
-
-#     def visit_constant_(self, op: Constant) -> Expr:
-#         return op
-
-#     def visit_global_var_(self, op: GlobalVar) -> Expr:
-#         return op
-
-#     def visit_tuple_(self, op: Tuple) -> Expr:
-#         unchanged = True
-#         fields = []
-#         for field in op.fields:
-#             new_field = self.visit_expr(field)
-#             fields.append(new_field)
-#             unchanged &= field.same_as(new_field)
-
-#         if unchanged:
-#             return op
-#         else:
-#             return Tuple(fields, op.span)
-
-#     def visit_var_(self, op: Var) -> Expr:
-#         return op
-
-#     def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
-#         return op
-
-#     def visit_function_(self, op: Function) -> Expr:
-#         body = self.visit_expr(op.body)
-
-#         if op.body.same_as(body):
-#             return op
-#         else:
-#             return Function(op.params, body, op.ret_type, op.attrs, op.span)
-
-#     def visit_call_(self, call_node: Call) -> Expr:
-#         new_op = self.visit_expr(call_node.op)
-#         unchanged = call_node.op.same_as(new_op)
-
-#         ty_args = []
-#         for ty_arg in call_node.type_args:
-#             new_ty_arg = self.visit_type(ty_arg)
-#             ty_args.append(new_ty_arg)
-#             unchanged &= ty_arg.same_as(new_ty_arg)
-
-#         call_args = []
-#         for arg in call_node.args:
-#             new_arg = self.visit_expr(arg)
-#             call_args.append(new_arg)
-#             unchanged &= arg.same_as(new_arg)
-
-#         if unchanged:
-#             return call_node
-#         else:
-#             return Call(new_op, call_args, call_node.attrs, ty_args, call_node.span)
-
-#     def visit_if_(self, op: If) -> Expr:
-#         guard = self.visit_expr(op.cond)
-#         true_b = self.visit_expr(op.true_branch)
-#         false_b = self.visit_expr(op.false_branch)
-#         if (
-#             op.cond.same_as(guard)
-#             and op.true_branch.same_as(true_b)
-#             and op.false_branch.same_as(false_b)
-#         ):
-#             return op
-#         else:
-#             return If(guard, true_b, false_b, op.span)
-
-#     def visit_op_(self, op: Op) -> Expr:
-#         return op
-
-#     def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
-#         t = self.visit_expr(op.tuple_value)
-#         if op.tuple_value.same_as(t):
-#             return op
-#         else:
-#             return TupleGetItem(t, op.index)
-
-#     def visit_shape_expr_(self, op: ShapeExpr) -> Expr:
-#         return op
-
-#     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> Expr:
-#         return op
-
-#     def visit_extern_func_(self, op: ExternFunc) -> Expr:
-#         return op
-
-#     def visit_seq_expr_(self, op: SeqExpr) -> Expr:
-#         all_blocks_unchanged = True
-#         blocks = []
-#         for block in op.blocks:
-#             new_block = self.visit_binding_block(block)
-#             if new_block.bindings:
-#                 blocks.append(new_block)
-#             all_blocks_unchanged &= block.same_as(new_block)
-
-#         body = self.visit_expr(op.body)
-#         if all_blocks_unchanged and op.body.same_as(body):
-#             return op
-#         else:
-#             return SeqExpr(blocks, body, op.span)
-
-#     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
-#         """Mutate BindingBlock.
-
-#         Parameters
-#         ----------
-#         block: BindingBlock
-#             The binding block to be visited.
-
-#         Returns
-#         -------
-#         block: BindingBlock
-#             The binding block after transformation.
-#         """
-#         bindings = []
-#         if isinstance(block, BindingBlock):
-#             for binding in block.bindings:
-#                 if isinstance(binding, VarBinding):
-#                     new_value = self.visit_expr(binding.value)
-#                     bindings.append(VarBinding(binding.var, new_value, binding.span))
-#                 elif isinstance(binding, MatchShape):
-#                     new_value = self.visit_expr(binding.value)
-#                     bindings.append(
-#                         MatchShape(new_value, binding.pattern, binding.var, binding.span)
-#                     )
-#                 else:
-#                     raise TypeError("Invalid type: {0}".format(type(block)))
-#         else:
-#             raise TypeError("Invalid type: {0}".format(type(block)))
-#         if isinstance(block, DataflowBlock):
-#             return DataflowBlock(bindings)
-#         else:
-#             return BindingBlock(bindings)
-
-#     def visit_type(self, t: Type) -> Type:
-#         return t
-
-
-# class ExprMutator(ExprMutatorBase):
-#     """
-#     A mutator works in normal form.
-
-#     ExprMutator expects input AST to be in the normal form, i.e., the expressions are normalized(no
-#     nesting and hence the AST is in ANF), and all checked_type_ and shape_ of expressions are
-#     available. Note: We can use relax.transform.Normalize()(mod) to transform relax IR into
-#     the normal form.
-#     """
-
-#     def __init__(self, mod: Optional[IRModule] = None) -> None:
-#         super().__init__()
-#         self.builder_ = BlockBuilder(mod)
-#         self.var_remap_ = dict()
-
-#     def visit_expr(self, expr) -> Expr:
-#         return self.builder_.normalize(ExprFunctor.visit_expr(self, expr))
-
-#     def visit_tuple_(self, op: Tuple) -> Expr:
-#         unchanged = True
-#         fields = []
-#         for field in op.fields:
-#             new_field = self.visit_expr(field)
-#             fields.append(new_field)
-#             unchanged &= field.same_as(new_field)
-
-#         if unchanged:
-#             return op
-#         else:
-#             new_tuple = Tuple(fields, op.span)
-#             return new_tuple
-
-#     def visit_var_(self, op: Var) -> Expr:
-#         if op.vid in self.var_remap_:
-#             return self.var_remap_[op.vid]
-
-#         return op
-
-#     def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
-#         if op.vid in self.var_remap_:
-#             return self.var_remap_[op.vid]
-
-#         return op
-
-#     def visit_function_(self, op: Function) -> Expr:
-#         params = []
-#         all_params_unchanged = True
-#         for param in op.params:
-#             new_param = self.visit_var_def(param)
-#             params.append(new_param)
-#             all_params_unchanged &= param.same_as(new_param)
-
-#         ret_type = self.visit_type(op.ret_type)
-#         body = self.visit_with_new_scope(op.body)
-
-#         # TODO(@lesheng): op.ret_type.same_as(ret_type) after Type.same_as is fixed
-#         if all_params_unchanged and (op.ret_type == ret_type) and op.body.same_as(body):
-#             return op
-#         else:
-#             return Function(params, body, ret_type, op.attrs, op.span)
-
-#     def visit_if_(self, op: If) -> Expr:
-#         guard = self.visit_expr(op.cond)
-#         true_b = self.visit_with_new_scope(op.true_branch)
-#         false_b = self.visit_with_new_scope(op.false_branch)
-#         if (
-#             op.cond.same_as(guard)
-#             and op.true_branch.same_as(true_b)
-#             and op.false_branch.same_as(false_b)
-#         ):
-#             return op
-#         else:
-#             return If(guard, true_b, false_b, op.span)
-
-#     def visit_seq_expr_(self, op: SeqExpr) -> Expr:
-#         all_blocks_unchanged = True
-#         blocks = []
-#         for block in op.blocks:
-#             new_block = self.visit_binding_block(block)
-#             if new_block.bindings:
-#                 blocks.append(new_block)
-#             all_blocks_unchanged &= block.same_as(new_block)
-
-#         self.builder_._begin_binding_block()
-#         body = self.visit_expr(op.body)
-#         prologue = self.builder_._end_block()
-#         if prologue.bindings:
-#             blocks.append(prologue)
-#             all_blocks_unchanged = False
-
-#         if all_blocks_unchanged and op.body.same_as(body):
-#             return op
-#         else:
-#             return SeqExpr(blocks, body, op.span)
-
-#     def visit_var_binding_(self, binding: VarBinding) -> None:
-#         """Visit VarBinding, a new VarBinding will be emitted
-
-#         Parameters
-#         ----------
-#         binding: VarBinding
-#             The VarBinding to be visited.
-#         """
-#         new_value = self.visit_expr(binding.value)
-#         new_var = self.visit_var_def(binding.var)
-
-#         def emit(b: VarBinding):
-#             if self.builder_.current_block_is_dataflow() and not isinstance(b.var, DataflowVar):
-#                 self.builder_.emit_output_var_binding(b)
-#             else:
-#                 self.builder_.emit_var_binding(b)
-
-#         if binding.var.same_as(new_var) and binding.value.same_as(new_value):
-#             emit(binding)
-#             return
-
-#         temp = self.with_shape_and_type(new_var, new_value.shape_, new_value._checked_type_)
-#         if not temp.same_as(new_var):
-#             new_var = temp
-#             self.var_remap_[binding.var.vid] = new_var
-
-#         emit(VarBinding(new_var, new_value))
-
-#     def visit_match_shape_(self, binding: MatchShape) -> None:
-#         """Visit MatchShape, a new MatchShape will be emitted
-
-#         Parameters
-#         ----------
-#         binding: MatchShape
-#             The MatchShape binding to be visited.
-#         """
-#         new_value = self.visit_expr(binding.value)
-#         new_pattern = self.visit_expr(ShapeExpr(binding.pattern))
-
-#         if binding.var:
-#             new_shape = None
-#             if new_value._checked_type_ and isinstance(new_value._checked_type_, DynTensorType):
-#                 new_shape = new_pattern
-#             new_var = self.visit_var_def(binding.var)
-#             temp = self.with_shape_and_type(new_var, new_shape, new_value._checked_type_)
-#             if not temp.same_as(new_var):
-#                 new_var = temp
-#                 self.var_remap_[binding.var.vid] = new_var
-
-#         if binding.value.same_as(new_value) and binding.pattern.same_as(new_pattern):
-#             if not binding.var or (binding.var and binding.var.same_as(new_var)):
-#                 self.builder_.match_shape_binding(binding)
-#                 return
-
-#         self.builder_.match_shape_binding(MatchShape(new_value, new_pattern.values, new_var))
-
-#     def visit_binding_block_(self, block: BindingBlock) -> BindingBlock:
-#         self.builder_._begin_binding_block()
-#         for binding in block.bindings:
-#             self.visit_binding(binding)
-#         return self.builder_._end_block()
-
-#     def visit_dataflow_block_(self, block: DataflowBlock) -> BindingBlock:
-#         self.builder_._begin_dataflow_block()
-#         for binding in block.bindings:
-#             self.visit_binding(binding)
-#         return self.builder_._end_block()
-
-#     def visit_dataflow_var_def_(self, var: DataflowVar) -> Var:
-#         """Rewrite the dataflow var definition site.
-
-#         Parameters
-#         ----------
-#         var: DataflowVar
-#             The dataflow var to be visited.
-
-#         Returns
-#         -------
-#         var: Dataflowvar
-#             The dataflow var after post-order rewritten.
-#         """
-#         shape_unchanged = True
-#         new_shape = None
-#         if var.shape_:
-#             new_shape = self.visit_expr(var.shape_)
-#             shape_unchanged &= var.shape_.same_as(new_shape)
-
-#         if shape_unchanged:
-#             return var
-#         else:
-#             new_var = DataflowVar(var.vid, None, var._checked_type_, var.span)
-#             _update_shape(new_var, new_shape)
-
-#             self.var_remap_[var.vid] = new_var
-#             return new_var
-
-#     def visit_var_def_(self, var: Var) -> Var:
-#         """Rewrite the var definition site.
-
-#         Parameters
-#         ----------
-#         var: Var
-#             The var to be visited.
-
-#         Returns
-#         -------
-#         var: Var
-#             The var after post-order rewritten.
-#         """
-#         shape_unchanged = True
-#         new_shape = None
-#         if var.shape_:
-#             new_shape = self.visit_expr(var.shape_)
-#             shape_unchanged &= var.shape_.same_as(new_shape)
-
-#         if shape_unchanged:
-#             return var
-#         else:
-#             new_var = Var(var.vid, None, var._checked_type_, var.span)
-#             _update_shape(new_var, new_shape)
-
-#             self.var_remap_[var.vid] = new_var
-#             return new_var
-
-#     def visit_binding(self, binding: Binding) -> None:
-#         if isinstance(binding, MatchShape):
-#             self.visit_match_shape_(binding)
-#         elif isinstance(binding, VarBinding):
-#             self.visit_var_binding_(binding)
-#         else:
-#             raise TypeError("Invalid type: {0}".format(type(binding)))
-
-#     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
-#         if isinstance(block, DataflowBlock):
-#             ret = self.visit_dataflow_block_(block)
-#         elif isinstance(block, BindingBlock):
-#             ret = self.visit_binding_block_(block)
-#         else:
-#             raise TypeError("Invalid type: {0}".format(type(block)))
-
-#         return ret
-
-#     def visit_var_def(self, var: Var) -> Var:
-#         ret = None
-#         if isinstance(var, DataflowVar):
-#             ret = self.visit_dataflow_var_def_(var)
-#         elif isinstance(var, Var):
-#             ret = self.visit_var_def_(var)
-#         else:
-#             raise TypeError("Invalid type: {0}".format(type(var)))
-#         return ret
-
-#     def visit_with_new_scope(self, expr: Expr) -> Expr:
-#         self.builder_._begin_binding_block()
-#         ret = self.visit_expr(expr)
-#         prologue = self.builder_._end_block()
-#         if prologue.bindings:
-#             ret = SeqExpr([prologue], ret)
-#         return ret
-
-#     def with_shape_and_type(self, var: Var, shape: Optional[Expr], t: Type) -> Var:
-#         """Create a new var with specified shape and type if the original var's shape or type
-#         does not match with the specified ones.
-
-#         Parameters
-#         ----------
-#         var: Var
-#             The var to be updated.
-#         shape: Optional[Expr]
-#             The specified shape.
-#         t: Type
-#             The specified type.
-
-#         Returns
-#         -------
-#         var: Var
-#             The var filled with shape and type.
-#         """
-#         shape_changed = (var.shape_ is not None) ^ (shape is not None)
-#         shape_changed |= (
-#             var.shape_ and shape and not self.builder_.can_prove_shape_equal(var.shape_, shape)
-#         )
-
-#         type_changed = (var._checked_type_ is not None) ^ (t is not None)
-#         type_changed |= var._checked_type_ and t and not structural_equal(var._checked_type_, t)
-
-#         if shape_changed or type_changed:
-#             new_var = (
-#                 DataflowVar(var.vid, None, None, var.span)
-#                 if isinstance(var, DataflowVar)
-#                 else Var(var.vid, None, None, var.span)
-#             )
-#             _update_shape(new_var, var.shape_)
-#             _update_type(new_var, var._checked_type_)
-#             var = new_var
-
-#         if shape_changed:
-#             var.shape_ = shape
-
-#         if type_changed:
-#             var._checked_type_ = t
-
-#         return var
-
-#     def lookup_binding(self, var: Var) -> Optional[Expr]:
-#         return self.builder_.lookup_binding(var)

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -95,21 +95,14 @@ Example
             # just for demo purposes
             ...
 
-        # customize post-order rewrite function
-        def rewrite_var_post_order(self, op: Expr) -> Expr:
-            # just for demo purposes
-            ...
-
     # mymutator is now a special mutator that rewrite every Tuple with
-    # user-customized visit_tuple_, and rewrite every Var with user-customized
-    # rewrite_var_post_order in the post order.
+    # user-customized visit_tuple_
     mymutator = MyExprMutator()
     # apply mymutator to Expr/Binding/BindingBlock/VarDef
     mymutator.visit_expr(expr)
     mymutator.visit_binding(binding)
     mymutator.visit_binding_block(bindingblock)
     mymutator.visit_var_def(var)
-    # Note: In this case, we cannot override rewrite_tuple_post_order in MyExprMutator.
 """
 
 

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -17,10 +17,12 @@
 # pylint: disable=no-else-return, unidiomatic-typecheck, invalid-name, arguments-differ
 """The expression functor of Relax."""
 import tvm
-from typing import Optional
+from typing import Optional, Callable
 from tvm.ir import Op
 from tvm.ir.base import structural_equal
 from tvm.ir.module import IRModule
+from tvm.meta_schedule.utils import derived_object
+
 from .ty import DynTensorType
 from .expr import Type, Span, Expr
 from .expr import Function, ExternFunc
@@ -35,63 +37,73 @@ from ..relay import Id
 from .block_builder import BlockBuilder
 from . import _ffi_api
 
-expr_names = [
-    "constant",
-    "tuple",
-    "var",
-    "dataflow_var",
-    "shape_expr",
-    "runtime_dep_shape",
-    "extern_func",
-    "global_var",
-    "function",
-    "call",
-    "seq_expr",
-    "if",
-    "op",
-    "tuple_getitem",
-]
-other_names = [
-    "var_binding",
-    "match_shape",
-    "binding_block",
-    "dataflow_block",
-    "var_def",
-    "dataflow_var_def",
-]
-visit_func_names = [
-    "visit_expr",
-    "visit_binding",
-    "visit_binding_block",
-    "visit_var_def",
-    "visit_type",
-    "visit_span",
-] + [f"visit_{name}_" for name in (expr_names + other_names)]
-post_order_func_names = [f"rewrite_{name}_post_order" for name in expr_names]
-
-# @tvm._ffi.register_object("relax.ExprFunctor")
-class ExprFunctor(tvm.runtime.Object):
-    """TODO"""
-
-
-# @tvm._ffi.register_object("relax.ExprVisitor")
-class ExprVisitor(ExprFunctor):
-    """TODO"""
-
-
-# @tvm._ffi.register_object("relax.ExprMutatorBase")
-class ExprMutatorBase:
-    """TODO"""
-
-
-# @tvm._ffi.register_object("relax.ExprMutator")
-class ExprMutator:
-    """TODO"""
-
+visitor = derived_object
+mutator = derived_object
 
 @tvm._ffi.register_object("expr_functor.PyExprVisitor")
 class _PyExprVisitor(tvm.runtime.Object):
     """TODO"""
+
+    def __init__(
+        self,
+        f_visit_expr: Callable = None,
+        f_visit_constant_: Callable = None,
+        f_visit_tuple_: Callable = None,
+        f_visit_var_: Callable = None,
+        f_visit_dataflow_var_: Callable = None,
+        f_visit_shape_expr_: Callable = None,
+        f_visit_runtime_dep_shape_: Callable = None,
+        f_visit_extern_func_: Callable = None,
+        f_visit_global_var_: Callable = None,
+        f_visit_function_: Callable = None,
+        f_visit_call_: Callable = None,
+        f_visit_seq_expr_: Callable = None,
+        f_visit_if_: Callable = None,
+        f_visit_op_: Callable = None,
+        f_visit_tuple_getitem_: Callable = None,
+        f_visit_binding: Callable = None,
+        f_visit_var_binding_: Callable = None,
+        f_visit_match_shape_: Callable = None,
+        f_visit_binding_block: Callable = None,
+        f_visit_binding_block_: Callable = None,
+        f_visit_dataflow_block_: Callable = None,
+        f_visit_var_def: Callable = None,
+        f_visit_var_def_: Callable = None,
+        f_visit_dataflow_var_def_: Callable = None,
+        f_visit_type: Callable = None,
+        f_visit_span: Callable = None,
+    ) -> None:
+        """Constructor."""
+
+        self.__init_handle_by_constructor__(
+            _ffi_api.MakePyExprVisitor,
+            f_visit_expr,
+            f_visit_constant_,
+            f_visit_tuple_,
+            f_visit_var_,
+            f_visit_dataflow_var_,
+            f_visit_shape_expr_,
+            f_visit_runtime_dep_shape_,
+            f_visit_extern_func_,
+            f_visit_global_var_,
+            f_visit_function_,
+            f_visit_call_,
+            f_visit_seq_expr_,
+            f_visit_if_,
+            f_visit_op_,
+            f_visit_tuple_getitem_,
+            f_visit_binding,
+            f_visit_var_binding_,
+            f_visit_match_shape_,
+            f_visit_binding_block,
+            f_visit_binding_block_,
+            f_visit_dataflow_block_,
+            f_visit_var_def,
+            f_visit_var_def_,
+            f_visit_dataflow_var_def_,
+            f_visit_type,
+            f_visit_span,
+        )
 
     def visit_expr(self, expr: Expr) -> None:
         return _ffi_api.PyExprVisitorVisitExpr(self, expr)
@@ -106,7 +118,39 @@ class _PyExprVisitor(tvm.runtime.Object):
         return _ffi_api.PyExprVisitorVisitVarDef(self, var)
 
 
-class PyExprVisitor(_PyExprVisitor):
+class PyExprVisitor:
+    _tvm_metadata = {
+        "cls": _PyExprVisitor,
+        "methods": [
+            "visit_expr",
+            "visit_constant_",
+            "visit_tuple_",
+            "visit_var_",
+            "visit_dataflow_var_",
+            "visit_shape_expr_",
+            "visit_runtime_dep_shape_",
+            "visit_extern_func_",
+            "visit_global_var_",
+            "visit_function_",
+            "visit_call_",
+            "visit_seq_expr_",
+            "visit_if_",
+            "visit_op_",
+            "visit_tuple_getitem_",
+            "visit_binding",
+            "visit_var_binding_",
+            "visit_match_shape_",
+            "visit_binding_block",
+            "visit_binding_block_",
+            "visit_dataflow_block_",
+            "visit_var_def",
+            "visit_var_def_",
+            "visit_dataflow_var_def_",
+            "visit_type",
+            "visit_span",
+        ],
+    }
+
     def visit_expr(self, expr: Expr) -> None:
         return _ffi_api.PyExprVisitorVisitExpr(self._outer(), expr)
 
@@ -119,6 +163,72 @@ class PyExprVisitor(_PyExprVisitor):
     def visit_var_def(self, var: Var) -> None:
         return _ffi_api.PyExprVisitorVisitVarDef(self._outer(), var)
 
+    def visit_constant_(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def visit_tuple_(self, op: Tuple) -> None:
+        raise NotImplementedError
+
+    def visit_var_(self, op: Var) -> None:
+        raise NotImplementedError
+
+    def visit_dataflow_var_(self, op: DataflowVar) -> None:
+        raise NotImplementedError
+
+    def visit_shape_expr_(self, op: ShapeExpr) -> None:
+        raise NotImplementedError
+
+    def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
+        raise NotImplementedError
+
+    def visit_extern_func_(self, op: ExternFunc) -> None:
+        raise NotImplementedError
+
+    def visit_global_var_(self, op: GlobalVar) -> None:
+        raise NotImplementedError
+
+    def visit_function_(self, op: Function) -> None:
+        raise NotImplementedError
+
+    def visit_call_(self, op: Call) -> None:
+        raise NotImplementedError
+
+    def visit_seq_expr_(self, op: SeqExpr) -> None:
+        raise NotImplementedError
+
+    def visit_if_(self, op: If) -> None:
+        raise NotImplementedError
+
+    def visit_op_(self, op: Op) -> None:
+        raise NotImplementedError
+
+    def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
+        raise NotImplementedError
+
+    def visit_var_binding_(self, binding: VarBinding) -> None:
+        raise NotImplementedError
+
+    def visit_match_shape_(self, binding: MatchShape) -> None:
+        raise NotImplementedError
+
+    def visit_binding_block_(self, block: BindingBlock) -> None:
+        raise NotImplementedError
+
+    def visit_dataflow_block_(self, block: DataflowBlock) -> None:
+        raise NotImplementedError
+
+    def visit_var_def_(self, var: Var) -> None:
+        raise NotImplementedError
+
+    def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
+        raise NotImplementedError
+
+    def visit_type(self, t: Type) -> None:
+        raise NotImplementedError
+
+    def visit_span(self, span: Span) -> None:
+        raise NotImplementedError
+
 
 @tvm._ffi.register_object("expr_functor.PyExprMutator")
 class _PyExprMutator(tvm.runtime.Object):
@@ -126,14 +236,94 @@ class _PyExprMutator(tvm.runtime.Object):
 
     builder_: BlockBuilder
 
-    def __init__(self, packed_value) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.MakeExprMutator, *packed_value)
-
-    def set_var_remap(self, id: Id, var: Var) -> None:
-        return _ffi_api.PyExprMutatorSetVarRemap(self, id, var)
-
-    def get_var_remap(self, id: Id) -> Var:
-        return _ffi_api.PyExprMutatorGetVarRemap(self, id)
+    def __init__(
+        self,
+        builder: BlockBuilder = None,
+        f_visit_expr: Callable = None,
+        f_visit_constant_: Callable = None,
+        f_visit_tuple_: Callable = None,
+        f_visit_var_: Callable = None,
+        f_visit_dataflow_var_: Callable = None,
+        f_visit_shape_expr_: Callable = None,
+        f_visit_runtime_dep_shape_: Callable = None,
+        f_visit_extern_func_: Callable = None,
+        f_visit_global_var_: Callable = None,
+        f_visit_function_: Callable = None,
+        f_visit_call_: Callable = None,
+        f_visit_seq_expr_: Callable = None,
+        f_visit_if_: Callable = None,
+        f_visit_op_: Callable = None,
+        f_visit_tuple_getitem_: Callable = None,
+        f_visit_binding: Callable = None,
+        f_visit_var_binding_: Callable = None,
+        f_visit_match_shape_: Callable = None,
+        f_visit_binding_block: Callable = None,
+        f_visit_binding_block_: Callable = None,
+        f_visit_dataflow_block_: Callable = None,
+        f_visit_var_def: Callable = None,
+        f_visit_var_def_: Callable = None,
+        f_visit_dataflow_var_def_: Callable = None,
+        f_visit_type: Callable = None,
+        f_visit_span: Callable = None,
+        f_rewrite_constant_post_order: Callable = None,
+        f_rewrite_tuple_post_order: Callable = None,
+        f_rewrite_var_post_order: Callable = None,
+        f_rewrite_dataflow_var_post_order: Callable = None,
+        f_rewrite_shape_expr_post_order: Callable = None,
+        f_rewrite_runtime_dep_shape_post_order: Callable = None,
+        f_rewrite_extern_func_post_order: Callable = None,
+        f_rewrite_global_var_post_order: Callable = None,
+        f_rewrite_function_post_order: Callable = None,
+        f_rewrite_call_post_order: Callable = None,
+        f_rewrite_seq_expr_post_order: Callable = None,
+        f_rewrite_if_post_order: Callable = None,
+        f_rewrite_op_post_order: Callable = None,
+        f_rewrite_tuple_getitem_post_order: Callable = None,
+    ) -> None:
+        self.__init_handle_by_constructor__(
+            _ffi_api.MakePyExprMutator,
+            builder,
+            f_visit_expr,
+            f_visit_constant_,
+            f_visit_tuple_,
+            f_visit_var_,
+            f_visit_dataflow_var_,
+            f_visit_shape_expr_,
+            f_visit_runtime_dep_shape_,
+            f_visit_extern_func_,
+            f_visit_global_var_,
+            f_visit_function_,
+            f_visit_call_,
+            f_visit_seq_expr_,
+            f_visit_if_,
+            f_visit_op_,
+            f_visit_tuple_getitem_,
+            f_visit_binding,
+            f_visit_var_binding_,
+            f_visit_match_shape_,
+            f_visit_binding_block,
+            f_visit_binding_block_,
+            f_visit_dataflow_block_,
+            f_visit_var_def,
+            f_visit_var_def_,
+            f_visit_dataflow_var_def_,
+            f_visit_type,
+            f_visit_span,
+            f_rewrite_constant_post_order,
+            f_rewrite_tuple_post_order,
+            f_rewrite_var_post_order,
+            f_rewrite_dataflow_var_post_order,
+            f_rewrite_shape_expr_post_order,
+            f_rewrite_runtime_dep_shape_post_order,
+            f_rewrite_extern_func_post_order,
+            f_rewrite_global_var_post_order,
+            f_rewrite_function_post_order,
+            f_rewrite_call_post_order,
+            f_rewrite_seq_expr_post_order,
+            f_rewrite_if_post_order,
+            f_rewrite_op_post_order,
+            f_rewrite_tuple_getitem_post_order,
+        )
 
     def visit_expr(self, expr: Expr) -> Expr:
         return _ffi_api.PyExprMutatorVisitExpr(self, expr)
@@ -147,25 +337,57 @@ class _PyExprMutator(tvm.runtime.Object):
     def visit_var_def(self, var: Var) -> Var:
         return _ffi_api.PyExprMutatorVisitVarDef(self, var)
 
-    def visit_with_new_scope(self, expr: Expr) -> Expr:
-        return _ffi_api.PyExprMutatorVisitWithNewScope(self, expr)
-
-    def lookup_binding(self, var: Var) -> Optional[Expr]:
-        return _ffi_api.PyExprMutatorLookupBinding(self, var)
-
-    def with_shape_and_type(self, var: Var, shape: None, t: Type) -> Var:  # TODO: shape anno
-        return _ffi_api.PyExprMutatorWithShapeAndType(self, var, shape, t)
-
 
 class PyExprMutator:
-    def __init__(self) -> None:
-        """"""
+    _tvm_metadata = {
+        "cls": _PyExprMutator,
+        "fields": ["builder_"],
+        "methods": [
+            "visit_expr",
+            "visit_constant_",
+            "visit_tuple_",
+            "visit_var_",
+            "visit_dataflow_var_",
+            "visit_shape_expr_",
+            "visit_runtime_dep_shape_",
+            "visit_extern_func_",
+            "visit_global_var_",
+            "visit_function_",
+            "visit_call_",
+            "visit_seq_expr_",
+            "visit_if_",
+            "visit_op_",
+            "visit_tuple_getitem_",
+            "visit_binding",
+            "visit_var_binding_",
+            "visit_match_shape_",
+            "visit_binding_block",
+            "visit_binding_block_",
+            "visit_dataflow_block_",
+            "visit_var_def",
+            "visit_var_def_",
+            "visit_dataflow_var_def_",
+            "visit_type",
+            "visit_span",
+            "rewrite_constant_post_order",
+            "rewrite_tuple_post_order",
+            "rewrite_var_post_order",
+            "rewrite_dataflow_var_post_order",
+            "rewrite_shape_expr_post_order",
+            "rewrite_runtime_dep_shape_post_order",
+            "rewrite_extern_func_post_order",
+            "rewrite_global_var_post_order",
+            "rewrite_function_post_order",
+            "rewrite_call_post_order",
+            "rewrite_seq_expr_post_order",
+            "rewrite_if_post_order",
+            "rewrite_op_post_order",
+            "rewrite_tuple_getitem_post_order",
+        ],
+    }
 
-    def __getattr__(self, name):
-        if name in ["builder_"]:
-            return getattr(self._outer(), name)
-        else:
-            return self.__getattribute__(name)
+    def __init__(self) -> None:
+        self.builder_ = BlockBuilder()
 
     def set_var_remap(self, id: Id, var: Var) -> None:
         return _ffi_api.PyExprMutatorSetVarRemap(self._outer(), id, var)
@@ -185,6 +407,114 @@ class PyExprMutator:
     def visit_var_def(self, var: Var) -> Var:
         return _ffi_api.PyExprMutatorVisitVarDef(self._outer(), var)
 
+    def visit_constant_(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def visit_tuple_(self, op: Tuple) -> None:
+        raise NotImplementedError
+
+    def visit_var_(self, op: Var) -> None:
+        raise NotImplementedError
+
+    def visit_dataflow_var_(self, op: DataflowVar) -> None:
+        raise NotImplementedError
+
+    def visit_shape_expr_(self, op: ShapeExpr) -> None:
+        raise NotImplementedError
+
+    def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
+        raise NotImplementedError
+
+    def visit_extern_func_(self, op: ExternFunc) -> None:
+        raise NotImplementedError
+
+    def visit_global_var_(self, op: GlobalVar) -> None:
+        raise NotImplementedError
+
+    def visit_function_(self, op: Function) -> None:
+        raise NotImplementedError
+
+    def visit_call_(self, op: Call) -> None:
+        raise NotImplementedError
+
+    def visit_seq_expr_(self, op: SeqExpr) -> None:
+        raise NotImplementedError
+
+    def visit_if_(self, op: If) -> None:
+        raise NotImplementedError
+
+    def visit_op_(self, op: Op) -> None:
+        raise NotImplementedError
+
+    def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
+        raise NotImplementedError
+
+    def visit_var_binding_(self, binding: VarBinding) -> None:
+        raise NotImplementedError
+
+    def visit_match_shape_(self, binding: MatchShape) -> None:
+        raise NotImplementedError
+
+    def visit_binding_block_(self, block: BindingBlock) -> None:
+        raise NotImplementedError
+
+    def visit_dataflow_block_(self, block: DataflowBlock) -> None:
+        raise NotImplementedError
+
+    def visit_var_def_(self, var: Var) -> None:
+        raise NotImplementedError
+
+    def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
+        raise NotImplementedError
+
+    def visit_type(self, t: Type) -> None:
+        raise NotImplementedError
+
+    def visit_span(self, span: Span) -> None:
+        raise NotImplementedError
+
+    def rewrite_constant_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_tuple_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_var_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_dataflow_var_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_shape_expr_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_runtime_dep_shape_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_extern_func_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_global_var_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_function_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_call_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_seq_expr_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_if_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_op_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
+    def rewrite_tuple_getitem_post_order(self, op: Constant) -> None:
+        raise NotImplementedError
+
     def visit_with_new_scope(self, expr: Expr) -> Expr:
         return _ffi_api.PyExprMutatorVisitWithNewScope(self._outer(), expr)
 
@@ -193,110 +523,3 @@ class PyExprMutator:
 
     def with_shape_and_type(self, var: Var, shape: None, t: Type) -> Var:  # TODO: shape anno
         return _ffi_api.PyExprMutatorWithShapeAndType(self._outer(), var, shape, t)
-
-
-def visitor(visitor_cls=None):
-    import functools
-    import weakref
-
-    def _extract(inst, name):
-        def method(*args, **kwargs):
-            return getattr(inst, name)(*args, **kwargs)
-
-        return method
-
-    class PyVisitor(_PyExprVisitor):
-        def __init__(self, *args, **kwargs) -> None:
-            "Constructor."
-            self.handle = None
-            self._inst = visitor_cls(*args, **kwargs)
-
-            packed_value = []
-
-            for func_name in visit_func_names:
-                if hasattr(self._inst, func_name):
-                    if hasattr(PyExprVisitor, func_name) and (
-                        getattr(visitor_cls, func_name) == getattr(PyExprVisitor, func_name)
-                    ):
-                        continue
-                    packed_value.append(func_name)
-                    packed_value.append(_extract(self._inst, func_name))
-
-            self.__init_handle_by_constructor__(_ffi_api.MakeExprVisitor, *packed_value)
-
-            self._inst._outer = weakref.ref(self)
-
-        def __getattr__(self, name):
-            # fall back to instance attribute if there is not any
-            return self._inst.__getattribute__(name)
-
-        def __setattr__(self, name, value):
-            """TODO"""
-            if name not in ["_inst", "key", "handle"]:
-                self._inst.__setattr__(name, value)
-            else:
-                super(PyVisitor, self).__setattr__(name, value)
-
-    functools.update_wrapper(PyVisitor.__init__, visitor_cls.__init__)
-    PyVisitor.__name__ = visitor_cls.__name__
-    PyVisitor.__doc__ = visitor_cls.__doc__
-    PyVisitor.__module__ = visitor_cls.__module__
-    return PyVisitor
-
-
-def mutator(mutator_cls=None):
-    import functools
-    import weakref
-
-    def _extract(inst, name):
-        def method(*args, **kwargs):
-            return getattr(inst, name)(*args, **kwargs)
-
-        return method
-
-    class PyMutator(_PyExprMutator):
-        def __init__(self, *args, **kwargs) -> None:
-            "Constructor."
-            self.handle = None
-            self._inst = mutator_cls(*args, **kwargs)
-
-            packed_value = []
-
-            for func_name in visit_func_names:
-                if hasattr(self._inst, func_name):
-                    if hasattr(PyExprMutator, func_name) and (
-                        getattr(mutator_cls, func_name) == getattr(PyExprMutator, func_name)
-                    ):
-                        continue
-                    packed_value.append(func_name)
-                    packed_value.append(_extract(self._inst, func_name))
-
-            for func_name in post_order_func_names:
-                # rewrite_{name}_post_order
-                if hasattr(self._inst, func_name):
-                    if f"visit_{'_'.join(func_name.split('_')[1:-2])}_" in packed_value:
-                        raise RuntimeError(func_name)  # TODO: RuntimeError?
-                    packed_value.append(func_name)
-                    packed_value.append(_extract(self._inst, func_name))
-
-            super().__init__(packed_value)
-
-            self._inst._outer = weakref.ref(self)
-            self.builder_ = super().__getattr__("builder_")
-
-        def __getattr__(self, name):
-            # fall back to instance attribute if there is not any
-            return self._inst.__getattribute__(name)
-
-        def __setattr__(self, name, value):
-            """TODO"""
-            if name not in ["_inst", "key", "handle"]:  # TODO: Why do we need key here
-                self._inst.__setattr__(name, value)
-            else:
-                super(PyMutator, self).__setattr__(name, value)
-
-    functools.update_wrapper(PyMutator.__init__, mutator_cls.__init__)
-    PyMutator.__name__ = mutator_cls.__name__
-    PyMutator.__doc__ = mutator_cls.__doc__
-    PyMutator.__module__ = mutator_cls.__module__
-    return PyMutator

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -119,7 +119,7 @@ class _PyExprVisitor(Object):
     A TVM object to support customization of ExprVisitor on the python side.
     This is the decorated result returned from visitor decorator.
 
-    WARNING: This is NOT the user facing class for method overloading inheritance.
+    WARNING: This is NOT the user facing class for method overwriting inheritance.
 
     See also: visitor, PyExprVisitor
     """
@@ -230,9 +230,9 @@ class _PyExprVisitor(Object):
 class PyExprVisitor:
     """
     An abstract ExprVisitor with customized methods on the python-side.
-    This is the user facing class for method overloading inheritance.
+    This is the user facing class for method overwriting inheritance.
     _tvm_metadata discribes the class to inherit("cls"), the methods
-    that users can overload("methods").
+    that users can overwrite("methods").
 
     Note: @relax.expr_functor.visitor is required for proper usage of any inherited class.
 
@@ -278,7 +278,7 @@ class PyExprVisitor:
 
     def visit_expr(self, expr: Expr) -> None:
         """Generic dispatcher for Expr.
-        Users can customized this function to overload VisitExpr(const Expr& expr) on the C++ side.
+        Users can customized this function to overwrite VisitExpr(const Expr& expr) on the C++ side.
 
         Parameters
         ----------
@@ -290,7 +290,7 @@ class PyExprVisitor:
 
     def visit_binding(self, binding: Binding) -> None:
         """Generic dispatcher for Binding.
-        Users can customized this function to overload VisitBinding(const Binding& binding)
+        Users can customized this function to overwrite VisitBinding(const Binding& binding)
         on the C++ side.
 
         Parameters
@@ -303,7 +303,7 @@ class PyExprVisitor:
 
     def visit_binding_block(self, block: BindingBlock) -> None:
         """Generic dispatcher for BindingBlock.
-        Users can customized this function to overload VisitBindingBlock(const BindingBlock& block)
+        Users can customized this function to overwrite VisitBindingBlock(const BindingBlock& block)
         on the C++ side.
 
         Parameters
@@ -316,7 +316,7 @@ class PyExprVisitor:
 
     def visit_var_def(self, var: Var) -> None:
         """Generic dispatcher for visiting the var definition site.
-        Users can customized this function to overload VisitVarDef(const Var& var) on the C++ side.
+        Users can customized this function to overwrite VisitVarDef(const Var& var) on the C++ side.
         Note that visit_var_() will only visit the usage site of an Var.
 
         Parameters
@@ -329,7 +329,7 @@ class PyExprVisitor:
 
     def visit_constant_(self, op: Constant) -> None:
         """Visit Constant.
-        Users can customized this function to overload VisitExpr_(const ConstantNode* op)
+        Users can customized this function to overwrite VisitExpr_(const ConstantNode* op)
         on the C++ side.
 
         Parameters
@@ -341,7 +341,7 @@ class PyExprVisitor:
 
     def visit_tuple_(self, op: Tuple) -> None:
         """Visit Tuple.
-        Users can customized this function to overload VisitExpr_(const TupleNode* op)
+        Users can customized this function to overwrite VisitExpr_(const TupleNode* op)
         on the C++ side.
 
         Parameters
@@ -353,7 +353,7 @@ class PyExprVisitor:
 
     def visit_var_(self, op: Var) -> None:
         """Visit Var.
-        Users can customized this function to overload VisitExpr_(const VarNode* op)
+        Users can customized this function to overwrite VisitExpr_(const VarNode* op)
         on the C++ side.
 
         Parameters
@@ -365,7 +365,7 @@ class PyExprVisitor:
 
     def visit_dataflow_var_(self, op: DataflowVar) -> None:
         """Visit DataflowVar.
-        Users can customized this function to overload VisitExpr_(const DataflowVarNode* op)
+        Users can customized this function to overwrite VisitExpr_(const DataflowVarNode* op)
         on the C++ side.
 
         Parameters
@@ -377,7 +377,7 @@ class PyExprVisitor:
 
     def visit_shape_expr_(self, op: ShapeExpr) -> None:
         """Visit ShapeExpr.
-        Users can customized this function to overload VisitExpr_(const ShapeExprNode* op)
+        Users can customized this function to overwrite VisitExpr_(const ShapeExprNode* op)
         on the C++ side.
 
         Parameters
@@ -389,7 +389,7 @@ class PyExprVisitor:
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
         """Visit RuntimeDepShape.
-        Users can customized this function to overload VisitExpr_(const RuntimeDepShapeNode* op)
+        Users can customized this function to overwrite VisitExpr_(const RuntimeDepShapeNode* op)
         on the C++ side.
 
         Parameters
@@ -401,7 +401,7 @@ class PyExprVisitor:
 
     def visit_extern_func_(self, op: ExternFunc) -> None:
         """Visit ExternFunc.
-        Users can customized this function to overload VisitExpr_(const ExternFuncNode* op)
+        Users can customized this function to overwrite VisitExpr_(const ExternFuncNode* op)
         on the C++ side.
 
         Parameters
@@ -413,7 +413,7 @@ class PyExprVisitor:
 
     def visit_global_var_(self, op: GlobalVar) -> None:
         """Visit GlobalVar.
-        Users can customized this function to overload VisitExpr_(const GlobalVarNode* op)
+        Users can customized this function to overwrite VisitExpr_(const GlobalVarNode* op)
         on the C++ side.
 
         Parameters
@@ -425,7 +425,7 @@ class PyExprVisitor:
 
     def visit_function_(self, op: Function) -> None:
         """Visit Function.
-        Users can customized this function to overload VisitExpr_(const FunctionNode* op)
+        Users can customized this function to overwrite VisitExpr_(const FunctionNode* op)
         on the C++ side.
 
         Parameters
@@ -437,7 +437,7 @@ class PyExprVisitor:
 
     def visit_call_(self, op: Call) -> None:
         """Visit Call.
-        Users can customized this function to overload VisitExpr_(const CallNode* op)
+        Users can customized this function to overwrite VisitExpr_(const CallNode* op)
         on the C++ side.
 
         Parameters
@@ -449,7 +449,7 @@ class PyExprVisitor:
 
     def visit_seq_expr_(self, op: SeqExpr) -> None:
         """Visit SeqExpr.
-        Users can customized this function to overload VisitExpr_(const SeqExprNode* op)
+        Users can customized this function to overwrite VisitExpr_(const SeqExprNode* op)
         on the C++ side.
 
         Parameters
@@ -461,7 +461,8 @@ class PyExprVisitor:
 
     def visit_if_(self, op: If) -> None:
         """Visit If.
-        Users can customized this function to overload VisitExpr_(const IfNode* op) on the C++ side.
+        Users can customized this function to overwrite VisitExpr_(const IfNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -472,7 +473,8 @@ class PyExprVisitor:
 
     def visit_op_(self, op: Op) -> None:
         """Visit Op.
-        Users can customized this function to overload VisitExpr_(const OpNode* op) on the C++ side.
+        Users can customized this function to overwrite VisitExpr_(const OpNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -483,7 +485,7 @@ class PyExprVisitor:
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
         """Visit TupleGetItem.
-        Users can customized this function to overload VisitExpr_(const TupleGetItemNode* op)
+        Users can customized this function to overwrite VisitExpr_(const TupleGetItemNode* op)
         on the C++ side.
 
         Parameters
@@ -495,7 +497,7 @@ class PyExprVisitor:
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
         """Visit VarBinding.
-        Users can customized this function to overload VisitBinding_(const VarBindingNode* binding)
+        Users can customized this function to overwrite VisitBinding_(const VarBindingNode* binding)
         on the C++ side.
 
         Parameters
@@ -507,7 +509,7 @@ class PyExprVisitor:
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
         """Visit MatchShape.
-        Users can customized this function to overload VisitBinding_(const MatchShapeNode* binding)
+        Users can customized this function to overwrite VisitBinding_(const MatchShapeNode* binding)
         on the C++ side.
 
         Parameters
@@ -519,7 +521,7 @@ class PyExprVisitor:
 
     def visit_binding_block_(self, block: BindingBlock) -> None:
         """Visit BindingBlock.
-        Users can customized this function to overload VisitBindingBlock_(const BindingBlockNode*
+        Users can customized this function to overwrite VisitBindingBlock_(const BindingBlockNode*
         block) on the C++ side.
 
         Parameters
@@ -531,7 +533,7 @@ class PyExprVisitor:
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> None:
         """Visit DataflowBlock.
-        Users can customized this function to overload VisitBindingBlock_(const DataflowBlockNode*
+        Users can customized this function to overwrite VisitBindingBlock_(const DataflowBlockNode*
         block) on the C++ side.
 
         Parameters
@@ -543,7 +545,7 @@ class PyExprVisitor:
 
     def visit_var_def_(self, var: Var) -> None:
         """Visit the Var definition site.
-        Users can customized this function to overload VisitVarDef_(const VarNode* var)
+        Users can customized this function to overwrite VisitVarDef_(const VarNode* var)
         on the C++ side.
 
         Parameters
@@ -555,7 +557,7 @@ class PyExprVisitor:
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
         """Visit the DataflowVar definition site.
-        Users can customized this function to overload VisitVarDef_(const DataflowVarNode* var)
+        Users can customized this function to overwrite VisitVarDef_(const DataflowVarNode* var)
         on the C++ side.
 
         Parameters
@@ -567,7 +569,7 @@ class PyExprVisitor:
 
     def visit_type(self, t: Type) -> None:
         """Visit Type.
-        Users can customized this function to overload VisitType(const Type& t) on the C++ side.
+        Users can customized this function to overwrite VisitType(const Type& t) on the C++ side.
 
         Parameters
         ----------
@@ -578,7 +580,7 @@ class PyExprVisitor:
 
     def visit_span(self, span: Span) -> None:
         """Visit Span.
-        Users can customized this function to overload VisitSpan(const Span& span) on the C++ side.
+        Users can customized this function to overwrite VisitSpan(const Span& span) on the C++ side.
 
         Parameters
         ----------
@@ -594,7 +596,7 @@ class _PyExprMutator(Object):
     A TVM object to support customization of ExprMutator on the python side.
     This is the decorated result returned from mutator decorator.
 
-    WARNING: This is NOT the user facing class for method overloading inheritance.
+    WARNING: This is NOT the user facing class for method overwriting inheritance.
 
     See also: mutator, PyExprmutator
     """
@@ -750,9 +752,9 @@ class _PyExprMutator(Object):
 class PyExprMutator:
     """
     An abstract ExprMutator with customized methods on the python-side.
-    This is the user facing class for method overloading inheritance.
+    This is the user facing class for method overwriting inheritance.
     _tvm_metadata discribes the class to inherit("cls"), the methods that users can
-    overload("methods"), the constructor's parameters("fields")
+    overwrite("methods"), the constructor's parameters("fields")
 
     Note: @relax.expr_functor.mutator is required for proper usage of any inherited class.
 
@@ -817,7 +819,7 @@ class PyExprMutator:
 
     def visit_expr(self, expr: Expr) -> Expr:
         """Generic dispatcher for Expr.
-        Users can customized this function to overload VisitExpr(const Expr& expr) on the C++ side.
+        Users can customized this function to overwrite VisitExpr(const Expr& expr) on the C++ side.
 
         Parameters
         ----------
@@ -834,7 +836,7 @@ class PyExprMutator:
 
     def visit_binding(self, binding: Binding) -> None:
         """Generic dispatcher for Binding.
-        Users can customized this function to overload VisitBinding(const Binding& binding)
+        Users can customized this function to overwrite VisitBinding(const Binding& binding)
         on the C++ side.
 
         Parameters
@@ -847,7 +849,7 @@ class PyExprMutator:
 
     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
         """Generic dispatcher for BindingBlock.
-        Users can customized this function to overload VisitBindingBlock(const BindingBlock& block)
+        Users can customized this function to overwrite VisitBindingBlock(const BindingBlock& block)
         on the C++ side.
 
         Parameters
@@ -865,7 +867,7 @@ class PyExprMutator:
 
     def visit_var_def(self, var: Var) -> Var:
         """Generic dispatcher for visiting the var definition site.
-        Users can customized this function to overload VisitVarDef(const Var& var) on the C++ side.
+        Users can customized this function to overwrite VisitVarDef(const Var& var) on the C++ side.
         Note that visit_var_() will only visit the usage site of an Var.
 
         Parameters
@@ -883,7 +885,7 @@ class PyExprMutator:
 
     def visit_constant_(self, op: Constant) -> Expr:
         """Visit Constant.
-        Users can customized this function to overload VisitExpr_(const ConstantNode* op)
+        Users can customized this function to overwrite VisitExpr_(const ConstantNode* op)
         on the C++ side.
 
         Parameters
@@ -900,7 +902,7 @@ class PyExprMutator:
 
     def visit_tuple_(self, op: Tuple) -> Expr:
         """Visit Tuple.
-        Users can customized this function to overload VisitExpr_(const TupleNode* op)
+        Users can customized this function to overwrite VisitExpr_(const TupleNode* op)
         on the C++ side.
 
         Parameters
@@ -917,7 +919,7 @@ class PyExprMutator:
 
     def visit_var_(self, op: Var) -> Expr:
         """Visit Var.
-        Users can customized this function to overload VisitExpr_(const VarNode* op)
+        Users can customized this function to overwrite VisitExpr_(const VarNode* op)
         on the C++ side.
 
         Parameters
@@ -934,7 +936,7 @@ class PyExprMutator:
 
     def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
         """Visit DataflowVar.
-        Users can customized this function to overload VisitExpr_(const DataflowVarNode* op)
+        Users can customized this function to overwrite VisitExpr_(const DataflowVarNode* op)
         on the C++ side.
 
         Parameters
@@ -951,7 +953,7 @@ class PyExprMutator:
 
     def visit_shape_expr_(self, op: ShapeExpr) -> Expr:
         """Visit ShapeExpr.
-        Users can customized this function to overload VisitExpr_(const ShapeExprNode* op)
+        Users can customized this function to overwrite VisitExpr_(const ShapeExprNode* op)
         on the C++ side.
 
         Parameters
@@ -968,7 +970,7 @@ class PyExprMutator:
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> Expr:
         """Visit RuntimeDepShape.
-        Users can customized this function to overload VisitExpr_(const RuntimeDepShapeNode* op)
+        Users can customized this function to overwrite VisitExpr_(const RuntimeDepShapeNode* op)
         on the C++ side.
 
         Parameters
@@ -985,7 +987,7 @@ class PyExprMutator:
 
     def visit_extern_func_(self, op: ExternFunc) -> Expr:
         """Visit ExternFunc.
-        Users can customized this function to overload VisitExpr_(const ExternFuncNode* op)
+        Users can customized this function to overwrite VisitExpr_(const ExternFuncNode* op)
         on the C++ side.
 
         Parameters
@@ -1002,7 +1004,7 @@ class PyExprMutator:
 
     def visit_global_var_(self, op: GlobalVar) -> Expr:
         """Visit GlobalVar.
-        Users can customized this function to overload VisitExpr_(const GlobalVarNode* op)
+        Users can customized this function to overwrite VisitExpr_(const GlobalVarNode* op)
         on the C++ side.
 
         Parameters
@@ -1019,7 +1021,7 @@ class PyExprMutator:
 
     def visit_function_(self, op: Function) -> Expr:
         """Visit Function.
-        Users can customized this function to overload VisitExpr_(const FunctionNode* op)
+        Users can customized this function to overwrite VisitExpr_(const FunctionNode* op)
         on the C++ side.
 
         Parameters
@@ -1036,7 +1038,7 @@ class PyExprMutator:
 
     def visit_call_(self, op: Call) -> Expr:
         """Visit Call.
-        Users can customized this function to overload VisitExpr_(const CallNode* op)
+        Users can customized this function to overwrite VisitExpr_(const CallNode* op)
         on the C++ side.
 
         Parameters
@@ -1053,7 +1055,7 @@ class PyExprMutator:
 
     def visit_seq_expr_(self, op: SeqExpr) -> Expr:
         """Visit SeqExpr.
-        Users can customized this function to overload VisitExpr_(const SeqExprNode* op)
+        Users can customized this function to overwrite VisitExpr_(const SeqExprNode* op)
         on the C++ side.
 
         Parameters
@@ -1070,7 +1072,8 @@ class PyExprMutator:
 
     def visit_if_(self, op: If) -> Expr:
         """Visit If.
-        Users can customized this function to overload VisitExpr_(const IfNode* op) on the C++ side.
+        Users can customized this function to overwrite VisitExpr_(const IfNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1086,7 +1089,8 @@ class PyExprMutator:
 
     def visit_op_(self, op: Op) -> Expr:
         """Visit Op.
-        Users can customized this function to overload VisitExpr_(const OpNode* op) on the C++ side.
+        Users can customized this function to overwrite VisitExpr_(const OpNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1102,7 +1106,7 @@ class PyExprMutator:
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
         """Visit TupleGetItem.
-        Users can customized this function to overload VisitExpr_(const TupleGetItemNode* op)
+        Users can customized this function to overwrite VisitExpr_(const TupleGetItemNode* op)
         on the C++ side.
 
         Parameters
@@ -1119,7 +1123,7 @@ class PyExprMutator:
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
         """Visit VarBinding.
-        Users can customized this function to overload VisitBinding_(const VarBindingNode* binding)
+        Users can customized this function to overwrite VisitBinding_(const VarBindingNode* binding)
         on the C++ side.
 
         Parameters
@@ -1131,7 +1135,7 @@ class PyExprMutator:
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
         """Visit MatchShape.
-        Users can customized this function to overload VisitBinding_(const MatchShapeNode* binding)
+        Users can customized this function to overwrite VisitBinding_(const MatchShapeNode* binding)
         on the C++ side.
 
         Parameters
@@ -1143,7 +1147,7 @@ class PyExprMutator:
 
     def visit_binding_block_(self, block: BindingBlock) -> BindingBlock:
         """Visit BindingBlock.
-        Users can customized this function to overload VisitBindingBlock_(const BindingBlockNode*
+        Users can customized this function to overwrite VisitBindingBlock_(const BindingBlockNode*
         block) on the C++ side.
 
         Parameters
@@ -1160,7 +1164,7 @@ class PyExprMutator:
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> BindingBlock:
         """Visit DataflowBlock.
-        Users can customized this function to overload VisitBindingBlock_(const DataflowBlockNode*
+        Users can customized this function to overwrite VisitBindingBlock_(const DataflowBlockNode*
         block) on the C++ side.
 
         Parameters
@@ -1177,7 +1181,7 @@ class PyExprMutator:
 
     def visit_var_def_(self, var: Var) -> Var:
         """Visit the Var definition site.
-        Users can customized this function to overload VisitVarDef_(const VarNode* var)
+        Users can customized this function to overwrite VisitVarDef_(const VarNode* var)
         on the C++ side.
 
         Parameters
@@ -1194,7 +1198,7 @@ class PyExprMutator:
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> Var:
         """Visit the DataflowVar definition site.
-        Users can customized this function to overload VisitVarDef_(const DataflowVarNode* var)
+        Users can customized this function to overwrite VisitVarDef_(const DataflowVarNode* var)
         on the C++ side.
 
         Parameters
@@ -1211,7 +1215,7 @@ class PyExprMutator:
 
     def visit_type(self, t: Type) -> Type:
         """Visit Type.
-        Users can customized this function to overload VisitType(const Type& t) on the C++ side.
+        Users can customized this function to overwrite VisitType(const Type& t) on the C++ side.
 
         Parameters
         ----------
@@ -1227,7 +1231,7 @@ class PyExprMutator:
 
     def visit_span(self, span: Span) -> Span:
         """Visit Span.
-        Users can customized this function to overload VisitSpan(const Span& span) on the C++ side.
+        Users can customized this function to overwrite VisitSpan(const Span& span) on the C++ side.
 
         Parameters
         ----------

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -19,11 +19,8 @@
 import tvm
 from typing import Optional, Callable
 from tvm.ir import Op
-from tvm.ir.base import structural_equal
-from tvm.ir.module import IRModule
 from tvm.meta_schedule.utils import derived_object
 
-from .ty import DynTensorType
 from .expr import Type, Span, Expr
 from .expr import Function, ExternFunc
 from .expr import Constant, Var, DataflowVar
@@ -32,13 +29,13 @@ from .expr import GlobalVar, SeqExpr, Tuple
 from .expr import Call, If, TupleGetItem
 from .expr import Binding, MatchShape, VarBinding
 from .expr import BindingBlock, DataflowBlock
-from .expr import _update_shape, _update_type
 from ..relay import Id
 from .block_builder import BlockBuilder
 from . import _ffi_api
 
 visitor = derived_object
 mutator = derived_object
+
 
 @tvm._ffi.register_object("expr_functor.PyExprVisitor")
 class _PyExprVisitor(tvm.runtime.Object):
@@ -407,46 +404,46 @@ class PyExprMutator:
     def visit_var_def(self, var: Var) -> Var:
         return _ffi_api.PyExprMutatorVisitVarDef(self._outer(), var)
 
-    def visit_constant_(self, op: Constant) -> None:
+    def visit_constant_(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def visit_tuple_(self, op: Tuple) -> None:
+    def visit_tuple_(self, op: Tuple) -> Expr:
         raise NotImplementedError
 
-    def visit_var_(self, op: Var) -> None:
+    def visit_var_(self, op: Var) -> Expr:
         raise NotImplementedError
 
-    def visit_dataflow_var_(self, op: DataflowVar) -> None:
+    def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
         raise NotImplementedError
 
-    def visit_shape_expr_(self, op: ShapeExpr) -> None:
+    def visit_shape_expr_(self, op: ShapeExpr) -> Expr:
         raise NotImplementedError
 
-    def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
+    def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> Expr:
         raise NotImplementedError
 
-    def visit_extern_func_(self, op: ExternFunc) -> None:
+    def visit_extern_func_(self, op: ExternFunc) -> Expr:
         raise NotImplementedError
 
-    def visit_global_var_(self, op: GlobalVar) -> None:
+    def visit_global_var_(self, op: GlobalVar) -> Expr:
         raise NotImplementedError
 
-    def visit_function_(self, op: Function) -> None:
+    def visit_function_(self, op: Function) -> Expr:
         raise NotImplementedError
 
-    def visit_call_(self, op: Call) -> None:
+    def visit_call_(self, op: Call) -> Expr:
         raise NotImplementedError
 
-    def visit_seq_expr_(self, op: SeqExpr) -> None:
+    def visit_seq_expr_(self, op: SeqExpr) -> Expr:
         raise NotImplementedError
 
-    def visit_if_(self, op: If) -> None:
+    def visit_if_(self, op: If) -> Expr:
         raise NotImplementedError
 
-    def visit_op_(self, op: Op) -> None:
+    def visit_op_(self, op: Op) -> Expr:
         raise NotImplementedError
 
-    def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
+    def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
         raise NotImplementedError
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
@@ -455,64 +452,64 @@ class PyExprMutator:
     def visit_match_shape_(self, binding: MatchShape) -> None:
         raise NotImplementedError
 
-    def visit_binding_block_(self, block: BindingBlock) -> None:
+    def visit_binding_block_(self, block: BindingBlock) -> BindingBlock:
         raise NotImplementedError
 
-    def visit_dataflow_block_(self, block: DataflowBlock) -> None:
+    def visit_dataflow_block_(self, block: DataflowBlock) -> BindingBlock:
         raise NotImplementedError
 
-    def visit_var_def_(self, var: Var) -> None:
+    def visit_var_def_(self, var: Var) -> Var:
         raise NotImplementedError
 
-    def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
+    def visit_dataflow_var_def_(self, var: DataflowVar) -> Var:
         raise NotImplementedError
 
-    def visit_type(self, t: Type) -> None:
+    def visit_type(self, t: Type) -> Type:
         raise NotImplementedError
 
-    def visit_span(self, span: Span) -> None:
+    def visit_span(self, span: Span) -> Span:
         raise NotImplementedError
 
-    def rewrite_constant_post_order(self, op: Constant) -> None:
+    def rewrite_constant_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_tuple_post_order(self, op: Constant) -> None:
+    def rewrite_tuple_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_var_post_order(self, op: Constant) -> None:
+    def rewrite_var_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_dataflow_var_post_order(self, op: Constant) -> None:
+    def rewrite_dataflow_var_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_shape_expr_post_order(self, op: Constant) -> None:
+    def rewrite_shape_expr_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_runtime_dep_shape_post_order(self, op: Constant) -> None:
+    def rewrite_runtime_dep_shape_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_extern_func_post_order(self, op: Constant) -> None:
+    def rewrite_extern_func_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_global_var_post_order(self, op: Constant) -> None:
+    def rewrite_global_var_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_function_post_order(self, op: Constant) -> None:
+    def rewrite_function_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_call_post_order(self, op: Constant) -> None:
+    def rewrite_call_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_seq_expr_post_order(self, op: Constant) -> None:
+    def rewrite_seq_expr_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_if_post_order(self, op: Constant) -> None:
+    def rewrite_if_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_op_post_order(self, op: Constant) -> None:
+    def rewrite_op_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
-    def rewrite_tuple_getitem_post_order(self, op: Constant) -> None:
+    def rewrite_tuple_getitem_post_order(self, op: Constant) -> Expr:
         raise NotImplementedError
 
     def visit_with_new_scope(self, expr: Expr) -> Expr:

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -34,6 +34,39 @@ from .expr import _update_shape, _update_type
 from .block_builder import BlockBuilder
 from . import _ffi_api
 
+expr_names = [
+    "constant",
+    "tuple",
+    "var",
+    "dataflow_var",
+    "shape_expr",
+    "runtime_dep_shape",
+    "extern_func",
+    "global_var",
+    "function",
+    "call",
+    "seq_expr",
+    "if",
+    "op",
+    "tuple_getitem",
+]
+other_names = [
+    "var_binding",
+    "match_shape",
+    "binding_block",
+    "dataflow_block",
+    "var_def",
+    "dataflow_var_def",
+]
+visit_func_names = [
+    "visit_expr",
+    "visit_binding",
+    "visit_binding_block",
+    "visit_var_def",
+    "visit_type",
+    "visit_span",
+] + [f"visit_{name}_" for name in (expr_names + other_names)]
+post_order_func_names = [f"rewrite_{name}_post_order" for name in expr_names]
 
 # @tvm._ffi.register_object("relax.ExprFunctor")
 class ExprFunctor(tvm.runtime.Object):
@@ -55,70 +88,148 @@ class ExprMutator:
     """TODO"""
 
 
-def _wrap_visitor(visitor_cls):
-    class PyVisitor(tvm.runtime.Object):
-        def __init__(self) -> None:
-            self.handle = None
+@tvm._ffi.register_object("expr_functor.PyExprVisitor")
+class _PyExprVisitor(tvm.runtime.Object):
+    """TODO"""
 
-            all_func_names = [
-                "visit_expr",
-                "visit_constant_",
-                "visit_tuple_",
-                "visit_var_",
-                "visit_dataflow_var_",
-                "visit_shape_expr_",
-                "visit_runtime_dep_shape_",
-                "visit_extern_func_",
-                "visit_global_var_",
-                "visit_function_",
-                "visit_call_",
-                "visit_seq_expr_",
-                "visit_if_",
-                "visit_op_",
-                "visit_tuple_getitem_",
-                "visit_binding",
-                "visit_var_binding_",
-                "visit_match_shape_",
-                "visit_binding_block",
-                "visit_binding_block_",
-                "visit_dataflow_block_",
-                "visit_var_def",
-                "visit_var_def_",
-                "visit_dataflow_var_def_",
-                "visit_type",
-                "visit_span",
-            ]
-            # packed_funcs = []
-            # packed_func_names = []
-            packed_value = []
 
-            inst = visitor_cls()
+class PyExprVisitor(_PyExprVisitor):
+    def visit_expr(self, expr: Expr) -> None:
+        return _ffi_api.PyExprVisitorVisitExpr(self._outer(), expr)
 
-            for func_name in all_func_names:
-                if hasattr(inst, func_name):
-                    # packed_funcs.append(visitor_cls.getattr[func_name])
-                    # packed_func_names.append(func_name)
-                    packed_value.append(func_name)
-                    packed_value.append(getattr(inst, func_name))
+    def visit_binding(self, binding: Binding) -> None:
+        return _ffi_api.PyExprVisitorVisitBinding(self._outer(), binding)
 
-            # print(packed_value)
-            self.__init_handle_by_constructor__(
-                _ffi_api.MakeExprVisitor, *packed_value  # packed_funcs, packed_func_names
-            )
+    def visit_binding_block(self, block: BindingBlock) -> None:
+        return _ffi_api.PyExprVisitorVisitBindingBlock(self._outer(), block)
 
-        def visit_expr(self, expr: Expr) -> None:
-            return _ffi_api.PyExprVisitorVisitExpr(self, expr)
+    def visit_var_def(self, var: Var) -> None:
+        return _ffi_api.PyExprVisitorVisitVarDef(self._outer(), var)
 
-    return PyVisitor
+
+@tvm._ffi.register_object("expr_functor.PyExprMutator")
+class _PyExprMutator(tvm.runtime.Object):
+    """TODO"""
+
+
+class PyExprMutator(_PyExprMutator):
+    def visit_expr(self, expr: Expr) -> Expr:
+        return _ffi_api.PyExprMutatorVisitExpr(self._outer(), expr)
+
+    def visit_binding(self, binding: Binding) -> None:
+        return _ffi_api.PyExprMutatorVisitBinding(self._outer(), binding)
+
+    def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
+        return _ffi_api.PyExprMutatorVisitBindingBlock(self._outer(), block)
+
+    def visit_var_def(self, var: Var) -> Var:
+        return _ffi_api.PyExprMutatorVisitVarDef(self._outer(), var)
 
 
 def visitor(visitor_cls=None):
-    def create_visitor(visitor_cls):
-        return _wrap_visitor(visitor_cls)
+    import functools
+    import weakref
 
-    if visitor_cls:
-        return create_visitor(visitor_cls)
-    return create_visitor
+    def _extract(inst, name):
+        def method(*args, **kwargs):
+            return getattr(inst, name)(*args, **kwargs)
+
+        return method
+
+    class PyVisitor(_PyExprVisitor):
+        def __init__(self, *args, **kwargs) -> None:
+            "Constructor."
+            self.handle = None
+            self._inst = visitor_cls(*args, **kwargs)
+
+            packed_value = []
+
+            for func_name in visit_func_names:
+                if hasattr(self._inst, func_name):
+                    if hasattr(PyExprVisitor, func_name) and (
+                        getattr(visitor_cls, func_name) == getattr(PyExprVisitor, func_name)
+                    ):
+                        continue
+                    packed_value.append(func_name)
+                    packed_value.append(_extract(self._inst, func_name))
+
+            self.__init_handle_by_constructor__(_ffi_api.MakeExprVisitor, *packed_value)
+
+            self._inst._outer = weakref.ref(self)
+
+        def __getattr__(self, name):
+            # fall back to instance attribute if there is not any
+            return self._inst.__getattribute__(name)
+
+        def __setattr__(self, name, value):
+            """TODO"""
+            if name not in ["_inst", "key", "handle"]:
+                self._inst.__setattr__(name, value)
+            else:
+                super(PyVisitor, self).__setattr__(name, value)
+
+    functools.update_wrapper(PyVisitor.__init__, visitor_cls.__init__)
+    PyVisitor.__name__ = visitor_cls.__name__
+    PyVisitor.__doc__ = visitor_cls.__doc__
+    PyVisitor.__module__ = visitor_cls.__module__
+    return PyVisitor
+
+
+def mutator(mutator_cls=None):
+    import functools
+    import weakref
+
+    def _extract(inst, name):
+        def method(*args, **kwargs):
+            return getattr(inst, name)(*args, **kwargs)
+
+        return method
+
+    class PyMutator(_PyExprMutator):
+        def __init__(self, *args, **kwargs) -> None:
+            "Constructor."
+            self.handle = None
+            self._inst = mutator_cls(*args, **kwargs)
+
+            packed_value = []
+
+            for func_name in visit_func_names:
+                if hasattr(self._inst, func_name):
+                    if hasattr(PyExprMutator, func_name) and (
+                        getattr(mutator_cls, func_name) == getattr(PyExprMutator, func_name)
+                    ):
+                        continue
+                    packed_value.append(func_name)
+                    packed_value.append(_extract(self._inst, func_name))
+
+            for func_name in post_order_func_names:
+                # rewrite_{name}_post_order
+                if hasattr(self._inst, func_name):
+                    if f"visit_{'_'.join(func_name.split('_')[1:-2])}_" in packed_value:
+                        raise RuntimeError(func_name)  # TODO: RuntimeError?
+                    packed_value.append(func_name)
+                    packed_value.append(_extract(self._inst, func_name))
+
+            self.__init_handle_by_constructor__(_ffi_api.MakeExprMutator, *packed_value)
+
+            self._inst._outer = weakref.ref(self)
+
+        def __getattr__(self, name):
+            # fall back to instance attribute if there is not any
+            return self._inst.__getattribute__(name)
+
+        def __setattr__(self, name, value):
+            """TODO"""
+            if name not in ["_inst", "key", "handle"]:  # TODO: Why do we need key here
+                self._inst.__setattr__(name, value)
+            else:
+                super(PyMutator, self).__setattr__(name, value)
+
+    functools.update_wrapper(PyMutator.__init__, mutator_cls.__init__)
+    PyMutator.__name__ = mutator_cls.__name__
+    PyMutator.__doc__ = mutator_cls.__doc__
+    PyMutator.__module__ = mutator_cls.__module__
+    return PyMutator
 
 
 # class ExprFunctor:

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -16,8 +16,9 @@
 # under the License.
 # pylint: disable=no-else-return, unidiomatic-typecheck, invalid-name, arguments-differ
 """The expression functor of Relax."""
-import tvm
 from typing import Optional, Callable
+
+import tvm
 from tvm.runtime import Object
 from tvm.ir import Op
 from tvm.meta_schedule.utils import derived_object
@@ -58,7 +59,7 @@ Example
         def visit_call_(self, op: Call) -> None:
             # just for demo purposes
             ...
-    # myvisitor is now a special visitor that visit every Call with 
+    # myvisitor is now a special visitor that visit every Call with
     # user-customized visit_call_
     myvisitor = MyExprVisitor()
     # apply myvisitor to Expr/Binding/BindingBlock/VarDef
@@ -99,7 +100,7 @@ Example
             # just for demo purposes
             ...
 
-    # mymutator is now a special mutator that rewrite every Tuple with 
+    # mymutator is now a special mutator that rewrite every Tuple with
     # user-customized visit_tuple_, and rewrite every Var with user-customized
     # rewrite_var_post_order in the post order.
     mymutator = MyExprMutator()
@@ -230,7 +231,8 @@ class PyExprVisitor:
     """
     An abstract ExprVisitor with customized methods on the python-side.
     This is the user facing class for method overloading inheritance.
-    _tvm_metadata discribes the class to inherit("cls"), the methods that users can overload("methods").
+    _tvm_metadata discribes the class to inherit("cls"), the methods
+    that users can overload("methods").
 
     Note: @derived_object is required for proper usage of any inherited class.
 
@@ -288,7 +290,8 @@ class PyExprVisitor:
 
     def visit_binding(self, binding: Binding) -> None:
         """Generic dispatcher for Binding.
-        Users can customized this function to overload VisitBinding(const Binding& binding) on the C++ side.
+        Users can customized this function to overload VisitBinding(const Binding& binding)
+        on the C++ side.
 
         Parameters
         ----------
@@ -300,7 +303,8 @@ class PyExprVisitor:
 
     def visit_binding_block(self, block: BindingBlock) -> None:
         """Generic dispatcher for BindingBlock.
-        Users can customized this function to overload VisitBindingBlock(const BindingBlock& block) on the C++ side.
+        Users can customized this function to overload VisitBindingBlock(const BindingBlock& block)
+        on the C++ side.
 
         Parameters
         ----------
@@ -325,7 +329,8 @@ class PyExprVisitor:
 
     def visit_constant_(self, op: Constant) -> None:
         """Visit Constant.
-        Users can customized this function to overload VisitExpr_(const ConstantNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const ConstantNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -336,7 +341,8 @@ class PyExprVisitor:
 
     def visit_tuple_(self, op: Tuple) -> None:
         """Visit Tuple.
-        Users can customized this function to overload VisitExpr_(const TupleNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const TupleNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -347,7 +353,8 @@ class PyExprVisitor:
 
     def visit_var_(self, op: Var) -> None:
         """Visit Var.
-        Users can customized this function to overload VisitExpr_(const VarNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const VarNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -358,7 +365,8 @@ class PyExprVisitor:
 
     def visit_dataflow_var_(self, op: DataflowVar) -> None:
         """Visit DataflowVar.
-        Users can customized this function to overload VisitExpr_(const DataflowVarNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const DataflowVarNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -369,7 +377,8 @@ class PyExprVisitor:
 
     def visit_shape_expr_(self, op: ShapeExpr) -> None:
         """Visit ShapeExpr.
-        Users can customized this function to overload VisitExpr_(const ShapeExprNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const ShapeExprNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -380,7 +389,8 @@ class PyExprVisitor:
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
         """Visit RuntimeDepShape.
-        Users can customized this function to overload VisitExpr_(const RuntimeDepShapeNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const RuntimeDepShapeNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -391,7 +401,8 @@ class PyExprVisitor:
 
     def visit_extern_func_(self, op: ExternFunc) -> None:
         """Visit ExternFunc.
-        Users can customized this function to overload VisitExpr_(const ExternFuncNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const ExternFuncNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -402,7 +413,8 @@ class PyExprVisitor:
 
     def visit_global_var_(self, op: GlobalVar) -> None:
         """Visit GlobalVar.
-        Users can customized this function to overload VisitExpr_(const GlobalVarNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const GlobalVarNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -413,7 +425,8 @@ class PyExprVisitor:
 
     def visit_function_(self, op: Function) -> None:
         """Visit Function.
-        Users can customized this function to overload VisitExpr_(const FunctionNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const FunctionNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -424,7 +437,8 @@ class PyExprVisitor:
 
     def visit_call_(self, op: Call) -> None:
         """Visit Call.
-        Users can customized this function to overload VisitExpr_(const CallNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const CallNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -435,7 +449,8 @@ class PyExprVisitor:
 
     def visit_seq_expr_(self, op: SeqExpr) -> None:
         """Visit SeqExpr.
-        Users can customized this function to overload VisitExpr_(const SeqExprNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const SeqExprNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -468,7 +483,8 @@ class PyExprVisitor:
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
         """Visit TupleGetItem.
-        Users can customized this function to overload VisitExpr_(const TupleGetItemNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const TupleGetItemNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -479,7 +495,8 @@ class PyExprVisitor:
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
         """Visit VarBinding.
-        Users can customized this function to overload VisitBinding_(const VarBindingNode* binding) on the C++ side.
+        Users can customized this function to overload VisitBinding_(const VarBindingNode* binding)
+        on the C++ side.
 
         Parameters
         ----------
@@ -490,7 +507,8 @@ class PyExprVisitor:
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
         """Visit MatchShape.
-        Users can customized this function to overload VisitBinding_(const MatchShapeNode* binding) on the C++ side.
+        Users can customized this function to overload VisitBinding_(const MatchShapeNode* binding)
+        on the C++ side.
 
         Parameters
         ----------
@@ -501,7 +519,8 @@ class PyExprVisitor:
 
     def visit_binding_block_(self, block: BindingBlock) -> None:
         """Visit BindingBlock.
-        Users can customized this function to overload VisitBindingBlock_(const BindingBlockNode* block) on the C++ side.
+        Users can customized this function to overload VisitBindingBlock_(const BindingBlockNode*
+        block) on the C++ side.
 
         Parameters
         ----------
@@ -512,7 +531,8 @@ class PyExprVisitor:
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> None:
         """Visit DataflowBlock.
-        Users can customized this function to overload VisitBindingBlock_(const DataflowBlockNode* block) on the C++ side.
+        Users can customized this function to overload VisitBindingBlock_(const DataflowBlockNode*
+        block) on the C++ side.
 
         Parameters
         ----------
@@ -523,7 +543,8 @@ class PyExprVisitor:
 
     def visit_var_def_(self, var: Var) -> None:
         """Visit the Var definition site.
-        Users can customized this function to overload VisitVarDef_(const VarNode* var) on the C++ side.
+        Users can customized this function to overload VisitVarDef_(const VarNode* var)
+        on the C++ side.
 
         Parameters
         ----------
@@ -534,7 +555,8 @@ class PyExprVisitor:
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
         """Visit the DataflowVar definition site.
-        Users can customized this function to overload VisitVarDef_(const DataflowVarNode* var) on the C++ side.
+        Users can customized this function to overload VisitVarDef_(const DataflowVarNode* var)
+        on the C++ side.
 
         Parameters
         ----------
@@ -729,7 +751,8 @@ class PyExprMutator:
     """
     An abstract ExprMutator with customized methods on the python-side.
     This is the user facing class for method overloading inheritance.
-    _tvm_metadata discribes the class to inherit("cls"), the methods that users can overload("methods"), the constructor's parameters("fields")
+    _tvm_metadata discribes the class to inherit("cls"), the methods that users can
+    overload("methods"), the constructor's parameters("fields")
 
     Note: @derived_object is required for proper usage of any inherited class.
 
@@ -811,7 +834,8 @@ class PyExprMutator:
 
     def visit_binding(self, binding: Binding) -> None:
         """Generic dispatcher for Binding.
-        Users can customized this function to overload VisitBinding(const Binding& binding) on the C++ side.
+        Users can customized this function to overload VisitBinding(const Binding& binding)
+        on the C++ side.
 
         Parameters
         ----------
@@ -823,7 +847,8 @@ class PyExprMutator:
 
     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
         """Generic dispatcher for BindingBlock.
-        Users can customized this function to overload VisitBindingBlock(const BindingBlock& block) on the C++ side.
+        Users can customized this function to overload VisitBindingBlock(const BindingBlock& block)
+        on the C++ side.
 
         Parameters
         ----------
@@ -858,7 +883,8 @@ class PyExprMutator:
 
     def visit_constant_(self, op: Constant) -> Expr:
         """Visit Constant.
-        Users can customized this function to overload VisitExpr_(const ConstantNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const ConstantNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -874,7 +900,8 @@ class PyExprMutator:
 
     def visit_tuple_(self, op: Tuple) -> Expr:
         """Visit Tuple.
-        Users can customized this function to overload VisitExpr_(const TupleNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const TupleNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -890,7 +917,8 @@ class PyExprMutator:
 
     def visit_var_(self, op: Var) -> Expr:
         """Visit Var.
-        Users can customized this function to overload VisitExpr_(const VarNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const VarNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -906,7 +934,8 @@ class PyExprMutator:
 
     def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
         """Visit DataflowVar.
-        Users can customized this function to overload VisitExpr_(const DataflowVarNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const DataflowVarNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -922,7 +951,8 @@ class PyExprMutator:
 
     def visit_shape_expr_(self, op: ShapeExpr) -> Expr:
         """Visit ShapeExpr.
-        Users can customized this function to overload VisitExpr_(const ShapeExprNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const ShapeExprNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -938,7 +968,8 @@ class PyExprMutator:
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> Expr:
         """Visit RuntimeDepShape.
-        Users can customized this function to overload VisitExpr_(const RuntimeDepShapeNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const RuntimeDepShapeNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -954,7 +985,8 @@ class PyExprMutator:
 
     def visit_extern_func_(self, op: ExternFunc) -> Expr:
         """Visit ExternFunc.
-        Users can customized this function to overload VisitExpr_(const ExternFuncNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const ExternFuncNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -970,7 +1002,8 @@ class PyExprMutator:
 
     def visit_global_var_(self, op: GlobalVar) -> Expr:
         """Visit GlobalVar.
-        Users can customized this function to overload VisitExpr_(const GlobalVarNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const GlobalVarNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -986,7 +1019,8 @@ class PyExprMutator:
 
     def visit_function_(self, op: Function) -> Expr:
         """Visit Function.
-        Users can customized this function to overload VisitExpr_(const FunctionNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const FunctionNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1002,7 +1036,8 @@ class PyExprMutator:
 
     def visit_call_(self, op: Call) -> Expr:
         """Visit Call.
-        Users can customized this function to overload VisitExpr_(const CallNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const CallNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1018,7 +1053,8 @@ class PyExprMutator:
 
     def visit_seq_expr_(self, op: SeqExpr) -> Expr:
         """Visit SeqExpr.
-        Users can customized this function to overload VisitExpr_(const SeqExprNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const SeqExprNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1066,7 +1102,8 @@ class PyExprMutator:
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
         """Visit TupleGetItem.
-        Users can customized this function to overload VisitExpr_(const TupleGetItemNode* op) on the C++ side.
+        Users can customized this function to overload VisitExpr_(const TupleGetItemNode* op)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1082,7 +1119,8 @@ class PyExprMutator:
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
         """Visit VarBinding.
-        Users can customized this function to overload VisitBinding_(const VarBindingNode* binding) on the C++ side.
+        Users can customized this function to overload VisitBinding_(const VarBindingNode* binding)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1093,7 +1131,8 @@ class PyExprMutator:
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
         """Visit MatchShape.
-        Users can customized this function to overload VisitBinding_(const MatchShapeNode* binding) on the C++ side.
+        Users can customized this function to overload VisitBinding_(const MatchShapeNode* binding)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1104,7 +1143,8 @@ class PyExprMutator:
 
     def visit_binding_block_(self, block: BindingBlock) -> BindingBlock:
         """Visit BindingBlock.
-        Users can customized this function to overload VisitBindingBlock_(const BindingBlockNode* block) on the C++ side.
+        Users can customized this function to overload VisitBindingBlock_(const BindingBlockNode*
+        block) on the C++ side.
 
         Parameters
         ----------
@@ -1120,7 +1160,8 @@ class PyExprMutator:
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> BindingBlock:
         """Visit DataflowBlock.
-        Users can customized this function to overload VisitBindingBlock_(const DataflowBlockNode* block) on the C++ side.
+        Users can customized this function to overload VisitBindingBlock_(const DataflowBlockNode*
+        block) on the C++ side.
 
         Parameters
         ----------
@@ -1136,7 +1177,8 @@ class PyExprMutator:
 
     def visit_var_def_(self, var: Var) -> Var:
         """Visit the Var definition site.
-        Users can customized this function to overload VisitVarDef_(const VarNode* var) on the C++ side.
+        Users can customized this function to overload VisitVarDef_(const VarNode* var)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1152,7 +1194,8 @@ class PyExprMutator:
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> Var:
         """Visit the DataflowVar definition site.
-        Users can customized this function to overload VisitVarDef_(const DataflowVarNode* var) on the C++ side.
+        Users can customized this function to overload VisitVarDef_(const DataflowVarNode* var)
+        on the C++ side.
 
         Parameters
         ----------
@@ -1506,25 +1549,25 @@ class PyExprMutator:
         """
         raise NotImplementedError
 
-    def set_var_remap(self, id: Id, var: Var) -> None:
+    def set_var_remap(self, vid: Id, var: Var) -> None:
         """Remap a var to a new var in use-site.
 
         Parameters
         ----------
-        id : Id
+        vid : Id
             The vid of the old var.
         var : Var
             The new var.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorSetVarRemap(self._outer(), id, var)
+        return _ffi_api.PyExprMutatorSetVarRemap(self._outer(), vid, var)
 
-    def get_var_remap(self, id: Id) -> Var:
+    def get_var_remap(self, vid: Id) -> Var:
         """Remap a var to a new var in use-site.
 
         Parameters
         ----------
-        id : Id
+        vid : Id
             The vid of the old var
 
         Returns
@@ -1533,7 +1576,7 @@ class PyExprMutator:
             The remapped var.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorGetVarRemap(self._outer(), id)
+        return _ffi_api.PyExprMutatorGetVarRemap(self._outer(), vid)
 
     def visit_with_new_scope(self, expr: Expr) -> Expr:
         """Rewrite the expr with a new scope, used in a Function's body and the branches of If.

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=redefined-builtin
+# pylint: disable=redefined-builtin, abstract-method, arguments-differ
 """
 Utility script for printing Relax modules as AST diagrams,
 only intended to show how the AST is put together.

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -24,7 +24,7 @@ from tvm.ir.module import IRModule
 from tvm.ir.transform import PassContext
 from tvm.target import Target
 from tvm.ir import transform
-from tvm.relax import ExprMutator
+from tvm.relax import PyExprMutator
 from tvm.relax.expr import Call
 from tvm.relay.backend.te_compiler import select_implementation
 
@@ -69,7 +69,8 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
         """
         target = self.target
 
-        class Lowerer(ExprMutator):
+        @relax.expr_functor.mutator
+        class Lowerer(PyExprMutator):
             """Mutator that performs lowering."""
 
             def visit_call_(self, call_node: Call):

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=unused-argument, invalid-name, no-else-return
+# pylint: disable=unused-argument, invalid-name, no-else-return, abstract-method, arguments-differ
 """Relax transformation passes for testing"""
 
 from __future__ import annotations

--- a/python/tvm/relax/transform/fma_rewrite.py
+++ b/python/tvm/relax/transform/fma_rewrite.py
@@ -37,7 +37,8 @@ class EwiseFMARewriter(PyExprMutator):
     z0 = ewise_fma(a, b, c)
     """
 
-    def rewrite_call_post_order(self, call: Call) -> Call:  # pylint: disable=arguments-differ
+    def visit_call_(self, call: Call) -> Call:  # pylint: disable=arguments-differ
+        call = self.visit_expr_post_order(call)
         add_op = Op.get("relax.add")
         multiply_op = Op.get("relax.multiply")
         ewise_fma_op = Op.get("relax.ewise_fma")
@@ -95,7 +96,8 @@ class EwiseFuseFMAMutator(PyExprMutator):
 
         return self.builder_.get()
 
-    def rewrite_call_post_order(self, call: Call) -> Call:  # pylint: disable=arguments-differ
+    def visit_call_(self, call: Call) -> Call:  # pylint: disable=arguments-differ
+        call = self.visit_expr_post_order(call)
         add_op = Op.get("relax.add")
         multiply_op = Op.get("relax.multiply")
         ewise_fma_op = Op.get("relax.ewise_fma")

--- a/python/tvm/relax/transform/fma_rewrite.py
+++ b/python/tvm/relax/transform/fma_rewrite.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=unused-argument, invalid-name
+# pylint: disable=unused-argument, invalid-name, abstract-method
 """Perform fused multiply-add rewriting in Python"""
 from tvm.ir import Op
 from tvm.ir.module import IRModule
@@ -37,7 +37,7 @@ class EwiseFMARewriter(PyExprMutator):
     z0 = ewise_fma(a, b, c)
     """
 
-    def rewrite_call_post_order(self, call: Call) -> Call:
+    def rewrite_call_post_order(self, call: Call) -> Call:  # pylint: disable=arguments-differ
         add_op = Op.get("relax.add")
         multiply_op = Op.get("relax.multiply")
         ewise_fma_op = Op.get("relax.ewise_fma")
@@ -95,7 +95,7 @@ class EwiseFuseFMAMutator(PyExprMutator):
 
         return self.builder_.get()
 
-    def rewrite_call_post_order(self, call: Call) -> Call:
+    def rewrite_call_post_order(self, call: Call) -> Call:  # pylint: disable=arguments-differ
         add_op = Op.get("relax.add")
         multiply_op = Op.get("relax.multiply")
         ewise_fma_op = Op.get("relax.ewise_fma")

--- a/python/tvm/relax/transform/fma_rewrite.py
+++ b/python/tvm/relax/transform/fma_rewrite.py
@@ -129,5 +129,4 @@ class EwiseFuseFMA:
     """The wrapper for the EwiseFuseFMA pass."""
 
     def transform_module(self, mod, ctx):
-        m = EwiseFuseFMAMutator(mod)
-        return m.transform()
+        return EwiseFuseFMAMutator(mod).transform()

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -664,17 +664,8 @@ Var ExprMutator::WithShapeAndType(Var var, Optional<ObjectRef> shape, Type type)
   return var;
 }
 
-TVM_REGISTER_GLOBAL("relax.MakeExprVisitor").set_body([](TVMArgs args, TVMRetValue* rv) {
-  std::unordered_map<std::string, PackedFunc> map;
-
-  PackedFunc packed_func;
-  for (int i = 0; i < args.size(); i += 2) {
-    std::string func_name = args[i];
-    PackedFunc packed_func = args[i + 1];
-    map.emplace(func_name, packed_func);
-  }
-  *rv = PyExprVisitor(map);
-});
+// TODO relax.ExprFunctor.xx?
+TVM_REGISTER_GLOBAL("relax.MakePyExprVisitor").set_body_typed(PyExprVisitor::MakePyExprVisitor);
 
 TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitExpr")
     .set_body_typed([](PyExprVisitor visitor, const Expr& expr) { visitor->VisitExpr(expr); });
@@ -692,17 +683,7 @@ TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitBindingBlock")
 TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitVarDef")
     .set_body_typed([](PyExprVisitor visitor, const Var& var) { visitor->VisitVarDef(var); });
 
-TVM_REGISTER_GLOBAL("relax.MakeExprMutator").set_body([](TVMArgs args, TVMRetValue* rv) {
-  std::unordered_map<std::string, PackedFunc> map;
-
-  PackedFunc packed_func;
-  for (int i = 0; i < args.size(); i += 2) {
-    std::string func_name = args[i];
-    PackedFunc packed_func = args[i + 1];
-    map.emplace(func_name, packed_func);
-  }
-  *rv = PyExprMutator(map);
-});
+TVM_REGISTER_GLOBAL("relax.MakePyExprMutator").set_body_typed(PyExprMutator::MakePyExprMutator);
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitExpr")
     .set_body_typed([](PyExprMutator visitor, const Expr& expr) {

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -449,7 +449,6 @@ Expr ExprMutator::VisitExpr_(const SeqExprNode* op) {
     }
     all_blocks_unchanged &= block.same_as(new_block);
   }
-  std::cout << all_blocks_unchanged << std::endl;
 
   builder_->BeginBindingBlock();
   Expr body = this->VisitExpr(op->body);
@@ -460,10 +459,8 @@ Expr ExprMutator::VisitExpr_(const SeqExprNode* op) {
   }
 
   if (all_blocks_unchanged && body.same_as(op->body)) {
-    std::cout << "seqexpr1" << std::endl;
     return GetRef<Expr>(op);
   } else {
-    std::cout << "seqexpr2" << std::endl;
     return SeqExpr(blocks, body);
   }
 }
@@ -680,20 +677,20 @@ TVM_REGISTER_GLOBAL("relax.MakeExprVisitor").set_body([](TVMArgs args, TVMRetVal
 });
 
 TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitExpr")
-    .set_body_typed([](PyExprVisitor visitor, const Expr& expr) { visitor.VisitExpr(expr); });
+    .set_body_typed([](PyExprVisitor visitor, const Expr& expr) { visitor->VisitExpr(expr); });
 
 TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitBinding")
     .set_body_typed([](PyExprVisitor visitor, const Binding& binding) {
-      visitor.VisitBinding(binding);
+      visitor->VisitBinding(binding);
     });
 
 TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitBindingBlock")
     .set_body_typed([](PyExprVisitor visitor, const BindingBlock& block) {
-      visitor.VisitBindingBlock(block);
+      visitor->VisitBindingBlock(block);
     });
 
 TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitVarDef")
-    .set_body_typed([](PyExprVisitor visitor, const Var& var) { visitor.VisitVarDef(var); });
+    .set_body_typed([](PyExprVisitor visitor, const Var& var) { visitor->VisitVarDef(var); });
 
 TVM_REGISTER_GLOBAL("relax.MakeExprMutator").set_body([](TVMArgs args, TVMRetValue* rv) {
   std::unordered_map<std::string, PackedFunc> map;
@@ -709,21 +706,46 @@ TVM_REGISTER_GLOBAL("relax.MakeExprMutator").set_body([](TVMArgs args, TVMRetVal
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitExpr")
     .set_body_typed([](PyExprMutator visitor, const Expr& expr) {
-      return visitor.VisitExpr(expr);
+      return visitor->VisitExpr(expr);
     });
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitBinding")
     .set_body_typed([](PyExprMutator visitor, const Binding& binding) {
-      visitor.VisitBinding(binding);
+      visitor->VisitBinding(binding);
     });
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitBindingBlock")
     .set_body_typed([](PyExprMutator visitor, const BindingBlock& block) {
-      return visitor.VisitBindingBlock(block);
+      return visitor->VisitBindingBlock(block);
     });
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitVarDef")
-    .set_body_typed([](PyExprMutator visitor, const Var& var) { return visitor.VisitVarDef(var); });
+    .set_body_typed([](PyExprMutator visitor, const Var& var) {
+      return visitor->VisitVarDef(var);
+    });
+
+TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitWithNewScope")
+    .set_body_typed([](PyExprMutator visitor, const Expr& expr) {
+      return visitor->VisitWithNewScope(expr);
+    });
+
+TVM_REGISTER_GLOBAL("relax.PyExprMutatorLookupBinding")
+    .set_body_typed([](PyExprMutator visitor, const Var& var) {
+      return visitor->LookupBinding(var);
+    });
+
+TVM_REGISTER_GLOBAL("relax.PyExprMutatorWithShapeAndType")
+    .set_body_typed([](PyExprMutator visitor, Var var, Optional<ObjectRef> shape, Type type) {
+      return visitor->WithShapeAndType(var, shape, type);
+    });
+
+TVM_REGISTER_GLOBAL("relax.PyExprMutatorSetVarRemap")
+    .set_body_typed([](PyExprMutator visitor, Id id, Var var) {
+      return visitor->var_remap_[id] = var;
+    });
+
+TVM_REGISTER_GLOBAL("relax.PyExprMutatorGetVarRemap")
+    .set_body_typed([](PyExprMutator visitor, Id id) { return visitor->var_remap_[id]; });
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -664,5 +664,27 @@ Var ExprMutator::WithShapeAndType(Var var, Optional<ObjectRef> shape, Type type)
   return var;
 }
 
+// TVM_REGISTER_GLOBAL("relax.MakeExprVisitor").set_body_typed([](Array<String> func_names) {
+//   Array<PackedFunc> packed_funcs;
+//   return PyExprVisitor(packed_funcs, func_names);
+// });
+
+TVM_REGISTER_GLOBAL("relax.MakeExprVisitor").set_body([](TVMArgs args, TVMRetValue* rv) {
+  std::vector<PackedFunc> packed_funcs;
+  std::vector<std::string> func_names;
+  std::unordered_map<std::string, PackedFunc> map;
+
+  PackedFunc packed_func;
+  for (int i = 0; i < args.size(); i += 2) {
+    std::string func_name = args[i];
+    PackedFunc packed_func = args[i + 1];
+    map.emplace(func_name, packed_func);
+  }
+  // for (int i = 0; i < args.size(); i += 2) {
+  //   map.emplace(args[i], args[i + 1]);
+  // }
+  *rv = PyExprVisitor(map, new ExprVisitor());
+});
+
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -687,6 +687,31 @@ TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitExpr")
       visitor->ExprVisitor::VisitExpr(expr);
     });
 
+TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitBinding")
+    .set_body_typed([](PyExprVisitor visitor, const Binding& binding) {
+      visitor->ExprVisitor::VisitBinding(binding);
+    });
+
+TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitBindingBlock")
+    .set_body_typed([](PyExprVisitor visitor, const BindingBlock& block) {
+      visitor->ExprVisitor::VisitBindingBlock(block);
+    });
+
+TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitVarDef")
+    .set_body_typed([](PyExprVisitor visitor, const Var& var) {
+      visitor->ExprVisitor::VisitVarDef(var);
+    });
+
+TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitType")
+    .set_body_typed([](PyExprVisitor visitor, const Type& type) {
+      visitor->ExprVisitor::VisitType(type);
+    });
+
+TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitSpan")
+    .set_body_typed([](PyExprVisitor visitor, const Span& span) {
+      visitor->ExprVisitor::VisitSpan(span);
+    });
+
 TVM_REGISTER_GLOBAL("relax.MakePyExprMutator").set_body_typed(PyExprMutator::MakePyExprMutator);
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitExpr")
@@ -712,6 +737,26 @@ TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitVarDef")
 TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitExpr")
     .set_body_typed([](PyExprMutator visitor, const Expr& expr) {
       return visitor->ExprMutator::VisitExpr(expr);
+    });
+
+TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitBinding")
+    .set_body_typed([](PyExprMutator visitor, const Binding& binding) {
+      return visitor->ExprMutator::VisitBinding(binding);
+    });
+
+TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitBindingBlock")
+    .set_body_typed([](PyExprMutator visitor, const BindingBlock& block) {
+      return visitor->ExprMutator::VisitBindingBlock(block);
+    });
+
+TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitVarDef")
+    .set_body_typed([](PyExprMutator visitor, const Var& var) {
+      return visitor->ExprMutator::VisitVarDef(var);
+    });
+
+TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitType")
+    .set_body_typed([](PyExprMutator visitor, const Type& type) {
+      return visitor->ExprMutator::VisitType(type);
     });
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitExprPostOrder")

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -682,6 +682,11 @@ TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitBindingBlock")
 TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitVarDef")
     .set_body_typed([](PyExprVisitor visitor, const Var& var) { visitor->VisitVarDef(var); });
 
+TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitExpr")
+    .set_body_typed([](PyExprVisitor visitor, const Expr& expr) {
+      visitor->ExprVisitor::VisitExpr(expr);
+    });
+
 TVM_REGISTER_GLOBAL("relax.MakePyExprMutator").set_body_typed(PyExprMutator::MakePyExprMutator);
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitExpr")
@@ -702,6 +707,16 @@ TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitBindingBlock")
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitVarDef")
     .set_body_typed([](PyExprMutator visitor, const Var& var) {
       return visitor->VisitVarDef(var);
+    });
+
+TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitExpr")
+    .set_body_typed([](PyExprMutator visitor, const Expr& expr) {
+      return visitor->ExprMutator::VisitExpr(expr);
+    });
+
+TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitExprPostOrder")
+    .set_body_typed([](PyExprMutator visitor, const Expr& expr) {
+      return visitor->VisitExprPostOrder(expr);
     });
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitWithNewScope")

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -670,8 +670,6 @@ Var ExprMutator::WithShapeAndType(Var var, Optional<ObjectRef> shape, Type type)
 // });
 
 TVM_REGISTER_GLOBAL("relax.MakeExprVisitor").set_body([](TVMArgs args, TVMRetValue* rv) {
-  std::vector<PackedFunc> packed_funcs;
-  std::vector<std::string> func_names;
   std::unordered_map<std::string, PackedFunc> map;
 
   PackedFunc packed_func;
@@ -680,11 +678,11 @@ TVM_REGISTER_GLOBAL("relax.MakeExprVisitor").set_body([](TVMArgs args, TVMRetVal
     PackedFunc packed_func = args[i + 1];
     map.emplace(func_name, packed_func);
   }
-  // for (int i = 0; i < args.size(); i += 2) {
-  //   map.emplace(args[i], args[i + 1]);
-  // }
   *rv = PyExprVisitor(map, new ExprVisitor());
 });
+
+TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitExpr")
+    .set_body_typed([](PyExprVisitor visitor, const Expr& expr) { visitor.VisitExpr(expr); });
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -664,7 +664,6 @@ Var ExprMutator::WithShapeAndType(Var var, Optional<ObjectRef> shape, Type type)
   return var;
 }
 
-// TODO relax.ExprFunctor.xx?
 TVM_REGISTER_GLOBAL("relax.MakePyExprVisitor").set_body_typed(PyExprVisitor::MakePyExprVisitor);
 
 TVM_REGISTER_GLOBAL("relax.PyExprVisitorVisitExpr")

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -601,5 +601,23 @@ def test_overload_visit_and_post_order_visit_conflict():
         FailMutator().visit_expr(call_node)
 
 
+def test_inherit_visitor():
+    @relax.expr_functor.visitor
+    class InheritVisitor(ASTPrinter):
+        def visit_call_(self, op: Call) -> None:
+            self.log.add("InheritCall")
+            self.log.push_scope()
+            self.visit_expr(op.op)
+
+            for arg in op.args:
+                self.visit_expr(arg)
+            self.log.pop_scope()
+
+    call_node = relax.op.add(x, y)
+    iv = InheritVisitor()
+    iv.visit_expr(call_node)
+    assert str(iv.log) == "\n".join(["InheritCall", "\tOp", "\tVar", "\tVar"])
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -14,12 +14,22 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from re import L
 import pytest
 
 import tvm
 from tvm import relax, tir
-from tvm.relax import ExprFunctor, ExprVisitor, ExprMutatorBase, ExprMutator
+from tvm.relax import PyExprVisitor, PyExprMutator, visitor, mutator
 from tvm.ir.base import assert_structural_equal
+from tvm.ir import Op
+from tvm.relax.expr import Type, Span, Expr
+from tvm.relax.expr import Function, ExternFunc
+from tvm.relax.expr import Constant, Var, DataflowVar
+from tvm.relax.expr import ShapeExpr, RuntimeDepShape
+from tvm.relax.expr import GlobalVar, SeqExpr, Tuple
+from tvm.relax.expr import Call, If, TupleGetItem
+from tvm.relax.expr import Binding, MatchShape, VarBinding
+from tvm.relax.expr import BindingBlock, DataflowBlock
 
 m, n = tir.Var("m", "int64"), tir.Var("n", "int64")
 type_anno1 = relax.DynTensorType(1, "float32")
@@ -29,113 +39,385 @@ y = relax.Var("y", [m, n], type_anno2)
 bb = relax.BlockBuilder()
 
 
-def check_visit(expr):
+@visitor
+class BasicVisitor(PyExprVisitor):
+    """Default ExprVisitor"""
+
+
+class ASTLog:
+    def __init__(self, reverse=False) -> None:
+        self.log = []
+        self.indent = "\t"
+        self.level = 0
+        self.reverse = reverse
+
+    def push_scope(self):
+        self.level += 1
+
+    def pop_scope(self):
+        self.level -= 1
+
+    def add(self, s: str):
+        self.log.append(self.indent * self.level + s)
+
+    def __str__(self) -> str:
+        return "\n".join(reversed(self.log) if self.reverse else self.log)
+
+
+@visitor
+class ASTPrinter(PyExprVisitor):
+    """TODO"""
+
+    def __init__(self) -> None:
+        self.log = ASTLog()
+
+    def visit_constant_(self, op: Constant) -> None:
+        self.log.add("Constant")
+
+    def visit_global_var_(self, op: GlobalVar) -> None:
+        self.log.add("GlobalVar")
+
+    def visit_tuple_(self, op: Tuple) -> None:
+        self.log.add("Tuple")
+        self.log.push_scope()
+        for field in op.fields:
+            self.visit_expr(field)
+        self.log.pop_scope()
+
+    def visit_var_(self, op: Var) -> None:
+        self.log.add("Var")
+
+    def visit_dataflow_var_(self, op: DataflowVar) -> None:
+        self.log.add("DataflowVar")
+
+    def visit_function_(self, op: Function) -> None:
+        self.log.add("Function")
+        self.log.push_scope()
+        for param in op.params:
+            self.visit_var_def(param)
+
+        self.visit_expr(op.body)
+        self.log.pop_scope()
+
+    def visit_call_(self, op: Call) -> None:
+        self.log.add("Call")
+        self.log.push_scope()
+        self.visit_expr(op.op)
+
+        for arg in op.args:
+            self.visit_expr(arg)
+        self.log.pop_scope()
+
+    def visit_if_(self, op: If) -> None:
+        self.log.add("If")
+        self.log.push_scope()
+        self.visit_expr(op.cond)
+        self.visit_expr(op.true_branch)
+        self.visit_expr(op.false_branch)
+        self.log.pop_scope()
+
+    def visit_op_(self, op: Op) -> None:
+        self.log.add("Op")
+
+    def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
+        self.log.add("TupleGetItem")
+        self.log.push_scope()
+        self.visit_expr(op.tuple_value)
+        self.log.pop_scope()
+
+    def visit_shape_expr_(self, op: ShapeExpr) -> None:
+        self.log.add("ShapeExpr")
+
+    def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
+        self.log.add("RuntimeDepShape")
+
+    def visit_extern_func_(self, op: ExternFunc) -> None:
+        self.log.add("ExternFunc")
+
+    def visit_seq_expr_(self, op: SeqExpr) -> None:
+        self.log.add("SeqExpr")
+        self.log.push_scope()
+        for block in op.blocks:
+            self.visit_binding_block(block)
+        self.visit_expr(op.body)
+        self.log.pop_scope()
+
+    def visit_var_binding_(self, binding: VarBinding) -> None:
+        self.log.add("VarBinding")
+        self.log.push_scope()
+        self.visit_expr(binding.value)
+        self.visit_var_def(binding.var)
+        self.log.pop_scope()
+
+    def visit_match_shape_(self, binding: MatchShape) -> None:
+        self.log.add("MatchShape")
+        self.log.push_scope()
+        self.visit_expr(binding.value)
+        self.visit_expr(ShapeExpr(binding.pattern))
+        if binding.var:
+            self.visit_var_def(binding.var)
+        self.log.pop_scope()
+
+    def visit_binding_block_(self, block: BindingBlock) -> None:
+        self.log.add("BindingBlock")
+        self.log.push_scope()
+        for binding in block.bindings:
+            self.visit_binding(binding)
+        self.log.pop_scope()
+
+    def visit_dataflow_block_(self, block: DataflowBlock) -> None:
+        self.log.add("DataflowBlock")
+        self.log.push_scope()
+        for binding in block.bindings:
+            self.visit_binding(binding)
+        self.log.pop_scope()
+
+    def visit_var_def_(self, var: Var) -> None:
+        self.log.add("VarDef")
+
+    def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
+        self.log.add("DataflowVarDef")
+
+
+@mutator
+class BasicMutator(PyExprMutator):
+    """Default ExprMutator"""
+
+
+@mutator
+class ASTPostPrinterMutator(PyExprMutator):
+    """TODO"""
+
+    def __init__(self) -> None:
+        self.log = ASTLog()
+
+    def rewrite_constant_post_order(self, op: Constant) -> Expr:
+        self.log.add("Constant")
+        return op
+
+    def rewrite_global_var_post_order(self, op: GlobalVar) -> Expr:
+        self.log.add("GlobalVar")
+        return op
+
+    def rewrite_tuple_post_order(self, op: Tuple) -> Expr:
+        self.log.add("Tuple")
+        return op
+
+    def rewrite_var_post_order(self, op: Var) -> Expr:
+        self.log.add("Var")
+        return op
+
+    def rewrite_dataflow_var_post_order(self, op: DataflowVar) -> Expr:
+        self.log.add("DataflowVar")
+        return op
+
+    def rewrite_function_post_order(self, op: Function) -> Expr:
+        self.log.add("Function")
+        return op
+
+    def rewrite_call_post_order(self, op: Call) -> Expr:
+        self.log.add("Call")
+        return op
+
+    def rewrite_call_post_order(self, op: If) -> Expr:
+        self.log.add("If")
+        return op
+
+    def rewrite_op_post_order(self, op: Op) -> Expr:
+        self.log.add("Op")
+        return op
+
+    def rewrite_tuple_getitem_post_order(self, op: TupleGetItem) -> Expr:
+        self.log.add("TupleGetItem")
+        return op
+
+    def rewrite_shape_expr_post_order(self, op: ShapeExpr) -> Expr:
+        self.log.add("ShapeExpr")
+        return op
+
+    def rewrite_runtime_dep_shape_post_order(self, op: RuntimeDepShape) -> Expr:
+        self.log.add("RuntimeDepShape")
+        return op
+
+    def rewrite_extern_func_post_order(self, op: ExternFunc) -> Expr:
+        self.log.add("ExternFunc")
+        return op
+
+    def rewrite_seq_expr_post_order(self, op: SeqExpr) -> Expr:
+        self.log.add("SeqExpr")
+        return op
+
+
+def basic_check(expr, visitor_str, mutator_str):
     def visit(f, expr):
         if isinstance(expr, relax.Expr):
             return f.visit_expr(expr)
         elif isinstance(expr, relax.BindingBlock):
             return f.visit_binding_block(expr)
 
-    if isinstance(expr, relax.Expr):
-        with pytest.raises(NotImplementedError):
-            ef = ExprFunctor()
-            visit(ef, expr)
+    basic_visitor = BasicVisitor()
+    visit(basic_visitor, expr)
 
-    ev = ExprVisitor()
-    visit(ev, expr)
+    log_visitor = ASTPrinter()
+    visit(log_visitor, expr)
+    assert str(log_visitor.log) == visitor_str
 
-    em_base = ExprMutatorBase()
-    assert_structural_equal(visit(em_base, expr), expr)
-
-    em = ExprMutator()
+    basic_mutator = BasicMutator()
     if isinstance(expr, relax.Expr):
         expr = bb.normalize(expr)
-    assert_structural_equal(visit(em, expr), expr)
+    assert_structural_equal(visit(basic_mutator, expr), expr)
+
+    post_log_mutator = ASTPostPrinterMutator()
+    if isinstance(expr, relax.Expr):
+        expr = bb.normalize(expr)
+    assert_structural_equal(visit(post_log_mutator, expr), expr)
+    assert str(post_log_mutator.log) == mutator_str
 
 
 def test_constant():
-    check_visit(relax.const(1.0))
+    basic_check(relax.const(1.0), "Constant", "Constant")
 
 
 def test_var():
-    check_visit(x)
+    basic_check(x, "Var", "Var")
 
 
 def test_dataflow_var():
     lv = relax.DataflowVar("lv", [n], type_anno1)
-    check_visit(lv)
+    basic_check(lv, "DataflowVar", "DataflowVar")
 
 
 def test_tuple():
     t = relax.Tuple([x, y])
-    check_visit(t)
+    basic_check(t, "\n".join(["Tuple", "\tVar", "\tVar"]), "\n".join(["Var", "Var", "Tuple"]))
 
 
 def test_global_var():
     gv = relax.GlobalVar("gv")
-    check_visit(gv)
+    basic_check(gv, "GlobalVar", "GlobalVar")
 
 
 def test_seq_expr():
     bindings = [relax.VarBinding(x, relax.const(1))]
     blocks = [relax.BindingBlock(bindings)]
     seq_expr = relax.SeqExpr(blocks, x)
-    check_visit(seq_expr)
+    basic_check(
+        seq_expr,
+        "\n".join(
+            [
+                "SeqExpr",
+                "\tBindingBlock",
+                "\t\tVarBinding",
+                "\t\t\tConstant",
+                "\t\t\tVarDef",
+                "\tVar",
+            ]
+        ),
+        "",
+    )
 
 
 def test_shape_expr():
     x = relax.ShapeExpr([m, n])
-    check_visit(x)
+    basic_check(x, "ShapeExpr", "ShapeExpr")
 
 
-def test_runtime_dep_shape():
-    runtime_dep_shape = relax.RuntimeDepShape()
-    check_visit(runtime_dep_shape)
+# def test_runtime_dep_shape():
+#     runtime_dep_shape = relax.RuntimeDepShape()
+#     basic_check(runtime_dep_shape, "RuntimeDepShape")
 
 
-def test_call():
-    call_node = relax.op.add(x, y)
-    check_visit(call_node)
+# def test_call():
+#     call_node = relax.op.add(x, y)
+#     basic_check(call_node, "\n".join(["Call", "\tOp", "\tVar", "\tVar"]))
 
 
-def test_if():
-    if_node = relax.If(x, x, x)
-    check_visit(if_node)
+# def test_if():
+#     if_node = relax.If(x, x, x)
+#     basic_check(if_node, "\n".join(["If", "\tVar", "\tVar", "\tVar"]))
 
 
-def test_tuple_getitem():
-    op = relax.TupleGetItem(relax.Tuple([x, y]), 0)
-    check_visit(op)
+# def test_tuple_getitem():
+#     tuple_getitem_node = relax.TupleGetItem(relax.Tuple([x, y]), 0)
+#     basic_check(tuple_getitem_node, "\n".join(["TupleGetItem", "\tTuple", "\t\tVar", "\t\tVar"]))
 
 
-def test_binding_block():
-    bb._begin_binding_block()
-    gv0 = bb.emit(relax.op.add(x, y))
-    gv1 = bb.match_shape(y, [m, n])
-    b0 = bb._end_block()
-    check_visit(b0)
+# def test_binding_block():
+#     bb._begin_binding_block()
+#     gv0 = bb.emit(relax.op.add(x, y))
+#     gv1 = bb.match_shape(y, [m, n])
+#     b0 = bb._end_block()
+#     basic_check(
+#         b0,
+#         "\n".join(
+#             [
+#                 "BindingBlock",
+#                 "\tVarBinding",
+#                 "\t\tCall",
+#                 "\t\t\tOp",
+#                 "\t\t\tVar",
+#                 "\t\t\tVar",
+#                 "\t\tVarDef",
+#                 "\tMatchShape",
+#                 "\t\tVar",
+#                 "\t\tShapeExpr",
+#                 "\t\tVarDef",
+#             ]
+#         ),
+#     )
 
 
-def test_dataflow_block():
-    bb._begin_dataflow_block()
-    lv0 = bb.emit(relax.op.add(x, y))
-    gv1 = bb.match_shape(y, [m, n])
-    b0 = bb._end_block()
-    check_visit(b0)
+# def test_dataflow_block():
+#     bb._begin_dataflow_block()
+#     lv0 = bb.emit(relax.op.add(x, y))
+#     gv1 = bb.match_shape(y, [m, n])
+#     b0 = bb._end_block()
+#     basic_check(
+#         b0,
+#         "\n".join(
+#             [
+#                 "DataflowBlock",
+#                 "\tVarBinding",
+#                 "\t\tCall",
+#                 "\t\t\tOp",
+#                 "\t\t\tVar",
+#                 "\t\t\tVar",
+#                 "\t\tDataflowVarDef",
+#                 "\tMatchShape",
+#                 "\t\tVar",
+#                 "\t\tShapeExpr",
+#                 "\t\tDataflowVarDef",
+#             ]
+#         ),
+#     )
 
 
-def test_function():
-    bindings = [relax.VarBinding(x, relax.const(1))]
-    blocks = [relax.BindingBlock(bindings)]
-    seq_expr = relax.SeqExpr(blocks, x)
-    ret_type = relax.DynTensorType(-1, "float32")
-    func = relax.Function([x], seq_expr, ret_type)
-    check_visit(func)
+# def test_function():
+#     bindings = [relax.VarBinding(x, relax.const(1))]
+#     blocks = [relax.BindingBlock(bindings)]
+#     seq_expr = relax.SeqExpr(blocks, x)
+#     ret_type = relax.DynTensorType(-1, "float32")
+#     func = relax.Function([x], seq_expr, ret_type)
+#     basic_check(
+#         func,
+#         "\n".join(
+#             [
+#                 "Function",
+#                 "\tVarDef",
+#                 "\tSeqExpr",
+#                 "\t\tBindingBlock",
+#                 "\t\t\tVarBinding",
+#                 "\t\t\t\tConstant",
+#                 "\t\t\t\tVarDef",
+#                 "\t\tVar",
+#             ]
+#         ),
+#     )
 
 
-def test_extern_func():
-    func = relax.ExternFunc("f")
-    check_visit(func)
+# def test_extern_func():
+#     func = relax.ExternFunc("f")
+#     basic_check(func, "ExternFunc")
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -19,7 +19,7 @@ import pytest
 
 import tvm
 from tvm import relax, tir
-from tvm.relax import PyExprVisitor, PyExprMutator, visitor, mutator
+from tvm.relax import PyExprVisitor, PyExprMutator
 from tvm.ir.base import assert_structural_equal
 from tvm.ir import Op
 from tvm.relax.ty import DynTensorType
@@ -41,7 +41,7 @@ y = relax.Var("y", [m, n], type_anno2)
 bb = relax.BlockBuilder()
 
 
-@visitor
+@relax.expr_functor.visitor
 class BasicVisitor(PyExprVisitor):
     """Default ExprVisitor"""
 
@@ -66,7 +66,7 @@ class ASTLog:
         return "\n".join(reversed(self.log) if self.reverse else self.log)
 
 
-@visitor
+@relax.expr_functor.visitor
 class ASTPrinter(PyExprVisitor):
     """TODO"""
 
@@ -181,12 +181,12 @@ class ASTPrinter(PyExprVisitor):
         self.log.add("DataflowVarDef")
 
 
-@mutator
+@relax.expr_functor.mutator
 class BasicMutator(PyExprMutator):
     """Default ExprMutator"""
 
 
-@mutator
+@relax.expr_functor.mutator
 class ASTPostPrinterMutator(PyExprMutator):
     """TODO"""
 

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -191,6 +191,7 @@ class ASTPostPrinterMutator(PyExprMutator):
     """TODO"""
 
     def __init__(self) -> None:
+        super().__init__()
         self.log = ASTLog()
 
     def rewrite_constant_post_order(self, op: Constant) -> Expr:

--- a/tests/python/relax/test_pass_manager.py
+++ b/tests/python/relax/test_pass_manager.py
@@ -113,8 +113,7 @@ def test_function_pass():
     # create FunctionPass with the function_pass decorator
     @relax.transform.function_pass(opt_level=opt_level, name=pass_name)
     def decorator_transform(func, mod, ctx):
-        m = SwapMAVar()
-        return m.visit_expr(func)
+        return SwapMAVar().visit_expr(func)
 
     # check the transform info
     assert isinstance(decorator_transform, relax.transform.FunctionPass)
@@ -214,8 +213,7 @@ def test_dataflowblock_pass():
     # create DataflowBlockPass with the dataflowblock_pass decorator
     @relax.transform.dataflowblock_pass(opt_level=opt_level, name=pass_name)
     def decorator_transform(block, mod, ctx):
-        m = SwapMAVar()
-        return m.visit_binding_block(block)
+        return SwapMAVar().visit_binding_block(block)
 
     # check the transform info
     assert isinstance(decorator_transform, relax.transform.DataflowBlockPass)

--- a/tests/python/relax/test_pass_manager.py
+++ b/tests/python/relax/test_pass_manager.py
@@ -70,7 +70,8 @@ class SwapMAVar(relax.PyExprMutator):
     def __init__(self) -> None:
         super().__init__()
 
-    def rewrite_call_post_order(self, call: Call) -> Call:
+    def visit_call_(self, call: Call) -> Call:
+        call = self.visit_expr_post_order(call)
         if call.op == ir.Op.get("relax.add"):
             new_op = ir.Op.get("relax.multiply")
         elif call.op == ir.Op.get("relax.multiply"):

--- a/tests/python/relax/test_pass_manager.py
+++ b/tests/python/relax/test_pass_manager.py
@@ -65,7 +65,7 @@ def test_function_class_pass():
 
 
 # Swap Multiply and Add Ops
-@relax.mutator
+@relax.expr_functor.mutator
 class SwapMAVar(relax.PyExprMutator):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
Add decorators `visitor` and `mutator` to help users create `ExprVisitor` and `ExprMutator` in Python. Users can customize visit/rewrite/post-order-rewrite function in Python.  `PyExprVisitor` and `PyExprMutator` lists the functions users can customize.

Example for `visitor`:
```Python
@relax.expr_functor.visitor
class MyExprVisitor(PyExprVisitor):
    # customize visit function
    def visit_call_(self, op: Call) -> None:
        # just for demo purposes
        ...
# myvisitor is now a special visitor that visit every Call with
# user-customized visit_call_
myvisitor = MyExprVisitor()
# apply myvisitor to Expr/Binding/BindingBlock/VarDef
myvisitor.visit_expr(expr)
myvisitor.visit_binding(binding)
myvisitor.visit_binding_block(bindingblock)
myvisitor.visit_var_def(var)
```
Example for `mutator`:
```Python
@relax.expr_functor.mutator
class MyExprMutator(PyExprMutator):
    # customize rewrite function
    def visit_tuple_(self, op: Tuple) -> Expr:
        # just for demo purposes
        ...

# mymutator is now a special mutator that rewrite every Tuple with
# user-customized visit_tuple_, and rewrite every Var with user-customized
# rewrite_var_post_order in the post order.
mymutator = MyExprMutator()
# apply mymutator to Expr/Binding/BindingBlock/VarDef
mymutator.visit_expr(expr)
mymutator.visit_binding(binding)
mymutator.visit_binding_block(bindingblock)
mymutator.visit_var_def(var)
```

Implementation:
Core part: `@derived_object`, an exquisite mechanism from `meta_schedule`. It's a decorator that allows us to overload C++ Functions on the Python side. Thanks, @junrushao1994 !
User-customized functions would be extracted as `PackedFunc`, and passed to the C++ side. On the C++ side, `PyExprVisitor` or `PyExprMutator` will check if there is overloading. 
The logic of `PyExprVisitor` will be
```C++
if (self->PY_FUNC != nullptr)  
    self->PY_FUNC(n);  // callback to user-customized Python function
else
    self->VisitExpr_(static_cast<const OP*>(n.get()));  // ExprVisitor::VisitExpr_
```
The logic of `PyExprMutator` will be
```C++
if (self->PY_POST_ORDER_FUNC != nullptr) { 
  Expr expr = self->VisitExprPostOrder_(static_cast<const OP*>(n.get()));  // ExprMutator::VisitExprPostOrder_
  expr = self->PY_POST_ORDER_FUNC(expr);  // callback to user-customized Python post-order-rewrite function
  return expr;
} else {
  if (self->PY_FUNC != nullptr) {
    Expr expr = self->PY_FUNC(n);  // callback to user-customized Python visit function
    return expr;
  } else
    return self->VisitExpr_(static_cast<const OP*>(n.get()));  // ExprMutator::VisitExpr_
}      
```

Create an AST Printer with the decorator! It's used in the testcase.

https://github.com/tlc-pack/relax/blob/1f37e67465b3e3b50503db849ea8a0f75c9c7a4d/tests/python/relax/test_expr_functor.py#L69-L72

cc: @YuchenJin @junrushao1994 @tqchen 