### PR TITLE
Clean warning messages by Clang and Pylint

### DIFF
--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -276,7 +276,7 @@ class ExprMutator : public ExprMutatorBase {
    * \param block The binding block to be visited.
    * \return The binding block after transformation.
    */
-  virtual BindingBlock VisitBindingBlock(const BindingBlock& block);
+  virtual BindingBlock VisitBindingBlock(const BindingBlock& block) override;
   // specific leaf level visitor functions
   virtual BindingBlock VisitBindingBlock_(const BindingBlockNode* block);
   virtual BindingBlock VisitBindingBlock_(const DataflowBlockNode* block);

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -276,7 +276,7 @@ class ExprMutator : public ExprMutatorBase {
    * \param block The binding block to be visited.
    * \return The binding block after transformation.
    */
-  virtual BindingBlock VisitBindingBlock(const BindingBlock& block);
+  virtual BindingBlock VisitBindingBlock(const BindingBlock& block) override;  // NOLINT(*)
   // specific leaf level visitor functions
   virtual BindingBlock VisitBindingBlock_(const BindingBlockNode* block);
   virtual BindingBlock VisitBindingBlock_(const DataflowBlockNode* block);

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -276,7 +276,7 @@ class ExprMutator : public ExprMutatorBase {
    * \param block The binding block to be visited.
    * \return The binding block after transformation.
    */
-  virtual BindingBlock VisitBindingBlock(const BindingBlock& block) override;
+  virtual BindingBlock VisitBindingBlock(const BindingBlock& block);
   // specific leaf level visitor functions
   virtual BindingBlock VisitBindingBlock_(const BindingBlockNode* block);
   virtual BindingBlock VisitBindingBlock_(const DataflowBlockNode* block);

--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -109,7 +109,7 @@ class VirtualMachine : public runtime::ModuleNode {
    */
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
-  ~VirtualMachine() final {}
+  ~VirtualMachine() {}
 
   const char* type_key() const final { return "relax.VirtualMachine"; }
 

--- a/python/tvm/relax/testing/nn.py
+++ b/python/tvm/relax/testing/nn.py
@@ -19,9 +19,10 @@
 
 
 from typing import List, Any, Callable
+import numpy as np
+
 import tvm
 from tvm import relax, topi, tir
-import numpy as np
 
 
 def emit_te(func: Callable, *args: Any, **kwargs: Any) -> relax.Var:

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -17,9 +17,9 @@
 # pylint: disable=invalid-name, redefined-builtin, no-else-return
 """The Relax virtual machine"""
 from typing import List, Optional, Union, Dict, Tuple
-from tvm._ffi import base as _base
 import numpy as np
 
+from tvm._ffi import base as _base
 import tvm
 from tvm import relax
 from tvm.ir.module import IRModule

--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=invalid-name, no-else-return, too-many-nested-blocks
 # pylint: disable=inconsistent-return-statements, ungrouped-imports
+# pylint: disable=arguments-differ
 """TVM Script Parser For Relax"""
 from __future__ import annotations
 
@@ -23,6 +24,8 @@ import inspect
 import json
 from enum import Enum
 from typing import Union, Dict, List, Tuple, Optional, Callable, Any
+import synr
+from synr import ast, Transformer
 
 import tvm
 from tvm import relay, relax, tir
@@ -33,8 +36,6 @@ from tvm.ir.module import IRModule
 from tvm.script.tir.node import BufferSlice
 import tvm.script.tir as tir_namespace
 import tvm.script.relax as relax_namespace
-import synr
-from synr import ast, Transformer
 
 from ..parser import TVMScriptParser as _TIRScriptParser
 from ..utils import tvm_span_from_synr, call_with_error_reporting

--- a/src/relax/backend/vm/vm_memory_lower.cc
+++ b/src/relax/backend/vm/vm_memory_lower.cc
@@ -66,6 +66,8 @@ class VMMemLowerMutator : public ExprMutator {
     return ret;
   }
 
+  using ExprMutator::VisitExpr_;
+
   Expr VisitExpr_(const CallNode* call) override {
     // post-order mutation
     Expr expr = VisitExprPostOrder_(call);

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -64,6 +64,8 @@ class VMShapeLowerMutator : public ExprMutator {
     StoreShape(shape, binding->pattern);
   }
 
+  using ExprMutator::VisitExpr_;
+
   Expr VisitExpr_(const ShapeExprNode* node) override {
     if (IsConstantShape(GetRef<ShapeExpr>(node))) {
       return ExprMutator::VisitExpr_(node);

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -42,6 +42,7 @@ namespace relax {
 
 class CallTIRMutator : public ExprMutator {
  public:
+  using ExprMutator::VisitExpr_;
   Expr VisitExpr_(const CallNode* call) override {
     // post-order mutation
     Expr expr = VisitExprPostOrder_(call);

--- a/src/relax/transform/fail_test_rewrite.cc
+++ b/src/relax/transform/fail_test_rewrite.cc
@@ -28,6 +28,8 @@ namespace relax {
 
 /*! \brief Rewrite/Remove global var or symbolic var in the dataflow block.*/
 class FailTestRewriter : public ExprMutator {
+  using ExprMutator::VisitExpr_;
+
   // Rewrite/Remove specific global var
   Var VisitVarDef_(const VarNode* var) override {
     if (var->name_hint() == "gv_rewrite") {

--- a/src/relax/transform/fma_rewrite.cc
+++ b/src/relax/transform/fma_rewrite.cc
@@ -44,6 +44,7 @@ namespace relax {
  * z0 = ewise_fma(a, lv0, c)
  */
 class EwiseFMARewriter : public ExprMutator {
+  using ExprMutator::VisitExpr_;
   Expr VisitExpr_(const CallNode* call) override {
     Expr expr = VisitExprPostOrder_(call);
     call = expr.as<CallNode>();
@@ -103,6 +104,8 @@ class EwiseFuseFMAMutator : public ExprMutator {
     }
     return builder_->GetContextIRModule();
   }
+
+  using ExprMutator::VisitExpr_;
 
   Expr VisitExpr_(const CallNode* call) override {
     Expr expr = VisitExprPostOrder_(call);

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -163,6 +163,8 @@ class ConstantFolder : public ExprMutator {
     return std::move(call);
   }
 
+  using ExprMutator::VisitExpr_;
+
   Expr VisitExpr_(const CallNode* call) final {
     // post-order mutation
     Call post_call = Downcast<Call>(VisitExprPostOrder_(call));

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -340,8 +340,6 @@ class GraphCreator : public ExprVisitor {
   IndexedForwardGraph graph_;
   /*! \brief The graph nodes whose patterns are set */
   std::unordered_set<IndexedForwardGraph::Node*> initialized_nodes_;
-  /*! \brief The structural equality checker */
-  StructuralEqual structural_equal_;
 };
 
 /*!
@@ -373,7 +371,6 @@ class FunctionCreator : public ExprMutator {
     if (const auto* var_binding = binding.as<VarBindingNode>()) {
       if (const auto* call = var_binding->value.as<CallNode>()) {
         ICHECK(call->op == Op::Get("relax.call_tir"));
-        const GlobalVar& global_var = Downcast<GlobalVar>(call->args[0]);
         // Update the name of the function.
         name_hint_ = name_hint_ + "_" + Downcast<GlobalVar>(call->args[0])->name_hint;
 

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -78,7 +78,6 @@ namespace relax {
 using relay::GraphPartitioner;
 using relay::IndexedForwardGraph;
 using relay::OpPatternKind;
-using support::LinkedList;
 using support::LinkNode;
 
 constexpr uint32_t kMaxFusedOps = 256;
@@ -561,7 +560,7 @@ class OperatorFusor : public ExprMutator {
       const GlobalVar& gv = kv.first;
       const BaseFunc& func = kv.second;
       // Only visit Relax function without attr kPrimitive.
-      if (func->IsInstance<relax::FunctionNode>() & !func->HasNonzeroAttr(attr::kPrimitive)) {
+      if (func->IsInstance<relax::FunctionNode>() && !func->HasNonzeroAttr(attr::kPrimitive)) {
         auto updated_func = Downcast<Function>(VisitExpr(func));
         builder_->UpdateFunction(gv, updated_func);
       }

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -633,7 +633,7 @@ class TIRFuseMutator : public ExprMutator {
 
   using ExprMutator::VisitExpr_;
 
-  Expr VisitExpr_(const CallNode* op) override final {
+  Expr VisitExpr_(const CallNode* op) final {
     static const Op& call_tir_op_ = Op::Get("relax.call_tir");
     Call call = Downcast<Call>(ExprMutator::VisitExpr_(op));
     if (call->op->IsInstance<GlobalVarNode>()) {

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -631,7 +631,9 @@ class TIRFuseMutator : public ExprMutator {
  private:
   explicit TIRFuseMutator(const IRModule& mod) : mod_(mod) {}
 
-  Expr VisitExpr_(const CallNode* op) final {
+  using ExprMutator::VisitExpr_;
+
+  Expr VisitExpr_(const CallNode* op) override final {
     static const Op& call_tir_op_ = Op::Get("relax.call_tir");
     Call call = Downcast<Call>(ExprMutator::VisitExpr_(op));
     if (call->op->IsInstance<GlobalVarNode>()) {

--- a/src/relax/transform/lambda_lift.cc
+++ b/src/relax/transform/lambda_lift.cc
@@ -44,6 +44,8 @@ class LambdaLifter : public ExprMutator {
  public:
   explicit LambdaLifter(const IRModule& module) : ExprMutator(module) { mod_ = module; }
 
+  using ExprMutator::VisitExpr_;
+
   Expr VisitExpr_(const CallNode* call_node) final {
     auto call = Downcast<Call>(ExprMutator::VisitExpr_(call_node));
     if (auto const* var = call_node->op.as<VarNode>()) {

--- a/src/relax/transform/resolve_globals.cc
+++ b/src/relax/transform/resolve_globals.cc
@@ -30,7 +30,9 @@ class GlobalVarResolver : public ExprMutator {
  public:
   GlobalVarResolver(IRModule mod, DiagnosticContext diag_ctx) : mod_(mod), diag_ctx_(diag_ctx) {}
 
-  Expr VisitExpr_(const GlobalVarNode* gvar) {
+  using ExprMutator::VisitExpr_;
+
+  Expr VisitExpr_(const GlobalVarNode* gvar) override {
     if (!mod_->ContainGlobalVar(gvar->name_hint)) {
       return GetRef<GlobalVar>(gvar);
     }

--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -58,7 +58,9 @@ class CodeGenRunner : ExprMutator {
     return out_mod;
   }
 
-  Expr VisitExpr_(const CallNode* call_node) {
+  using ExprMutator::VisitExpr_;
+
+  Expr VisitExpr_(const CallNode* call_node) override {
     auto call = Downcast<Call>(ExprMutator::VisitExpr_(call_node));
     if (auto const* gvarnode = call_node->op.as<GlobalVarNode>()) {
       const GlobalVar gvar = GetRef<GlobalVar>(gvarnode);
@@ -91,7 +93,7 @@ class CodeGenRunner : ExprMutator {
     return GetRef<Call>(call_node);
   }
 
-  Expr VisitExpr_(const FunctionNode* func_node) {
+  Expr VisitExpr_(const FunctionNode* func_node) override {
     Function func = GetRef<Function>(func_node);
     auto opt_codegen = func->GetAttr<String>(attr::kCodegen);
     if (opt_codegen.defined()) {


### PR DESCRIPTION
Compiling Relax shows tons of warnings due to non-well-formed language usages. This PR corrects those usages to reduce warnings and avoid future mis-uses. Note this PR only fixes warnings brought by relax files. Other files might still bring warnings (e.g., some relay passes).

The main correction is to put `using T::VisitExpr_` before overloading (So that other `VisitExpr_` won't be hidden by the current function overloading) and marked the overloaded `VisitExpr_` with keyword `overload`.

cc: @YuchenJin 