### PR TITLE
[TVMScript] B5: Support relax op

### DIFF
--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -188,3 +188,19 @@ def relax_print(*args: List[any]) -> None:
         print(*val_strs)
     else:
         print(format_str.format(*val_strs))
+
+
+def shape_of(expr: Expr) -> Expr:
+    """Get shape of a tensor.
+
+    Parameters
+    ----------
+    expr : Expr
+        The input Expr.
+
+    Returns
+    -------
+    result : Expr
+        The shape of the input
+    """
+    return _ffi_api.shape_of(expr)  # type: ignore # pylint: disable=no-member

--- a/python/tvm/relax/op/builtin/__init__.py
+++ b/python/tvm/relax/op/builtin/__init__.py
@@ -15,10 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=wildcard-import, redefined-builtin
-"""Relax core operators."""
+"""Relax builtin operators."""
 
-# Operators
-from .base import *
-from .tensor import *
-from .op_attrs import *
-from . import builtin
+from .builtin import *

--- a/python/tvm/relax/op/builtin/_ffi_api.py
+++ b/python/tvm/relax/op/builtin/_ffi_api.py
@@ -13,12 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License.
-# pylint: disable=wildcard-import, redefined-builtin
-"""Relax core operators."""
+"""FFI APIs for tvm.relax.op.builtin"""
+import tvm._ffi
 
-# Operators
-from .base import *
-from .tensor import *
-from .op_attrs import *
-from . import builtin
+tvm._ffi._init_api("relax.op.builtin", __name__)

--- a/python/tvm/relax/op/builtin/builtin.py
+++ b/python/tvm/relax/op/builtin/builtin.py
@@ -22,7 +22,9 @@ from ...expr import ShapeExpr, Call
 
 
 # TODO(relax-team): add documents
-def alloc_tensor(shape: Union[ShapeExpr, PrimExpr, List[PrimExpr]] , dtype: str, runtime_device_index: int) -> Call:
+def alloc_tensor(
+    shape: Union[ShapeExpr, PrimExpr, List[PrimExpr]], dtype: str, runtime_device_index: int
+) -> Call:
     if not isinstance(shape, ShapeExpr):
         if not isinstance(shape, (tuple, list)):
             shape = (shape,)

--- a/python/tvm/relax/op/builtin/builtin.py
+++ b/python/tvm/relax/op/builtin/builtin.py
@@ -13,12 +13,18 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License.
-# pylint: disable=wildcard-import, redefined-builtin
-"""Relax core operators."""
+"""The builtin Relax operators."""
 
-# Operators
-from .base import *
-from .tensor import *
-from .op_attrs import *
-from . import builtin
+from typing import List, Union
+from tvm.ir.expr import PrimExpr
+from . import _ffi_api
+from ...expr import ShapeExpr, Call
+
+
+# TODO(relax-team): add documents
+def alloc_tensor(shape: Union[ShapeExpr, PrimExpr, List[PrimExpr]] , dtype: str, runtime_device_index: int) -> Call:
+    if not isinstance(shape, ShapeExpr):
+        if not isinstance(shape, (tuple, list)):
+            shape = (shape,)
+        shape = ShapeExpr(shape)
+    return _ffi_api.alloc_tensor(shape, dtype, runtime_device_index)

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -14,16 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# # pylint: disable=redefined-builtin
+# pylint: disable=redefined-builtin, wrong-import-order
 """IRBuilder for Relax dialect"""
 
 from typing import Dict, List, Optional, Union
 
 from tvm._ffi import register_object as _register_object
 from tvm.ir import Type
-from tvm.relax import Call, Expr, ShapeExpr, Var
+from tvm.relax import Expr, Var
 from tvm.relax.op import call_tir
-import tvm.relax.op as _op
 from tvm.runtime import Object
 from tvm.tir import PrimExpr
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -21,13 +21,19 @@ from typing import Dict, List, Optional, Union
 
 from tvm._ffi import register_object as _register_object
 from tvm.ir import Type
-from tvm.relax import Expr, Var
+from tvm.relax import Call, Expr, ShapeExpr, Var
 from tvm.relax.op import call_tir
+import tvm.relax.op as _op
 from tvm.runtime import Object
 from tvm.tir import PrimExpr
 
 from . import _ffi_api
 from . import frame
+
+############################### Operators ###############################
+from tvm.relax.op import shape_of, make_closure, invoke_closure
+from tvm.relax.op import add, multiply, unique
+from tvm.relax.op import builtin
 
 
 ############################## Tensor Type ##############################
