### PR TITLE
[TVMScript] B6/B7: Symbolic shape and var shadowing 

### DIFF
--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -28,6 +28,7 @@ from tvm.tir import PrimExpr
 
 from . import _ffi_api
 from . import frame
+from ..tir import var as _tir_var
 
 ############################### Operators ###############################
 from tvm.relax.op import shape_of, make_closure, invoke_closure
@@ -44,7 +45,7 @@ class TensorType(Object):
 
 
 def tensor(
-    shape: Optional[List[PrimExpr]] = None,
+    shape: Optional[List[Union[PrimExpr, str]]] = None,
     dtype: Optional[str] = None,
     ndim: int = -1,
 ):
@@ -52,7 +53,7 @@ def tensor(
 
     Parameters
     ----------
-    shape: Optional[List[PrimExpr]]
+    shape: Optional[List[Union[PrimExpr, str]]]
         The shape of the tensor. It's runtime dependent if `shape` is None.
 
     dtype: Optional[str]
@@ -66,6 +67,12 @@ def tensor(
     tensor_type: TensorType
         The TensorType that is only used in ir_builder.
     """
+    if isinstance(shape, (tuple, list)):
+        shape = list(shape)
+        for i, s in enumerate(shape):
+            if isinstance(s, str):
+                shape[i] = _tir_var("int64", s)
+
     return _ffi_api.Tensor(shape, dtype, ndim)  # pylint: disable=no-member # type: ignore
 
 

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -46,7 +46,7 @@ def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -
             if prev_value.dtype != value.dtype:
                 self.report_error(
                     node,
-                    "Expected the same dtype for TIR vars"
+                    "Expected the same dtype for TIR vars "
                     f"but got {value.dtype} vs {prev_value.dtype}",
                 )
             return prev_value

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -46,7 +46,8 @@ def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -
             if prev_value.dtype != value.dtype:
                 self.report_error(
                     node,
-                    f"Expected the same dtype for TIR vars, but got {value.dtype} vs {prev_value.dtype}",
+                    "Expected the same dtype for TIR vars"
+                    f"but got {value.dtype} vs {prev_value.dtype}",
                 )
             return prev_value
         IRBuilder.name(var_name, value)


### PR DESCRIPTION
This PR features symbolic shape support and var shadowing in relax.

This PR is based on https://github.com/tlc-pack/relax/pull/244 because of testcase

Co-authored-by: Ruihang Lai <ruihangl@cs.cmu.edu>