### PR TITLE
[VM][UX] Allow for saving closures to avoid extra dictionary lookups in timing trials

### DIFF
--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -230,7 +230,7 @@ class VirtualMachine : public runtime::ModuleNode {
   std::unordered_map<std::string, std::vector<RegType>> inputs_;
   /*! \brief The function name to output register. */
   std::unordered_map<std::string, RegType> outputs_;
-  /*! \brief A store of closures created by `package_function`. */
+  /*! \brief A store of closures created by `save_function`. */
   std::unordered_map<std::string, PackedFunc> saved_closures_;
 };
 

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -230,6 +230,8 @@ class VirtualMachine : public runtime::ModuleNode {
   std::unordered_map<std::string, std::vector<RegType>> inputs_;
   /*! \brief The function name to output register. */
   std::unordered_map<std::string, RegType> outputs_;
+  /*! \brief A store of closures created by `package_function`. */
+  std::unordered_map<std::string, PackedFunc> saved_closures_;
 };
 
 }  // namespace relax_vm

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -402,7 +402,8 @@ class VirtualMachine(object):
             vm.set_input("func_name", arg0, arg1, ..., argn)
             timing_res = vm.time_evaluator("invoke_stateful", tvm.cpu())("func_name")
 
-        With saved closures via `package_function` (this results in fewer dictionary lookups in the timed portion):
+        With saved closures via `package_function` (this results in 
+        fewer dictionary lookups in the timed portion):
 
         .. code-block:: python
 

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -161,7 +161,9 @@ class VirtualMachine(object):
         """
         return self._invoke_closure(closure, *args)
 
-    def package_function(self, func_name: str, save_name: str, *args: List[Any]) -> PackedFunc:
+    def package_function(
+        self, func_name: str, save_name: str, *args: List[Any], include_return: bool = True
+    ) -> None:
         """
         Convenience function. Takes a function from the module and saves
         a `PackedFunc` that, when called, will invoke the function with the given arguments.
@@ -184,13 +186,18 @@ class VirtualMachine(object):
         save_name : str
             The name that the resulting closure should be saved under.
 
+        include_return : bool
+            Whether the saved PackedFunc should return its output.
+            If timing over RFC, it may not be desirable to send output
+            between machines.
+
         args : List[Any]
             The arguments to package up with the function.
         """
         cargs = []
         for arg in args:
             self._convert(arg, cargs)
-        self._package_function(func_name, save_name, *cargs)
+        self._package_function(func_name, save_name, int(include_return), *cargs)
 
     def _convert(self, arg: Any, cargs: List) -> None:
         """helper function to convert arguments to vm function."""

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -402,7 +402,7 @@ class VirtualMachine(object):
             vm.set_input("func_name", arg0, arg1, ..., argn)
             timing_res = vm.time_evaluator("invoke_stateful", tvm.cpu())("func_name")
 
-        With saved closures via `package_function` (this results in 
+        With saved closures via `package_function` (this results in
         fewer dictionary lookups in the timed portion):
 
         .. code-block:: python

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -188,7 +188,7 @@ class VirtualMachine(object):
 
         include_return : bool
             Whether the saved PackedFunc should return its output.
-            If timing over RFC, it may not be desirable to send output
+            If timing over RPC, it may not be desirable to send output
             between machines.
 
         args : List[Any]
@@ -383,7 +383,7 @@ class VirtualMachine(object):
 
         Example
         -------
-        Normal use with a VM function (may not work over RFC if the function returns a tuple):
+        Normal use with a VM function (may not work over RPC if the function returns a tuple):
 
         .. code-block:: python
 

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -391,12 +391,12 @@ class VirtualMachine(object):
         return self.module.time_evaluator(
             func_name,
             dev,
-            number=10,
-            repeat=1,
-            min_repeat_ms=0,
-            cooldown_interval_ms=0,
-            repeats_to_cooldown=1,
-            f_preproc="",
+            number=number,
+            repeat=repeat,
+            min_repeat_ms=min_repeat_ms,
+            cooldown_interval_ms=cooldown_interval_ms,
+            repeats_to_cooldown=repeats_to_cooldown,
+            f_preproc=f_preproc,
         )
 
 

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -90,7 +90,7 @@ class VirtualMachine(object):
             else exec["vm_load_executable"]()
         )
         self._invoke_closure = self.module["invoke_closure"]
-        self._package_function = self.module["package_function"]
+        self._save_function = self.module["save_function"]
         self._set_input = self.module["set_input"]
         self._invoke_stateful = self.module["invoke_stateful"]
         self._get_output = self.module["get_output"]
@@ -161,7 +161,7 @@ class VirtualMachine(object):
         """
         return self._invoke_closure(closure, *args)
 