@@ -190,8 +196,10 @@ def emit(value: Expr) -> Var:
 
 __all__ = [
     "TensorType",
+    "add",
     "arg",
     "binding_block",
+    "builtin",
     "call_tir",
     "dataflow",
     "emit",
@@ -200,5 +208,10 @@ __all__ = [
     "func_ret_type",
     "func_ret_value",
     "function",
+    "invoke_closure",
+    "make_closure",
+    "multiply",
+    "unique",
+    "shape_of",
     "tensor",
 ]

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -183,9 +183,12 @@ RELAY_REGISTER_OP("relax.builtin.alloc_tensor")
     .set_attr<FInferShape>("FInferShape", InferShapeAllocTensor)
     .set_attr<FInferType>("FInferType", InferTypeAllocTensor);
 
-Expr MakeAllocTensor(Expr shape) {
+Expr MakeAllocTensor(Expr shape, DataType dtype, int64_t runtime_device_index) {
+  auto attrs = make_object<AllocTensorAttrs>();
+  attrs->dtype = std::move(dtype);
+  attrs->runtime_device_index = std::move(runtime_device_index);
   static const Op& op = Op::Get("relax.builtin.alloc_tensor");
-  return Call(op, {shape}, {}, {});
+  return Call(op, {shape}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.builtin.alloc_tensor").set_body_typed(MakeAllocTensor);
@@ -198,9 +201,12 @@ RELAY_REGISTER_OP("relax.vm.builtin.alloc_storage")
     .add_argument("size", "Expr", "The size of the storage to allocate.")
     .set_attr<FInferType>("FInferType", ReturnObjectType);
 
-Expr MakeVMAllocStorage(Expr size) {
+Expr MakeVMAllocStorage(Expr size, DataType dtype, int64_t runtime_device_index) {
+  auto attrs = make_object<VMAllocStorageAttrs>();
+  attrs->dtype = std::move(dtype);
+  attrs->runtime_device_index = std::move(runtime_device_index);
   static const Op& op = Op::Get("relax.vm.builtin.alloc_storage");
-  return Call(op, {size}, {}, {});
+  return Call(op, {size}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_storage").set_body_typed(MakeVMAllocStorage);
@@ -228,9 +234,12 @@ RELAY_REGISTER_OP("relax.vm.builtin.alloc_tensor")
     .set_attr<FInferShape>("FInferShape", InferShapeVMAllocTensor)
     .set_attr<FInferType>("FInferType", InferTypeVMAllocTensor);
 
-Expr MakeVMAllocTensor(Expr storage, Expr shape) {
+Expr MakeVMAllocTensor(Expr storage, Expr shape, DataType dtype, int64_t runtime_device_index) {
+  auto attrs = make_object<VMAllocStorageAttrs>();
+  attrs->dtype = std::move(dtype);
+  attrs->runtime_device_index = std::move(runtime_device_index);
   static const Op& op = Op::Get("relax.vm.builtin.alloc_tensor");
-  return Call(op, {storage, shape}, {}, {});
+  return Call(op, {storage, shape}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_tensor").set_body_typed(MakeVMAllocTensor);
@@ -244,9 +253,11 @@ RELAY_REGISTER_OP("relax.vm.builtin.store_shape")
     .add_argument("heap", "Expr", "The heap to store the shape.")
     .set_attr<FInferType>("FInferType", ReturnVoidType);
 
-Expr MakeStoreShape(Expr shape, Expr heap) {
+Expr MakeStoreShape(Expr shape, Expr heap, Array<Integer> indices) {
+  auto attrs = make_object<ShapeHeapAttrs>();
+  attrs->indices = std::move(indices);
   static const Op& op = Op::Get("relax.vm.builtin.store_shape");
-  return Call(op, {shape, heap}, {}, {});
+  return Call(op, {shape, heap}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.vm.builtin.store_shape").set_body_typed(MakeStoreShape);
@@ -259,9 +270,11 @@ RELAY_REGISTER_OP("relax.vm.builtin.load_shape")
     .add_argument("heap", "Expr", "The heap to load the shape from.")
     .set_attr<FInferType>("FInferType", ReturnShapeType);
 
-Expr MakeLoadShape(Expr heap) {
+Expr MakeLoadShape(Expr heap, Array<Integer> indices) {
+  auto attrs = make_object<ShapeHeapAttrs>();
+  attrs->indices = std::move(indices);
   static const Op& op = Op::Get("relax.vm.builtin.load_shape");
-  return Call(op, {heap}, {}, {});
+  return Call(op, {heap}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.vm.builtin.load_shape").set_body_typed(MakeLoadShape);


### PR DESCRIPTION
This PR features the relax op support, which includes:
- Expose ops defined in cpp to Python
- Enable ir_builder/parser work with relax op

cc @YuchenJin @yongwww 