### PR TITLE
[Bugfix][Codegen] Fix var binding to a ConstantNode; Force VM if.cond register to take an NDArray instead of POD

### DIFF
--- a/include/tvm/runtime/relax_vm/vm.h
+++ b/include/tvm/runtime/relax_vm/vm.h
@@ -157,7 +157,12 @@ class VirtualMachine : public runtime::ModuleNode {
    * \return The object representing the result.
    */
   RegType Invoke(Index fidx, const std::vector<RegType>& args);
-
+  /*!
+   * \brief Read a VM register and cast it to int64_t.
+   * \param reg The register to read from.
+   * \return The read scalar.
+   */
+  int64_t LoadScalarInt(RegName reg) const;
   /*! \brief Run VM dispatch loop. */
   void RunLoop();
   /*!


### PR DESCRIPTION
Fix the bug in #212, the following IRModule failed to be compiled:
```python
@tvm.script.ir_module
class PrintConst:
    @R.function
    def main():
        x = relax.const([1, 2])
        y = relax.print(x)
        return x
```

The cause of this bug is VM Codegen did not handle binding ConstantNode to variable (`x = relax.const([1, 2])`) and save the constant NDArray to the register. Previously the codegen only handles the case where ConstantNode as CallNode's arguments. Now it's fixed and unit test is added. 

Fix the bug in https://github.com/tlc-pack/relax/issues/214#issuecomment-1211411432, the issue was caused by the VM simply read the condition register of the If instruction, and expect it to be a POD int or bool. https://github.com/tlc-pack/relax/commit/811e877c289fa52f55886c8a3e8dce10ed84915f adds a `LoadScalarInt` function similar to the Relay VM to check the If.cond register stores an NDArray, and cast it to int_64. Since we haven't introduced PrimValue and PrimType (that represents POD values like int and bool) to the Relax language yet, let's enforce `If->cond` to be a Tensor (NDArray at runtime).

cc: @slyubomirsky 