### PR TITLE
Fix BlockBuilder Scope Recovery in Misuse

### DIFF
--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -161,13 +161,18 @@ class BlockBuilder(Object):
         self._begin_binding_block()
 
     def _exit_function_scope(self, exc_type, exc_val, exc_tb):
-        if exc_type is None:
-            if not self._is_emit_func_output_called:
-                raise RuntimeError("emit_func_output must be called in a relax function.")
-
+        # record
+        is_emit_func_output_called = self._is_emit_func_output_called
+        # recover to default state
         self._blocks = []
         self._is_emit_func_output_called = False
         BlockBuilder._current = None
+
+        # NOTE: we must raise after we recover the state so future
+        # block builder scoping functions correctly
+        if exc_type is None:
+            if not is_emit_func_output_called:
+                raise RuntimeError("emit_func_output must be called in a relax function.")
 
     def _convert_te_arg(self, te_args: Any) -> typing.Tuple[Any, List[tvm.te.Tensor]]:
         """Helper function to convert Relax expressions to te tensor.

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -588,5 +588,27 @@ def test_no_func_params_fail():
             bb.emit_func_output(gv0)
 
 
+def test_block_builder_scope_recovery():
+    bb = rx.BlockBuilder()
+
+    n, m = tir.Var("n", "int64"), tir.Var("m", "int64")
+    type_anno = rx.DynTensorType(2, "float32")
+    x = rx.Var("x", [n, m], type_anno)
+    y = rx.Var("y", [m, n], type_anno)
+
+    with pytest.raises(RuntimeError):
+        # this line fails
+        with bb.function("func", [x, y]):
+            gv0 = bb.emit(rx.op.add(x, y))
+
+    # current should be recovered
+    assert rx.BlockBuilder.current() is None
+
+    # second attempt to do it correctly.
+    with bb.function("func", [x, y]):
+        gv0 = bb.emit(rx.op.add(x, y))
+        bb.emit_func_output(gv0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This happens in interactive usecases. When function scope
exit triggers an error, we need to recovery the
BlockBuilder.current properly so users can try again.

Added a testcase.