### PR TITLE
[FIX] Fix windows build issue when allocating a dynamic array

### DIFF
--- a/include/tvm/relax/tuning_api.h
+++ b/include/tvm/relax/tuning_api.h
@@ -34,17 +34,17 @@ namespace relax {
  * function. */
 TVM_ALWAYS_INLINE TVMRetValue CallPackedWithArgsInArray(const runtime::PackedFunc f,
                                                         const Array<ObjectRef>& args) {
-  const size_t kNumArgs = args.size();
-  TVMValue tvm_values[kNumArgs];
-  int tvm_type_codes[kNumArgs];
-  runtime::TVMArgsSetter setter(tvm_values, tvm_type_codes);
+  size_t num_args = args.size();
+  std::vector<TVMValue> values(num_args);
+  std::vector<int> codes(num_args);
+  runtime::TVMArgsSetter setter(values.data(), codes.data());
   const ObjectRef* ptr = args.template as<ArrayNode>()->begin();
-  for (size_t i = 0; i < kNumArgs; ++i) {
+  for (size_t i = 0; i < num_args; ++i) {
     setter(i, *(ptr + i));
   }
 
   TVMRetValue rv;
-  f.CallPacked(TVMArgs(tvm_values, tvm_type_codes, kNumArgs), &rv);
+  f.CallPacked(TVMArgs(values.data(), codes.data(), num_args), &rv);
   return rv;
 }
 

--- a/include/tvm/relax/tuning_api.h
+++ b/include/tvm/relax/tuning_api.h
@@ -27,6 +27,7 @@
 #include <tvm/ir/transform.h>
 #include <tvm/meta_schedule/database.h>
 
+#include <vector>
 namespace tvm {
 namespace relax {
 


### PR DESCRIPTION
In the current codebase, `kNumArgs` is a runtime-dependent variable (i.e. its value depends on the input shape of Array).

Allocating arrays with runtime values is not allowed during building on Windows (I'm surprised it can be compiled on Linux and macOS)

cc @sunggg 