-    def package_function(
+    def save_function(
         self, func_name: str, saved_name: str, *args: List[Any], include_return: bool = True
     ) -> None:
         """
@@ -197,7 +197,7 @@ class VirtualMachine(object):
         cargs = []
         for arg in args:
             self._convert(arg, cargs)
-        self._package_function(func_name, saved_name, int(include_return), *cargs)
+        self._save_function(func_name, saved_name, int(include_return), *cargs)
 
     def _convert(self, arg: Any, cargs: List) -> None:
         """helper function to convert arguments to vm function."""
@@ -336,7 +336,7 @@ class VirtualMachine(object):
         """
         Returns an evaluator that times a function in the module.
         This follows the same convention as time_evaluator in tvm.runtime.module.
-        This can be used in combination with package_function() so that the
+        This can be used in combination with save_function() so that the
         timings avoid extra dictionary lookups.
 
         Parameters
@@ -402,7 +402,7 @@ class VirtualMachine(object):
             vm.set_input("func_name", arg0, arg1, ..., argn)
             timing_res = vm.time_evaluator("invoke_stateful", tvm.cpu())("func_name")
 
-        With saved closures via `package_function` (this results in
+        With saved closures via `save_function` (this results in
         fewer dictionary lookups in the timed portion):
 
         .. code-block:: python
@@ -410,7 +410,7 @@ class VirtualMachine(object):
             target = tvm.target.Target("llvm", host="llvm")
             ex = relax.vm.build(TestTimeEvaluator, target)
             vm = relax.VirtualMachine(mod, tvm.cpu())
-            vm.package_function("func_name", "func_name_saved", arg0, arg1, ..., argn)
+            vm.save_function("func_name", "func_name_saved", arg0, arg1, ..., argn)
             timing_res = vm.time_evaluator("func_name_saved", tvm.cpu())()
 
         Returns

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -162,12 +162,12 @@ class VirtualMachine(object):
         return self._invoke_closure(closure, *args)
 
     def package_function(
-        self, func_name: str, save_name: str, *args: List[Any], include_return: bool = True
+        self, func_name: str, saved_name: str, *args: List[Any], include_return: bool = True
     ) -> None:
         """
         Convenience function. Takes a function from the module and saves
         a `PackedFunc` that, when called, will invoke the function with the given arguments.
-        The `PackedFunc` can be accessed from the module using `save_name`.
+        The `PackedFunc` can be accessed from the module using `saved_name`.
         This is included to facilitate timing trials:
         Invoking the returned `PackedFunc` will have less overhead from dictionary lookups
         than normally running through the VM.
@@ -183,7 +183,7 @@ class VirtualMachine(object):
         func_name : str
             The function that should be packaged up.
 
-        save_name : str
+        saved_name : str
             The name that the resulting closure should be saved under.
 
         include_return : bool
@@ -197,7 +197,7 @@ class VirtualMachine(object):
         cargs = []
         for arg in args:
             self._convert(arg, cargs)
-        self._package_function(func_name, save_name, int(include_return), *cargs)
+        self._package_function(func_name, saved_name, int(include_return), *cargs)
 
     def _convert(self, arg: Any, cargs: List) -> None:
         """helper function to convert arguments to vm function."""

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -381,6 +381,37 @@ class VirtualMachine(object):
         The function will be invoked  (1 + number x repeat) times,
         with the first call discarded in case there is lazy initialization.
 
+        Example
+        -------
+        Normal use with a VM function (may not work over RFC if the function returns a tuple):
+
+        .. code-block:: python
+
+            target = tvm.target.Target("llvm", host="llvm")
+            ex = relax.vm.build(TestTimeEvaluator, target)
+            vm = relax.VirtualMachine(mod, tvm.cpu())
+            timing_res = vm.time_evaluator("func_name", tvm.cpu())(arg0, arg1, ..., argn)
+
+        Use with the stateful API:
+
+        .. code-block:: python
+
+            target = tvm.target.Target("llvm", host="llvm")
+            ex = relax.vm.build(TestTimeEvaluator, target)
+            vm = relax.VirtualMachine(mod, tvm.cpu())
+            vm.set_input("func_name", arg0, arg1, ..., argn)
+            timing_res = vm.time_evaluator("invoke_stateful", tvm.cpu())("func_name")
+
+        With saved closures via `package_function` (this results in fewer dictionary lookups in the timed portion):
+
+        .. code-block:: python
+
+            target = tvm.target.Target("llvm", host="llvm")
+            ex = relax.vm.build(TestTimeEvaluator, target)
+            vm = relax.VirtualMachine(mod, tvm.cpu())
+            vm.package_function("func_name", "func_name_saved", arg0, arg1, ..., argn)
+            timing_res = vm.time_evaluator("func_name_saved", tvm.cpu())()
+
         Returns
         -------
         ftimer : function

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -110,6 +110,30 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
         }
       }
     });
+  } else if (name == "package_function") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      std::string func_name = args[0];
+      std::string closure_name = args[1];
+      const auto& m = exec_->global_map;
+      if (m.find(func_name) == m.end()) {
+        LOG(FATAL) << "ValueError: Unknown function: " << func_name;
+      }
+      if (m.find(closure_name) != m.end()) {
+        LOG(FATAL) << "ValueError: Name " << closure_name << " is already taken.";
+      }
+      Index gf_idx = m.at(func_name);
+      std::vector<RegType> inputs;
+      if (args.size() > 2) {
+        inputs = std::vector<RegType>(args.size() - 2);
+        for (int i = 2; i < args.size(); i++) {
+          inputs[i - 2] = args[i];
+        }
+      }
+      auto closure = PackedFunc([this, gf_idx, inputs](TVMArgs args, TVMRetValue* rv) {
+        *rv = this->Invoke(gf_idx, inputs);
+      });
+      saved_closures_[closure_name] = closure;
+    });
   } else if (name == "invoke_closure") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       ICHECK(exec_) << "The executable is not created yet.";
@@ -196,6 +220,11 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
       }
       *rv = vm_func.param_names[index];
     });
+  }
+
+  // check if this is a function we saved
+  if (saved_closures_.count(name)) {
+    return saved_closures_[name];
   }
 
   const auto& m = exec_->global_map;

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -110,7 +110,7 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
         }
       }
     });
-  } else if (name == "package_function") {
+  } else if (name == "save_function") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       std::string func_name = args[0];
       std::string closure_name = args[1];

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations  # must import to defer parsing of annotations
 import os
-from typing import Callable, Tuple
+from typing import Any, Callable, List, Tuple
 
 import numpy as np
 import pytest
@@ -69,6 +69,18 @@ def tile_packed(a, b):
     b[:] = tvm.nd.array(np.tile(a.numpy(), (1, 2)))
 
 
+def check_saved_func(vm: relax.VirtualMachine, func_name: str, *inputs: List[Any]) -> Object:
+    # uses package_function to create a closure with the given inputs
+    # and ensure the result is the same
+    # (assumes the functions return tensors and that they're idempotent)
+    saved_name = f"{func_name}_saved"
+    vm.package_function(func_name, saved_name, *inputs)
+    res1 = vm[func_name](*inputs)
+    res2 = vm[saved_name]()
+    tvm.testing.assert_allclose(res1.numpy(), res2.numpy(), rtol=1e-7, atol=1e-7)
+    return res1
+
+
 def test_vm_execute():
     ib = relax.ExecBuilder()
     with ib.function("func0", num_inputs=2):
@@ -86,7 +98,7 @@ def test_vm_execute():
             4,
         )
     )
-    add_res = vm["func0"](a, b)
+    add_res = check_saved_func(vm, "func0", a, b)
     tvm.testing.assert_allclose(add_res.numpy(), a.numpy() + b.numpy(), rtol=1e-7, atol=1e-7)
 
 
@@ -110,8 +122,8 @@ def test_vm_multiple_func():
             4,
         )
     )
-    mul_res = vm["func1"](a, b)
-    add_res = vm["func0"](a, b)
+    mul_res = check_saved_func(vm, "func1", a, b)
+    add_res = check_saved_func(vm, "func0", a, b)
     tvm.testing.assert_allclose(add_res.numpy(), a.numpy() + b.numpy(), rtol=1e-7, atol=1e-7)
     tvm.testing.assert_allclose(mul_res.numpy(), a.numpy() * b.numpy(), rtol=1e-7, atol=1e-7)
 
@@ -239,7 +251,7 @@ def test_vm_copy():
     ex = relax.vm.build(mod, target)
     inp = tvm.nd.array(np.random.rand(3, 4).astype(np.float32))
     vm = relax.VirtualMachine(ex, tvm.cpu())
-    res = vm["foo"](inp)
+    res = check_saved_func(vm, "foo", inp)
     tvm.testing.assert_allclose(res.numpy(), inp.numpy(), rtol=1e-7, atol=1e-7)
 
 
@@ -262,7 +274,7 @@ def test_vm_goto():
             4,
         )
     )
-    res = vm["main"](a, b)
+    res = check_saved_func(vm, "main", a, b)
     tvm.testing.assert_allclose(res.numpy(), a.numpy() + b.numpy(), rtol=1e-7, atol=1e-7)
 
 
@@ -436,7 +448,7 @@ def test_vm_compile_e2e():
 
     shape = (32, 16)
     inp = tvm.nd.array(np.random.rand(*shape).astype(np.float32))
-    res = vm["foo"](inp)
+    res = check_saved_func(vm, "foo", inp)
     tvm.testing.assert_allclose(res.numpy(), np.tile(inp.numpy(), (1, 2)), rtol=1e-7, atol=1e-7)
 
 
@@ -473,7 +485,7 @@ def test_vm_compile_e2e_func_param_with_shape():
 
     data = tvm.nd.array(np.random.rand(32, 16).astype(np.float32))
     weight = tvm.nd.array(np.random.rand(16, 32).astype(np.float32))
-    res = vm["func"](data, weight)
+    res = check_saved_func(vm, "func", data, weight)
     expected = np.dot(data.numpy(), weight.numpy())
     tvm.testing.assert_allclose(res.numpy(), expected, rtol=1e-6, atol=1e-6)
 
@@ -500,7 +512,7 @@ def test_vm_emit_te_extern():
 
     data = tvm.nd.array(np.random.rand(16, 32).astype(np.float32))
     weight = tvm.nd.array(np.random.rand(32, 16).astype(np.float32))
-    res = vm["rx_cblas_matmul"](data, weight)
+    res = check_saved_func(vm, "rx_cblas_matmul", data, weight)
     expected = np.dot(data.numpy(), weight.numpy())
     tvm.testing.assert_allclose(res.numpy(), expected, rtol=1e-6, atol=1e-6)
 
@@ -537,7 +549,7 @@ def test_vm_emit_te_concat():
             2,
         ).astype(np.float32)
     )
-    res = vm["rx_func"](inp, inp2)
+    res = check_saved_func(vm, "rx_func", inp, inp2)
     tvm.testing.assert_allclose(
         res.numpy(), np.append(inp.numpy(), inp2.numpy()), rtol=1e-7, atol=1e-7
     )
@@ -572,7 +584,7 @@ def test_vm_emit_te_dtype_change():
             1,
         ).astype(np.float32)
     )
-    res = vm["rx_func"](inp)
+    res = check_saved_func(vm, "rx_func", inp)
     np.testing.assert_allclose(res.numpy(), inp.numpy().astype("int16"))
 
 
@@ -598,7 +610,7 @@ def test_vm_emit_te_floor_symbolic_shape():
     vm = relax.VirtualMachine(ex, tvm.cpu())
     shape = (9,)
     inp = tvm.nd.array(np.random.rand(*shape).astype(np.float32))
-    res = vm["rx_func"](inp)
+    res = check_saved_func(vm, "rx_func", inp)
 
     def expected_output():
         output_shape = (shape[0] // 2,)
@@ -625,7 +637,7 @@ def test_vm_emit_te_constant_param_cpu():
     dev = tvm.cpu()
     vm = relax.VirtualMachine(exec, dev)
 
-    add_res = vm["main"](tvm.nd.array(x_np, dev))
+    add_res = check_saved_func(vm, "main", tvm.nd.array(x_np, dev))
     tvm.testing.assert_allclose(add_res.numpy(), x_np + c_np, rtol=1e-7, atol=1e-7)
 
 
@@ -652,7 +664,7 @@ def test_vm_emit_te_constant_param_gpu():
     dev = tvm.cuda()
     vm = relax.VirtualMachine(exec, dev)
 
-    add_res = vm["main"](tvm.nd.array(x_np, dev))
+    add_res = check_saved_func(vm, "main", tvm.nd.array(x_np, dev))
     tvm.testing.assert_allclose(add_res.numpy(), x_np + c_np, rtol=1e-7, atol=1e-7)
 
 
@@ -681,7 +693,7 @@ def test_vm_relax_symbolic_shape():
     shape2 = (3,)
     inp = tvm.nd.array(np.random.rand(*shape1).astype(np.float32))
     inp2 = tvm.nd.array(np.random.rand(*shape2).astype(np.float32))
-    res = vm["rx_func"](inp, inp2)
+    res = check_saved_func(vm, "rx_func", inp, inp2)
 
     def expected_output():
         return inp.numpy() + np.repeat(inp2.numpy(), 2)[:5]
@@ -719,7 +731,7 @@ def test_vm_relax_dyn_tir_shape():
     inp = tvm.nd.array(np.random.rand(2).astype(np.float32))
     inp2 = tvm.nd.array(np.random.rand(3).astype(np.float32))
 
-    res = vm["rx_func"](inp, inp2)
+    res = check_saved_func(vm, "rx_func", inp, inp2)
 
     tvm.testing.assert_allclose(res.numpy(), inp2.numpy(), rtol=1e-7, atol=1e-7)
 
@@ -768,7 +780,7 @@ def test_vm_tuplegetitem():
     vm = relax.VirtualMachine(ex, tvm.cpu())
     x_inp = tvm.nd.array(np.random.rand(2, 3))
     y_inp = tvm.nd.array(np.random.rand(2, 3))
-    res = vm["tuple_get_item"](x_inp, y_inp)
+    res = check_saved_func(vm, "tuple_get_item", x_inp, y_inp)
     tvm.testing.assert_allclose(res.numpy(), x_inp.numpy() + y_inp.numpy(), rtol=1e-7, atol=1e-7)
 
 
@@ -821,7 +833,7 @@ def test_sub_func_call():
     vm = relax.VirtualMachine(ex, tvm.cpu())
     x_inp = tvm.nd.array(np.random.rand(32, 32).astype(np.float32))
     y_inp = tvm.nd.array(np.random.rand(32, 32).astype(np.float32))
-    res = vm["main"](x_inp, y_inp)
+    res = check_saved_func(vm, "main", x_inp, y_inp)
     product = np.dot(x_inp.numpy(), y_inp.numpy())
     expected = product * product
     tvm.testing.assert_allclose(res.numpy(), expected, rtol=1e-6, atol=1e-6)
@@ -854,7 +866,7 @@ def test_recursion():
     recursion_runs = np.random.randint(1, 10)
     inp.fill(recursion_runs)
     inp = tvm.nd.array(inp)
-    res = vm["recursion"](inp)
+    res = check_saved_func(vm, "recursion", inp)
     tvm.testing.assert_allclose(res.numpy(), np.power(2.0, recursion_runs), rtol=1e-7, atol=1e-7)
 
 
@@ -880,7 +892,7 @@ def test_vm_closure():
     vm = relax.VirtualMachine(ex, tvm.cpu())
     x_inp = tvm.nd.array(np.random.rand(2, 3))
     y_inp = tvm.nd.array([[3.1, 4.0, 5.0], [6.0, 7.1, 9.0]])
-    res = vm["main"](x_inp, y_inp)
+    res = check_saved_func(vm, "main", x_inp, y_inp)
     tvm.testing.assert_allclose(res.numpy(), x_inp.numpy() + y_inp.numpy())
 
 

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -70,11 +70,11 @@ def tile_packed(a, b):
 
 
 def check_saved_func(vm: relax.VirtualMachine, func_name: str, *inputs: List[Any]) -> Object:
-    # uses package_function to create a closure with the given inputs
+    # uses save_function to create a closure with the given inputs
     # and ensure the result is the same
     # (assumes the functions return tensors and that they're idempotent)
     saved_name = f"{func_name}_saved"
-    vm.package_function(func_name, saved_name, *inputs)
+    vm.save_function(func_name, saved_name, *inputs)
     res1 = vm[func_name](*inputs)
     res2 = vm[saved_name]()
     tvm.testing.assert_allclose(res1.numpy(), res2.numpy(), rtol=1e-7, atol=1e-7)
@@ -941,7 +941,7 @@ def test_time_evaluator():
     assert timing_res.results
 
     # ensure we can use it with a closure
-    vm.package_function("main", "saved_main", x, y)
+    vm.save_function("main", "saved_main", x, y)
     timing_res = vm.time_evaluator("saved_main", tvm.cpu())()
     assert timing_res.results
 


### PR DESCRIPTION
This PR implements my idea in #179, adding a function that allows for saving a `PackedFunc` in the VM's module that just calls an existing function with a specific set of arguments. The main use of this is for timing, to avoid some overhead in looking up functions. I kept this separate from #207 because there was less discussion of this idea and it's a little unusual compared to other features we've added.

I named the function ~`package_function`~ `save_function` rather than `wrap_closure` since there is already an `invoke_closure` function and I did not want to create confusion. However, I'm unsatisfied with this name and will happily take suggestions if you like the idea.

I've also gone ahead and implemented the proposal in #178, since it was easy.