### PR TITLE
[VM][Benchmarking] Add option for saving e2e results as CSV file

### DIFF
--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -144,9 +144,9 @@ def f_measurement(
     rt_mod: runtime.Module, device: runtime.ndarray.Device, input_data: Dict[str, runtime.NDArray]
 ):
     vm = relax.vm.VirtualMachine(exec=rt_mod, device=device)
-    vm.set_input("main", **input_data)
-    evaluator = vm.module.time_evaluator(
-        func_name="main",
+    vm.save_function("main", "measure_func", **input_data, include_return=False)
+    evaluator = vm.time_evaluator(
+        func_name="measure_func",
         dev=device,
         repeat=ARGS.num_measurement_repeats,
         number=ARGS.num_measurements,

--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -86,22 +86,9 @@ def _parse_args():
         type=int,
         default=180,
     )
-    args.add_argument(
-        "--num-measurement-repeats",
-        type=int,
-        default=5
-    )
-    args.add_argument(
-        "--num-measurements",
-        type=int,
-        default=10
-    )
-    args.add_argument(
-        "--results-file",
-        type=string,
-        required=False,
-        default=None
-    )
+    args.add_argument("--num-measurement-repeats", type=int, default=5)
+    args.add_argument("--num-measurements", type=int, default=10)
+    args.add_argument("--results-file", type=stu, required=False, default=None)
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)
     parsed.input_shape = json.loads(parsed.input_shape)
@@ -245,7 +232,7 @@ def main():
     if not ARGS.results_file:
         print(result)
         return
-    
+
     out_path = os.path.abspath(os.path.expanduser(ARGS.results_file))
     with open(out_path, "w") as out_file:
         writer = csv.writer(out_file)
@@ -257,6 +244,7 @@ def main():
         writer.writerow(["num_measurement_repeats", ARGS.num_measurement_repeats])
         for res in result.results:
             writer.writerow([str(res)])
+
 
 if __name__ == "__main__":
     main()

--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -229,7 +229,7 @@ def main():
         result = f_measurement(executable.mod, dev, input_data)
 
     print(result)
-    
+
     if not ARGS.results_file:
         return
 

--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -88,7 +88,7 @@ def _parse_args():
     )
     args.add_argument("--num-measurement-repeats", type=int, default=5)
     args.add_argument("--num-measurements", type=int, default=10)
-    args.add_argument("--results-file", type=stu, required=False, default=None)
+    args.add_argument("--results-file", type=str, required=False, default=None)
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)
     parsed.input_shape = json.loads(parsed.input_shape)
@@ -215,7 +215,7 @@ def main():
             )
 
     # for documentation purposes
-    start_time = datetime.datetite.now()
+    start_time = datetime.datetime.now()
 
     if ARGS.rpc_config:
         result = run_module_via_rpc(

--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -20,7 +20,6 @@ import csv
 import json
 import argparse
 import logging
-import string
 from typing import Dict
 import numpy as np  # type: ignore
 

--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -83,6 +83,16 @@ def _parse_args():
         type=int,
         default=180,
     )
+    args.add_argument(
+        "--num-measurement-repeats",
+        type=int,
+        default=5
+    )
+    args.add_argument(
+        "--num-measurements",
+        type=int,
+        default=10
+    )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)
     parsed.input_shape = json.loads(parsed.input_shape)
@@ -142,7 +152,8 @@ def f_measurement(
     evaluator = vm.module.time_evaluator(
         func_name="main",
         dev=device,
-        repeat=5,
+        repeat=ARGS.num_measurement_repeats,
+        number=ARGS.num_measurements,
         min_repeat_ms=500,
     )
     print(evaluator())

--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -99,7 +99,8 @@ def _parse_args():
     args.add_argument(
         "--results-file",
         type=string,
-        required=False
+        required=False,
+        default=None
     )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)

--- a/apps/relax_examples/e2e_auto_tir.py
+++ b/apps/relax_examples/e2e_auto_tir.py
@@ -229,8 +229,9 @@ def main():
         dev = tvm.device(ARGS.target.kind.name)
         result = f_measurement(executable.mod, dev, input_data)
 
+    print(result)
+    
     if not ARGS.results_file:
-        print(result)
         return
 
     out_path = os.path.abspath(os.path.expanduser(ARGS.results_file))

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -257,6 +257,8 @@ class VirtualMachine(object):
                 idx = func_params.index(k)
                 new_args[idx] = kwargs[k]
                 cnt += 1
