### PR TITLE
[Op][Debugging] Add a print operator

### DIFF
--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -89,9 +89,9 @@ struct UniqueAttrs : public tvm::AttrsNode<UniqueAttrs> {
 };  // struct UniqueAttrs
 
 struct PrintAttrs : public tvm::AttrsNode<PrintAttrs> {
-  std::string format;
+  std::string format_str;
   TVM_DECLARE_ATTRS(PrintAttrs, "relax.attrs.PrintAttrs") {
-    TVM_ATTR_FIELD(format)
+    TVM_ATTR_FIELD(format_str)
         .describe("Python-style format string to use for displaying the input. Ignored if empty.")
         .set_default("");
   }

--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -90,7 +90,7 @@ struct UniqueAttrs : public tvm::AttrsNode<UniqueAttrs> {
 
 struct PrintAttrs : public tvm::AttrsNode<PrintAttrs> {
   std::string format;
-  TVM_DECLARE_ATTRS(UniqueAttrs, "relax.attrs.UniqueAttrs") {
+  TVM_DECLARE_ATTRS(PrintAttrs, "relax.attrs.PrintAttrs") {
     TVM_ATTR_FIELD(format)
         .describe("Python-style format string to use for displaying the input. Ignored if empty.")
         .set_default("");

--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -88,6 +88,15 @@ struct UniqueAttrs : public tvm::AttrsNode<UniqueAttrs> {
   }
 };  // struct UniqueAttrs
 
+struct PrintAttrs : public tvm::AttrsNode<PrintAttrs> {
+  std::string format;
+  TVM_DECLARE_ATTRS(UniqueAttrs, "relax.attrs.UniqueAttrs") {
+    TVM_ATTR_FIELD(format)
+        .describe("Python-style format string to use for displaying the input. Ignored if empty.")
+        .set_default("");
+  }
+};
+
 }  // namespace relax
 }  // namespace tvm
 #endif  // TVM_RELAX_OP_ATTR_TYPES_H_

--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -89,9 +89,9 @@ struct UniqueAttrs : public tvm::AttrsNode<UniqueAttrs> {
 };  // struct UniqueAttrs
 
 struct PrintAttrs : public tvm::AttrsNode<PrintAttrs> {
-  std::string format_str;
+  std::string format;
   TVM_DECLARE_ATTRS(PrintAttrs, "relax.attrs.PrintAttrs") {
-    TVM_ATTR_FIELD(format_str)
+    TVM_ATTR_FIELD(format)
         .describe("Python-style format string to use for displaying the input. Ignored if empty.")
         .set_default("");
   }

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -139,7 +139,7 @@ def relax_print(
     """
     Just prints whatever value is passed to it. Used for Relax's print op.
     """
-    if format == "":
+    if format_str == "":
         print(val)
     else:
         print(format_str.format(val))

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -132,12 +132,17 @@ def invoke_closure(
 
 
 @tvm.register_func("relax.run.print")
-def relax_print(
-    val: tvm.nd.array,
-    format_str : str = ""
-) -> None:
+def relax_print(val: tvm.Object, format_str: str = "") -> None:
     """
-    Just prints whatever value is passed to it. Used for Relax's print op.
+    Prints the value that is passed to it, possibly with a format string.
+
+    Parameters
+    ----------
+    val: tvm.Object
+        A value in TVM
+
+    format_str: str
+        A Python-style format string for printing the value
     """
     if format_str == "":
         print(val)

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -144,6 +144,7 @@ def relax_print(val: tvm.runtime.container, format_str: str = "") -> None:
     format_str: str
         A Python-style format string for printing the value
     """
+
     def render(val: tvm.Object) -> str:
         if isinstance(val, tvm.runtime.ndarray.NDArray):
             return str(val)

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -151,8 +151,8 @@ def relax_print(val: tvm.runtime.container, format_str: str = "") -> None:
         # no pretty-printer by default, so if we don't handle this,
         # then we can't look inside tuples
         if isinstance(val, tvm.runtime.container.ADT):
-            # the fields of an ADT are not directly accessible in Python,
-            # so I'm doing it this way
+            # the fields array of an ADT cannot be directly accessed in Python
+            # so we have to get the length and index into the fields separately
             fields = ", ".join([render(val[i]) for i in range(len(val))])
             # special case: tag = 0 is a tuple
             if val.tag == 0:

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -16,6 +16,7 @@
 """The base Relax operators."""
 from typing import Union, List, Optional
 
+import tvm
 from tvm.runtime.object import Object
 
 from . import _ffi_api
@@ -128,3 +129,17 @@ def invoke_closure(
         args = Tuple(args)
 
     return _ffi_api.invoke_closure(closure, args)
+
+
+@tvm.register_func("relax.run.print")
+def relax_print(
+    val: tvm.nd.array,
+    format_str : str = ""
+) -> None:
+    """
+    Just prints whatever value is passed to it. Used for Relax's print op.
+    """
+    if format == "":
+        print(val)
+    else:
+        print(format_str.format(val))

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -379,6 +379,11 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
       args.push_back(EmitConstantFromValue(unique_attrs->dim));
       return;
     }
+    if (call_node->op == print_op_) {
+      auto print_attrs = call_node->attrs.as<PrintAttrs>();
+      args.push_back(EmitConstantFromValue(print_attrs->format));
+      return;
+    }
     LOG(FATAL) << "Support for attributes of Op " << call_node->op
                << " has not been implemented yet.";
     return;
@@ -510,6 +515,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   const Op& load_shape_op_ = Op::Get("relax.vm.builtin.load_shape");
   const Op& call_tir_dyn_op_ = Op::Get("relax.vm.call_tir_dyn");
   const Op& unique_op_ = Op::Get("relax.unique");
+  const Op& print_op_ = Op::Get("relax.print");
   const Op& make_closure_op_ = Op::Get("relax.make_closure");
   const Op& invoke_closure_op_ = Op::Get("relax.invoke_closure");
 };

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -99,6 +99,23 @@ Expr MakeCallTIR(Expr func, Tuple args, Expr output_shape, Type output_type,
 
 TVM_REGISTER_GLOBAL("relax.op.call_tir").set_body_typed(MakeCallTIR);
 
+// print
+RELAY_REGISTER_OP("relax.print")
+    .set_attrs_type<PrintAttrs>()
+    .set_num_inputs(1)
+    .add_argument("val", "Expr", "The value to print.")
+    .set_attr<FInferType>("FInferType", ReturnVoidType)
+    .set_attr<FCallPacked>("FCallPacked", "relax.run.print");
+
+Expr MakePrint(Expr val, std::string format) {
+  auto attrs = make_object<PrintAttrs>();
+  attrs->format = format;
+  static const Op& op = Op::Get("relax.print");
+  return Call(op, {val}, Attrs(attrs));
+}
+
+TVM_REGISTER_GLOBAL("relax.op.print").set_body_typed(MakePrint);
+
 // make_closure
 
 RELAY_REGISTER_OP("relax.make_closure")

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -104,16 +104,16 @@ TVM_REGISTER_NODE_TYPE(PrintAttrs);
 
 RELAY_REGISTER_OP("relax.print")
     .set_attrs_type<PrintAttrs>()
-    .set_num_inputs(1)
-    .add_argument("val", "Expr", "The value to print.")
+    .set_num_inputs(-1)
+    .add_argument("vals", "Array<Expr>", "Values to print.")
     .set_attr<FInferType>("FInferType", ReturnVoidType)
     .set_attr<FCallPacked>("FCallPacked", "relax.run.print");
 
-Expr MakePrint(Expr val, std::string format) {
+Expr MakePrint(Array<Expr> vals, std::string format_str) {
   auto attrs = make_object<PrintAttrs>();
-  attrs->format = format;
+  attrs->format = format_str;
   static const Op& op = Op::Get("relax.print");
-  return Call(op, {val}, Attrs(attrs));
+  return Call(op, vals, Attrs(attrs));
 }
 
 TVM_REGISTER_GLOBAL("relax.op.print").set_body_typed(MakePrint);

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -100,6 +100,8 @@ Expr MakeCallTIR(Expr func, Tuple args, Expr output_shape, Type output_type,
 TVM_REGISTER_GLOBAL("relax.op.call_tir").set_body_typed(MakeCallTIR);
 
 // print
+TVM_REGISTER_NODE_TYPE(PrintAttrs);
+
 RELAY_REGISTER_OP("relax.print")
     .set_attrs_type<PrintAttrs>()
     .set_num_inputs(1)

--- a/tests/python/relax/test_relax_operators.py
+++ b/tests/python/relax/test_relax_operators.py
@@ -68,6 +68,9 @@ class PrintTest:
         p2 = relax.print(x, format="Number: {}")
         t = (x, x)
         p3 = relax.print(t, format="Tuple: {}")
+        p4 = relax.print(x, t)
+        p5 = relax.print(x, x, format="Custom print: {} {}")
+        p6 = relax.print(x, t, format="Another print: {} {}")
         return x
 
 
@@ -79,7 +82,8 @@ def test_print():
             run_cpu(PrintTest, "foo", tvm.nd.array(1))
             test_out.seek(0)
             printed_text = str(test_out.read())
-            assert printed_text == "1\nNumber: 1\nTuple: (1, 1)\n"
+            expected = "1\nNumber: 1\nTuple: (1, 1)\n1 (1, 1)\nCustom print: 1 1\nAnother print: 1 (1, 1)\n"
+            assert printed_text == expected
     finally:
         sys.stdout = stdout
 

--- a/tests/python/relax/test_relax_operators.py
+++ b/tests/python/relax/test_relax_operators.py
@@ -66,6 +66,8 @@ class PrintTest:
         #       it would be easy syntactic sugar to add.
         p1 = relax.print(x)
         p2 = relax.print(x, format="Number: {}")
+        t = (x, x)
+        p3 = relax.print(t, format="Tuple: {}")
         return x
 
 
@@ -74,10 +76,10 @@ def test_print():
         stdout = sys.stdout
         with tempfile.TemporaryFile(mode="w+") as test_out:
             sys.stdout = test_out
-            run_cpu(PrintTest, "foo", 1)
+            run_cpu(PrintTest, "foo", tvm.nd.array(1))
             test_out.seek(0)
             printed_text = str(test_out.read())
-            assert printed_text == "1\nNumber: 1\n"
+            assert printed_text == "1\nNumber: 1\nTuple: (1, 1)\n"
     finally:
         sys.stdout = stdout
 

--- a/tests/python/relax/test_relax_operators.py
+++ b/tests/python/relax/test_relax_operators.py
@@ -36,17 +36,19 @@ class InputModule:
         return y, y_sorted
 
 
-def test_unique():
-
-    mod = InputModule
-    # TODO(prakalp): also add test for compiling and running on cuda device.
+def run_cpu(mod, func_name, *input):
     target = tvm.target.Target("llvm")
     ex = relax.vm.build(mod, target)
     vm = relax.VirtualMachine(ex, tvm.cpu())
+    return vm[func_name](*input)
 
+
+def test_unique():
+
+    # TODO(prakalp): also add test for compiling and running on cuda device.
     data_numpy = np.random.randint(0, 16, (16, 16))
     data = tvm.nd.array(data_numpy)
-    result, result_sorted = vm["foo"](data)
+    result, result_sorted = run_cpu(InputModule, "foo", data)
 
     expected_output_sorted, indices = np.unique(data_numpy, return_index=True)
     expected_output = [data_numpy.flatten()[index] for index in sorted(indices, reverse=True)]
@@ -60,7 +62,10 @@ class PrintTest:
     @R.function
     def foo(x: Tensor((), "int32")):
         # results have to be bound, but we don't use them
-        _ = relax.print(x)
+        # TODO: We should allow calls whose results are not bound for side effects;
+        #       it would be easy syntactic sugar to add.
+        p1 = relax.print(x)
+        p2 = relax.print(x, format="Number: {}")
         return x
 
 
@@ -69,15 +74,10 @@ def test_print():
         stdout = sys.stdout
         with tempfile.TemporaryFile(mode="w+") as test_out:
             sys.stdout = test_out
-            mod = PrintTest
-            target = tvm.target.Target("llvm")
-            ex = relax.vm.build(mod, target)
-            vm = relax.VirtualMachine(ex, tvm.cpu())
-
-            vm["foo"](1)
+            run_cpu(PrintTest, "foo", 1)
             test_out.seek(0)
             printed_text = str(test_out.read())
-            assert printed_text == "1\n"
+            assert printed_text == "1\nNumber: 1\n"
     finally:
         sys.stdout = stdout
 

--- a/tests/python/relax/test_relax_operators.py
+++ b/tests/python/relax/test_relax_operators.py
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import annotations
-import sys  # must import to defer parsing of annotations
+from __future__ import annotations  # must import to defer parsing of annotations
+import sys
 import tempfile
 import pytest
 import tvm


### PR DESCRIPTION
As discussed in issue #191, having a `print` operator can be useful for debugging and demonstrating the semantics of the language. This PR uses the op registration mechanism to add a simple `print` operator that just calls a `PackedFunc` defined in Python. I would appreciate review and discussion of its properties, as it may be broadly useful but potentially frustrating if it doesn't live up to users' expectations.
