### PR TITLE
[VM][UX] Implement stateful API

### DIFF
--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -197,6 +197,14 @@ class VirtualMachine : public runtime::ModuleNode {
    */
   VMFunction LookupVMFunction(const std::string& func_name);
 
+  /*!
+   * \brief Look up whether the VM has outputs for the given function.
+   * \param func_name the function's name
+   * \return The output, if it exists. Logs a fatal error if not.
+   */
+  RegType LookupVMOutput(const std::string& func_name);
+
+
  private:
   /*! \brief The loaded executable. */
   ObjectPtr<Executable> exec_;
@@ -221,6 +229,8 @@ class VirtualMachine : public runtime::ModuleNode {
   std::vector<TVMRetValue> constants;
   /*! \brief The function name to input register mapping. */
   std::unordered_map<std::string, std::vector<RegType>> inputs_;
+  /*! \brief The function name to output register. */
+  std::unordered_map<std::string, RegType> outputs_;
 };
 
 }  // namespace relax_vm

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -204,7 +204,6 @@ class VirtualMachine : public runtime::ModuleNode {
    */
   RegType LookupVMOutput(const std::string& func_name);
 
-
  private:
   /*! \brief The loaded executable. */
   ObjectPtr<Executable> exec_;

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -198,6 +198,9 @@ class VirtualMachine(object):
         the arguments to DLTensor, which is supported in RPC where remote could only
         have a minimal C runtime.
 
+        Note: If `set_input` is used, the function *must* be called using `invoke_stateful`
+        and the results must be obtained using `get_outputs`.
+
         Parameters
         ----------
         func_name : str
@@ -241,7 +244,7 @@ class VirtualMachine(object):
         (even if it's to set 0 inputs); conversely, if `set_input` has been called,
         it is an error to call the function without using `invoke_stateful`.
 
-        The results of the call can be obtained by calling `get_output`.
+        The results of the call can be obtained by calling `get_outputs`.
 
         Parameters
         ----------

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -237,7 +237,7 @@ class VirtualMachine(object):
 
         self._set_input(func_name, *cargs)
 
-    def invoke_stateful(self, func_name: str = "main") -> None:
+    def invoke_stateful(self, func_name: str) -> None:
         """
         Call the named function from the VM module using the arguments set using `set_input`.
         It is an error to call `invoke_stateful` without using `set_input` first
@@ -249,11 +249,11 @@ class VirtualMachine(object):
         Parameters
         ----------
         func_name: str
-            The name of the function to call. "main" by default
+            The name of the function to call.
         """
         self._invoke_stateful(func_name)
 
-    def get_outputs(self, func_name: str = "main") -> Union[tvm.Object, Tuple[Any]]:
+    def get_outputs(self, func_name: str) -> Union[tvm.Object, Tuple[Any]]:
         """
         Get the value output by the function by the given name
         after a call of `invoke_stateful`.
@@ -263,7 +263,7 @@ class VirtualMachine(object):
         Parameters
         ----------
         func_name: str
-            The name of the function whose output should be fetched. "main" by default.
+            The name of the function whose output should be fetched.
 
         Returns
         -------

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -55,7 +55,6 @@ RegType VirtualMachine::LookupVMOutput(const std::string& func_name) {
   if (!outputs_.count(func_name)) {
     LOG(FATAL) << "ValueError: No output saved for call of \"" << func_name
                << "\"; use `invoke_stateful` to call it first.";
-    return {};
   }
   return outputs_[func_name];
 }

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -191,8 +191,8 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
     Index gf_idx = m.at(name);
     return PackedFunc([sptr_to_self, this, gf_idx, name](TVMArgs args, TVMRetValue* rv) {
       if (inputs_.count(name)) {
-        LOG(FATAL) << "Error: If inputs have been set, `invoke_stateful` must be used to invoke a "
-                      "function!";
+        LOG(FATAL) << "ValueError: If inputs have been set, `invoke_stateful`"
+                   << " must be used to invoke a function!";
         return;
       } else {
         std::vector<RegType> inputs(args.size());

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -160,6 +160,7 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
       auto adt = out.AsObjectRef<ADT>();
       if (index >= static_cast<int>(adt.size())) {
         LOG(FATAL) << "ValueError: Index out of range (" << index << " >= " << adt.size() << ").";
+        return;
       }
       *rv = adt[index];
     });

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -53,8 +53,8 @@ VMFunction VirtualMachine::LookupVMFunction(const std::string& func_name) {
 
 RegType VirtualMachine::LookupVMOutput(const std::string& func_name) {
   if (!outputs_.count(func_name)) {
-    LOG(FATAL) << "ValueError: No output saved for call of " << func_name
-               << "; use `invoke_stateful` to call it first.";
+    LOG(FATAL) << "ValueError: No output saved for call of \"" << func_name
+               << "\"; use `invoke_stateful` to call it first.";
     return {};
   }
   return outputs_[func_name];

--- a/tests/python/contrib/test_hexagon/test_relax_integration.py
+++ b/tests/python/contrib/test_hexagon/test_relax_integration.py
@@ -59,7 +59,8 @@ def test_conv2d(hexagon_session: Session):
     data = tvm.nd.array(data_np, dev)
     weight = tvm.nd.array(weight_np, dev)
     vm_rt.set_input("main", data, weight)
-    hexagon_res = vm_rt["main"]()
+    vm_rt.invoke_stateful()
+    hexagon_res = vm_rt.get_outputs()
 
     # Compile and run on Relay for comparison.
     dev = tvm.cpu()
@@ -106,7 +107,8 @@ def test_conv2d_dyn(hexagon_session: Session):
     data = tvm.nd.array(data_np, hexgaon_device)
     weight = tvm.nd.array(weight_np, hexgaon_device)
     vm_rt.set_input("main", data, weight)
-    hexagon_res = vm_rt["main"]()
+    vm_rt.invoke_stateful()
+    hexagon_res = vm_rt.get_outputs()
 
     # Compile and run on Relay for comparison.
     cpu_device = tvm.cpu()
@@ -138,7 +140,8 @@ def test_mlp(hexagon_session: Session):
     data_np = np.random.rand(*shape).astype("float32")
     data = tvm.nd.array(data_np, hexagon_device)
     vm_rt.set_input("main", data)
-    hexagon_res = vm_rt["main"]()
+    vm_rt.invoke_stateful()
+    hexagon_res = vm_rt.get_outputs()
 
     # Compile and run on Relay for comparison.
     cpu_dev = tvm.cpu()
@@ -171,7 +174,8 @@ def test_mlp_dyn(hexagon_session: Session):
     vm_rt = relax.VirtualMachine(vm_mod, dev)
     data = tvm.nd.array(data_np, dev)
     vm_rt.set_input("main", data)
-    hexagon_res = vm_rt["main"]()
+    vm_rt.invoke_stateful()
+    hexagon_res = vm_rt.get_outputs()
 
     # Compile and run on Relay for comparison.
     dev = tvm.cpu()
@@ -217,7 +221,8 @@ def test_mobilenet_onnx(hexagon_session: Session):
     vm_rt = relax.VirtualMachine(vm_mod, dev)
     data = tvm.nd.array(data_np, dev)
     vm_rt.set_input("main", data)
-    hexagon_res = vm_rt["main"]()
+    vm_rt.invoke_stateful()
+    hexagon_res = vm_rt.get_outputs()
 
     # Compile and run on LLVM for comparison.
     relax_mod = relay_translator.from_relay(relay_mod["main"], "llvm")
@@ -249,7 +254,8 @@ def test_mobilenet(hexagon_session: Session):
     vm_rt = relax.VirtualMachine(vm_mod, dev)
     data = tvm.nd.array(data_np, dev)
     vm_rt.set_input("main", data)
-    hexagon_res = vm_rt["main"]()
+    vm_rt.invoke_stateful()
+    hexagon_res = vm_rt.get_outputs()
 
     # Compile and run on LLVM for comparison.
     relax_mod = relay_translator.from_relay(relay_mod["main"], "llvm", params)
@@ -281,7 +287,8 @@ def test_mobilenet_dyn(hexagon_session: Session):
     vm_rt = relax.VirtualMachine(vm_mod, dev)
     data = tvm.nd.array(data_np, dev)
     vm_rt.set_input("main", data)
-    hexagon_res = vm_rt["main"]()
+    vm_rt.invoke_stateful()
+    hexagon_res = vm_rt.get_outputs()
 
     # Compile and run on Relay for comparison.
     dev = tvm.cpu()

--- a/tests/python/contrib/test_hexagon/test_relax_integration.py
+++ b/tests/python/contrib/test_hexagon/test_relax_integration.py
@@ -59,8 +59,8 @@ def test_conv2d(hexagon_session: Session):
     data = tvm.nd.array(data_np, dev)
     weight = tvm.nd.array(weight_np, dev)
     vm_rt.set_input("main", data, weight)
-    vm_rt.invoke_stateful()
-    hexagon_res = vm_rt.get_outputs()
+    vm_rt.invoke_stateful("main")
+    hexagon_res = vm_rt.get_outputs("main")
 
     # Compile and run on Relay for comparison.
     dev = tvm.cpu()
@@ -107,8 +107,8 @@ def test_conv2d_dyn(hexagon_session: Session):
     data = tvm.nd.array(data_np, hexgaon_device)
     weight = tvm.nd.array(weight_np, hexgaon_device)
     vm_rt.set_input("main", data, weight)
-    vm_rt.invoke_stateful()
-    hexagon_res = vm_rt.get_outputs()
+    vm_rt.invoke_stateful("main")
+    hexagon_res = vm_rt.get_outputs("main")
 
     # Compile and run on Relay for comparison.
     cpu_device = tvm.cpu()
@@ -140,8 +140,8 @@ def test_mlp(hexagon_session: Session):
     data_np = np.random.rand(*shape).astype("float32")
     data = tvm.nd.array(data_np, hexagon_device)
     vm_rt.set_input("main", data)
-    vm_rt.invoke_stateful()
-    hexagon_res = vm_rt.get_outputs()
+    vm_rt.invoke_stateful("main")
+    hexagon_res = vm_rt.get_outputs("main")
 
     # Compile and run on Relay for comparison.
     cpu_dev = tvm.cpu()
@@ -174,8 +174,8 @@ def test_mlp_dyn(hexagon_session: Session):
     vm_rt = relax.VirtualMachine(vm_mod, dev)
     data = tvm.nd.array(data_np, dev)
     vm_rt.set_input("main", data)
-    vm_rt.invoke_stateful()
-    hexagon_res = vm_rt.get_outputs()
+    vm_rt.invoke_stateful("main")
+    hexagon_res = vm_rt.get_outputs("main")
 
     # Compile and run on Relay for comparison.
     dev = tvm.cpu()
@@ -221,8 +221,8 @@ def test_mobilenet_onnx(hexagon_session: Session):
     vm_rt = relax.VirtualMachine(vm_mod, dev)
     data = tvm.nd.array(data_np, dev)
     vm_rt.set_input("main", data)
-    vm_rt.invoke_stateful()
-    hexagon_res = vm_rt.get_outputs()
+    vm_rt.invoke_stateful("main")
+    hexagon_res = vm_rt.get_outputs("main")
 
     # Compile and run on LLVM for comparison.
     relax_mod = relay_translator.from_relay(relay_mod["main"], "llvm")
@@ -254,8 +254,8 @@ def test_mobilenet(hexagon_session: Session):
     vm_rt = relax.VirtualMachine(vm_mod, dev)
     data = tvm.nd.array(data_np, dev)
     vm_rt.set_input("main", data)
-    vm_rt.invoke_stateful()
-    hexagon_res = vm_rt.get_outputs()
+    vm_rt.invoke_stateful("main")
+    hexagon_res = vm_rt.get_outputs("main")
 
     # Compile and run on LLVM for comparison.
     relax_mod = relay_translator.from_relay(relay_mod["main"], "llvm", params)
@@ -287,8 +287,8 @@ def test_mobilenet_dyn(hexagon_session: Session):
     vm_rt = relax.VirtualMachine(vm_mod, dev)
     data = tvm.nd.array(data_np, dev)
     vm_rt.set_input("main", data)
-    vm_rt.invoke_stateful()
-    hexagon_res = vm_rt.get_outputs()
+    vm_rt.invoke_stateful("main")
+    hexagon_res = vm_rt.get_outputs("main")
 
     # Compile and run on Relay for comparison.
     dev = tvm.cpu()

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -990,8 +990,7 @@ def set_input_attempt_stateless(vm: relax.VirtualMachine, device: tvm.runtime.De
 
 def set_input_attempt_invoke(vm: relax.VirtualMachine, device: tvm.runtime.Device) -> None:
     # this should fail: if the function needs inputs, you can't invoke directly
-    # note: argument defaults to main
-    vm.invoke_stateful()
+    vm.invoke_stateful("main")
 
 
 def set_input_attempt_get(vm: relax.VirtualMachine, device: tvm.runtime.Device) -> None:
@@ -999,7 +998,7 @@ def set_input_attempt_get(vm: relax.VirtualMachine, device: tvm.runtime.Device) 
     a = tvm.nd.array(np.random.rand(32, 32).astype("float32"), device)
     b = tvm.nd.array(np.random.rand(32, 32).astype("float32"), device)
     vm.set_input("main", a, b)
-    _ = vm.get_outputs()
+    _ = vm.get_outputs("main")
 
 
 def make_vm(mod) -> Tuple[relax.VirtualMachine, tvm.runtime.Device]:

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -974,7 +974,6 @@ def set_input_trial(vm: relax.VirtualMachine, device: tvm.runtime.Device) -> Non
     vm.set_input("test_vm_nested_tuple", b)
     vm.invoke_stateful("test_vm_nested_tuple")
     res3 = vm.get_outputs("test_vm_nested_tuple")
-    print(res3)
     assert len(res3) == 2 and len(res3[0]) == 2 and len(res3[0][1]) == 1
     result_cast = ((int(res3[0][0].numpy()), (int(res3[0][1][0].numpy()),)), int(res3[1].numpy()))
     assert result_cast == ((1, (1,)), 1)

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -952,7 +952,10 @@ def perform_set_input_trial(vm: relax.VirtualMachine, device: tvm.runtime.Device
     tvm.testing.assert_allclose(res0.numpy(), a.numpy() * b.numpy(), rtol=1e-7, atol=1e-7)
     tvm.testing.assert_allclose(res0.numpy(), res1.numpy(), rtol=1e-7, atol=1e-7)
 
-    vm.set_input("test_vm_tuple", tvm.nd.array(2, device))
+    # bug! If you don't bind the NDArray to a var, the memory will get corrupted.
+    # Possibly due to object lifecycles and other FFI issues
+    a = tvm.nd.array(2, device)
+    vm.set_input("test_vm_tuple", a)
     vm.invoke_stateful("test_vm_tuple")
     res2 = vm.get_outputs("test_vm_tuple")
     # the results are NDArrays wrapped around scalars, 


### PR DESCRIPTION
This PR implements the stateful API discussed in https://github.com/tlc-pack/relax/issues/179. It ensures that if you use `set_input` to set inputs, you must use `invoke_stateful` to run the function (otherwise failing) and must obtain the results using `get_output`. It handles nested tuple returns (I am pleased to say it simply works).