+            else:
+                print(f'Warning: Keyword argument "{k}" is unused in {func_name}')
         assert len(args) + cnt == len(func_params)
         idx = 0
         for i, arg in enumerate(new_args):

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -162,7 +162,12 @@ class VirtualMachine(object):
         return self._invoke_closure(closure, *args)
 
     def save_function(
-        self, func_name: str, saved_name: str, *args: List[Any], include_return: bool = True
+        self,
+        func_name: str,
+        saved_name: str,
+        *args: List[Any],
+        include_return: bool = True,
+        **kwargs: Dict[str, Any],
     ) -> None:
         """
         Convenience function. Takes a function from the module and saves
@@ -193,8 +198,13 @@ class VirtualMachine(object):
 
         args : List[Any]
             The arguments to package up with the function.
+
+        kwargs : Dict[str, Any]
+            Any named arguments to package up with the function
         """
         cargs = []
+        if kwargs:
+            args = self._convert_func_named_args(func_name, args, **kwargs)
         for arg in args:
             self._convert(arg, cargs)
         self._save_function(func_name, saved_name, int(include_return), *cargs)
@@ -231,6 +241,30 @@ class VirtualMachine(object):
         else:
             raise TypeError("Unsupported type: %s" % (type(arg)))
 
+    def _convert_func_named_args(self, func_name: str, args: Any, **kwargs: Any) -> Any:
+        """
+        Takes named function parameters and returns a list of those needed,
+        in the order they should appear
+        """
+        # kwargs can be a super set of the required function parameters.
+        # We only find the ones that are needed.
+        func_arity = self._get_function_arity(func_name)
+        func_params = [self._get_function_param_name(func_name, i) for i in range(func_arity)]
+        new_args = [None] * len(func_params)
+        cnt = 0
+        for k in kwargs:
+            if k in func_params:
+                idx = func_params.index(k)
+                new_args[idx] = kwargs[k]
+                cnt += 1
+        assert len(args) + cnt == len(func_params)
+        idx = 0
+        for i, arg in enumerate(new_args):
+            if arg is None:
+                new_args[i] = args[idx]
+                idx += 1
+        return new_args
+
     def set_input(self, func_name: str, *args: Any, **kwargs: Any) -> None:
         """Set the inputs to a function.
         This interface works when using VM over RPC by internally converting NDArray in
@@ -252,24 +286,7 @@ class VirtualMachine(object):
         cargs = []
 
         if kwargs:
-            # kwargs can be a super set of the required function parameters.
-            # We only find the ones that are needed.
-            func_arity = self._get_function_arity(func_name)
-            func_params = [self._get_function_param_name(func_name, i) for i in range(func_arity)]
-            new_args = [None] * len(func_params)
-            cnt = 0
-            for k in kwargs:
-                if k in func_params:
-                    idx = func_params.index(k)
-                    new_args[idx] = kwargs[k]
-                    cnt += 1
-            assert len(args) + cnt == len(func_params)
-            idx = 0
-            for i, arg in enumerate(new_args):
-                if arg is None:
-                    new_args[i] = args[idx]
-                    idx += 1
-            args = new_args
+            args = self._convert_func_named_args(func_name, args, **kwargs)
 
         for arg in args:
             self._convert(arg, cargs)

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -1191,6 +1191,23 @@ def test_set_input_rpc():
     run_on_rpc(TestVMSetInput, set_input_trial)
 
 
+def save_function_kwargs_trial(vm: relax.VirtualMachine, device: tvm.runtime.Device) -> None:
+    # just checking that we can use kwargs for the args when saving a function
+    a = tvm.nd.array(np.random.rand(32, 32).astype("float32"), device)
+    b = tvm.nd.array(np.random.rand(32, 32).astype("float32"), device)
+    vm.save_function("main", "saved_main", x=a, w=b)
+    res0 = vm["saved_main"]()
+    tvm.testing.assert_allclose(res0.numpy(), a.numpy() * b.numpy(), rtol=1e-7, atol=1e-7)
+
+
+def test_save_function_kwargs():
+    save_function_kwargs_trial(*make_vm(TestVMSetInput))
+
+
+def test_save_function_kwargs_rpc():
+    run_on_rpc(TestVMSetInput, save_function_kwargs_trial)
+
+
 # if you set an input, you should not be able to call statelessly
 @pytest.mark.xfail()
 def test_set_input_stateless_failure():


### PR DESCRIPTION
This PR makes some small additions to the end-to-end AutoTIR script, namely eliminating a bug (it was incorrectly using the stateful API) and adding an option to save the test results as a CSV file for benchmarking purposes (the data can then be separately analyzed as needed).

These changes also required a small extension to the `save_function` method in the VM, namely allowing it to take keyword arguments.

I would be particularly interested in reviewing how the results are saved and whether the files should perhaps be formatted differently.