### PR TITLE
Expose `relax.expr.Constant` to `relax.Constant`

### DIFF
--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -51,6 +51,7 @@ If = expr.If
 
 # helper functions
 const = expr.const
+Constant = expr.Constant
 extern = expr.extern
 te_tensor = expr.te_tensor
 


### PR DESCRIPTION
A minor fix to enable direct access to `relax.Constant` :-)

cc @YuchenJin @Hzfengsy @jinhongyii 