### PR TITLE
[Hexgaon] Use uploaded path to load module.

### DIFF
--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -346,8 +346,8 @@ class Session:
             hexagon_arch="v68",
         )
 
-        self.upload(path_exec, "exec.so")
-        return self._rpc.get_function("tvm.hexagon.load_module")("exec.so")
+        path = self.upload(path_exec, "exec.so")
+        return self._rpc.get_function("tvm.hexagon.load_module")(str(path))
 
     def _aot_executor_from_factory(
         self,

--- a/tests/scripts/task_python_hexagon.sh
+++ b/tests/scripts/task_python_hexagon.sh
@@ -42,7 +42,14 @@ fi
 export ANDROID_SERIAL_NUMBER=${device_serial}
 
 # Only test integration with Relax
-run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon/test_relax_integration.py
+# TODO(prakalp): Run the same tests on simulator and device once the bug with device is fixed.
+if [[ "${device_serial}" == "simulator" ]];
+    then
+        run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon/test_relax_integration.py
+    else
+        run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon/test_relax_integration.py::test_conv2d
+fi
+
 
 if [[ "${device_serial}" == "simulator" ]]; then
     kill ${TRACKER_PID}


### PR DESCRIPTION
Use uploaded path to load module remotely. This fixes a bug in Hexagon-Relax integration.

* Fixes a bug to use the uploaded file remote path for loading the module
remotely.

* Modifies the task_python_hexagon.sh script to only run passing test
on device. This is used by Jenkins CI.

This partially fixes https://github.com/tlc-pack/relax/issues/237. Thanks @YuchenJin. `test_conv2d` and other tests when run individually pass. Still need to investigate why `tests/python/contrib/test_hexagon/test_relax_integration.py` gets stuck.