### PR TITLE
[Bugfix] Couple of bug fixes to run TVM-gen code together with BYOC

### DIFF
--- a/python/tvm/ir/function.py
+++ b/python/tvm/ir/function.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Function defintiions."""
+from __future__ import annotations
 from typing import Union, Dict
 from enum import IntEnum
 import tvm.runtime
@@ -41,7 +42,7 @@ class BaseFunc(RelayExpr):
         """Return the attrs member of the function."""
         return _ffi_api.BaseFunc_Attrs(self)
 
-    def with_attr(self, attr_key_or_dict, attr_value=None):
+    def with_attr(self, attr_key_or_dict, attr_value=None) -> BaseFunc:
         """Create a new copy of the function and update the attribute.
 
         Parameters
@@ -54,7 +55,7 @@ class BaseFunc(RelayExpr):
 
         Returns
         -------
-        func : Function
+        func : BaseFunc
             A new copy of the function
         """
         # make sure we first copy so that we can safely do copy on write
@@ -70,7 +71,7 @@ class BaseFunc(RelayExpr):
             res._move(), attr_key_or_dict, tvm.runtime.convert(attr_value)
         )
 
-    def with_attrs(self, attr_map: Union[DictAttrs, Dict[str, Object]]):
+    def with_attrs(self, attr_map: Union[DictAttrs, Dict[str, Object]]) -> BaseFunc:
         """Copy the IRModule and add the given attribute map to it.
 
         Parameters
@@ -80,7 +81,7 @@ class BaseFunc(RelayExpr):
 
         Returns
         -------
-        func : Function
+        func : BaseFunc
             A new copy of the function
         """
         if isinstance(attr_map, tvm.ir.DictAttrs):
@@ -88,7 +89,7 @@ class BaseFunc(RelayExpr):
 
         return _ffi_api.BaseFuncWithAttrs(self, attr_map)
 
-    def without_attr(self, attr_key: str):
+    def without_attr(self, attr_key: str) -> BaseFunc:
         """Create a new copy of the function with an attribute without provided key.
 
         Parameters
@@ -99,7 +100,7 @@ class BaseFunc(RelayExpr):
 
         Returns
         -------
-        func : Function
+        func : BaseFunc
             A new copy of the function
         """
         return _ffi_api.BaseFuncWithoutAttr(self, attr_key)

--- a/python/tvm/ir/function.py
+++ b/python/tvm/ir/function.py
@@ -18,8 +18,10 @@
 from typing import Union, Dict
 from enum import IntEnum
 import tvm.runtime
+from tvm.runtime.object import Object
 
 from .expr import RelayExpr
+from .attrs import DictAttrs
 from . import _ffi_api
 
 
@@ -68,7 +70,7 @@ class BaseFunc(RelayExpr):
             res._move(), attr_key_or_dict, tvm.runtime.convert(attr_value)
         )
 
-    def with_attrs(self, attr_map: Union[tvm.ir.DictAttrs, Dict[str, tvm.Object]]):
+    def with_attrs(self, attr_map: Union[DictAttrs, Dict[str, Object]]):
         """Copy the IRModule and add the given attribute map to it.
 
         Parameters

--- a/python/tvm/ir/function.py
+++ b/python/tvm/ir/function.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Function defintiions."""
+from typing import Union, Dict
 from enum import IntEnum
 import tvm.runtime
 
@@ -67,7 +68,7 @@ class BaseFunc(RelayExpr):
             res._move(), attr_key_or_dict, tvm.runtime.convert(attr_value)
         )
 
-    def with_attrs(self, attr_map):
+    def with_attrs(self, attr_map: Union[tvm.ir.DictAttrs, Dict[str, tvm.Object]]):
         """Copy the IRModule and add the given attribute map to it.
 
         Parameters
@@ -77,8 +78,8 @@ class BaseFunc(RelayExpr):
 
         Returns
         -------
-        mod : IRModule
-            A new copy of the IRModule with the attribute
+        func : Function
+            A new copy of the function
         """
         if isinstance(attr_map, tvm.ir.DictAttrs):
             attr_map = attr_map._dict()

--- a/python/tvm/ir/function.py
+++ b/python/tvm/ir/function.py
@@ -67,6 +67,24 @@ class BaseFunc(RelayExpr):
             res._move(), attr_key_or_dict, tvm.runtime.convert(attr_value)
         )
 
+    def with_attrs(self, attr_map):
+        """Copy the IRModule and add the given attribute map to it.
+
+        Parameters
+        ----------
+        attr_map: Union[DictAttrs, Dict[str, Object]]
+            The attribute map
+
+        Returns
+        -------
+        mod : IRModule
+            A new copy of the IRModule with the attribute
+        """
+        if isinstance(attr_map, tvm.ir.DictAttrs):
+            attr_map = attr_map._dict()
+
+        return _ffi_api.BaseFuncWithAttrs(self, attr_map)
+
     def without_attr(self, attr_key: str):
         """Create a new copy of the function with an attribute without provided key.
 

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -348,3 +348,19 @@ class IRModule(Node):
         """
 
         return _ffi_api.Module_WithAttr(self, attr_key, attr_value)
+
+    def without_attr(self, attr_key):
+        """Copy the IRModule and remove an attribute key and its associated value.
+
+        Parameters
+        ----------
+        attr_key : str
+            The attribute key.
+
+        Returns
+        -------
+        mod : IRModule
+            A new copy of the IRModule without the attribute
+        """
+
+        return _ffi_api.Module_WithoutAttr(self, attr_key)

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -364,3 +364,21 @@ class IRModule(Node):
         """
 
         return _ffi_api.Module_WithoutAttr(self, attr_key)
+
+    def with_attrs(self, attr_map):
+        """Copy the IRModule and add the given attribute map to it.
+
+        Parameters
+        ----------
+        attr_map: Union[DictAttrs, Dict[str, Object]]
+            The attribute map
+
+        Returns
+        -------
+        mod : IRModule
+            A new copy of the IRModule with the attribute
+        """
+        if isinstance(attr_map, tvm.ir.DictAttrs):
+            attr_map = attr_map._dict()
+
+        return _ffi_api.Module_WithAttrs(self, attr_map)

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -15,13 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 """IRModule that holds the functions and type definitions."""
-from typing import Optional
+from __future__ import annotations
+from typing import Optional, Union, Dict
 import ast
 from tvm._ffi.base import string_types
 import tvm._ffi
+from tvm.runtime.object import Object
 
 from .base import Node
 from . import expr as _expr
+from .attrs import DictAttrs
 from ..ir.function import BaseFunc
 from . import type as _ty
 from . import _ffi_api
@@ -330,7 +333,7 @@ class IRModule(Node):
 
         return _ffi_api.Module_GetAttrs(self)
 
-    def with_attr(self, attr_key, attr_value):
+    def with_attr(self, attr_key, attr_value) -> IRModule:
         """Copy the IRModule and add an attribute to it.
 
         Parameters
@@ -349,7 +352,7 @@ class IRModule(Node):
 
         return _ffi_api.Module_WithAttr(self, attr_key, attr_value)
 
-    def without_attr(self, attr_key):
+    def without_attr(self, attr_key: str) -> IRModule:
         """Copy the IRModule and remove an attribute key and its associated value.
 
         Parameters
@@ -365,7 +368,7 @@ class IRModule(Node):
 
         return _ffi_api.Module_WithoutAttr(self, attr_key)
 
-    def with_attrs(self, attr_map):
+    def with_attrs(self, attr_map: Union[DictAttrs, Dict[str, Object]]) -> IRModule:
         """Copy the IRModule and add the given attribute map to it.
 
         Parameters

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -76,7 +76,9 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
             def visit_call_(self, call_node: Call):
                 # Ignore function calls
                 # We only target calls for operators
-                if isinstance(call_node.op, relax.GlobalVar):
+                if isinstance(call_node.op, relax.GlobalVar) or isinstance(
+                    call_node.op, relax.expr.ExternFunc
+                ):
                     return call_node
                 # Current relax op name simply adds "relax." prefix to relay op name.
                 # Thus, remove "relax." prefix to deduce relay op name.
@@ -116,6 +118,8 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
                     if isinstance(func, relax.Function):
                         updated_func = self.visit_expr(func)
                         self.builder_.update_func(gv, updated_func)
-                return self.builder_.get()
+                new_mod = self.builder_.get()
+                new_mod = new_mod.with_attrs(mod.attrs) if mod.attrs else new_mod
+                return new_mod
 
         return Lowerer().transform()

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -74,6 +74,10 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
             """Mutator that performs lowering."""
 
             def visit_call_(self, call_node: Call):
+                # Ignore function calls
+                # We only target calls for operators
+                if isinstance(call_node.op, relax.GlobalVar):
+                    return call_node
                 # Current relax op name simply adds "relax." prefix to relay op name.
                 # Thus, remove "relax." prefix to deduce relay op name.
                 relay_op_name = call_node.op.name[6:]

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -76,9 +76,7 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
             def visit_call_(self, call_node: Call):
                 # Ignore function calls
                 # We only target calls for operators
-                if isinstance(call_node.op, relax.GlobalVar) or isinstance(
-                    call_node.op, relax.expr.ExternFunc
-                ):
+                if isinstance(call_node.op, (relax.GlobalVar, relax.expr.ExternFunc)):
                     return call_node
                 # Current relax op name simply adds "relax." prefix to relay op name.
                 # Thus, remove "relax." prefix to deduce relay op name.

--- a/python/tvm/relax/transform/tuning_api/default_functions.py
+++ b/python/tvm/relax/transform/tuning_api/default_functions.py
@@ -16,7 +16,6 @@
 # under the License.
 """Relax Tuning Pass API default functions"""
 from typing import Dict, List, Optional
-import copy
 import sys
 import itertools
 import logging

--- a/python/tvm/relax/transform/tuning_api/default_functions.py
+++ b/python/tvm/relax/transform/tuning_api/default_functions.py
@@ -91,7 +91,7 @@ def default_generate_candidate(
                 choice = knob.choices[decision]
                 # Generate new candidate when this condition satisfies.
                 if choice.check_constr(cur_trace.out_mod):
-                    new_trace = copy.deepcopy(cur_trace)
+                    new_trace = cur_trace.deepcopy()
                     new_trace.add(knob, decision)
                     candidates.append(new_trace)
 

--- a/python/tvm/relax/transform/tuning_api/primitives.py
+++ b/python/tvm/relax/transform/tuning_api/primitives.py
@@ -18,7 +18,6 @@
 
 from typing import Callable, Union, Dict, List, Optional
 import logging
-import copy
 import tvm
 from tvm.runtime import Object
 from tvm.ir.module import IRModule
@@ -356,7 +355,7 @@ class Trace(Object):
     def deepcopy(self) -> "Trace":
         new_in_mod = deepcopy_irmodule(self.in_mod)
         new_knobs = [knob.deepcopy() for knob in self.knobs]
-        new_decisions = copy.deepcopy(self.decisions)
+        new_decisions = [str(decision) for decision in self.decisions]
         new_trace = Trace(new_in_mod, new_knobs, new_decisions)
         new_out_mod = deepcopy_irmodule(self.out_mod)
         new_trace.set_out_mod(new_out_mod)
@@ -387,7 +386,19 @@ def get_trace(in_: Union[Trace, IRModule, Expr]) -> Trace:
 
 
 @tvm.register_func("relax.tuning_api.deepcopy_irmodule")
-def deepcopy_irmodule(mod: IRModule):
+def deepcopy_irmodule(mod: IRModule) -> IRModule:
+    """
+    Deepcopy for an IRModule.
+
+    Parameters
+    ----------
+    mod: IRModule
+        input IRModule
+    Return
+    ----------
+    copied_mod: IRModule
+        deep-copied IRModule
+    """
     func_save_json = tvm.get_global_func("node.SaveJSON")
     func_load_json = tvm.get_global_func("node.LoadJSON")
     new_mod = None

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -487,10 +487,11 @@ def build(
     seq = tvm.transform.Sequential(passes)
     new_mod = seq(mod)
 
-    # split primfunc and relax function
+    # Split primfunc and relax function.
     rx_mod, tir_mod = _split_tir_relax(new_mod)
     lib = tvm.build(tir_mod, target=target)
 
+    # Extract external runtime modules if exist.
     ext_libs = []
     if mod.attrs and "external_mods" in mod.attrs:
         ext_libs = mod.attrs["external_mods"]

--- a/src/ir/function.cc
+++ b/src/ir/function.cc
@@ -52,6 +52,20 @@ TVM_REGISTER_GLOBAL("ir.BaseFuncWithAttr")
       }
     });
 
+TVM_REGISTER_GLOBAL("ir.BaseFuncWithAttrs")
+    .set_body_typed([](BaseFunc func, Map<String, ObjectRef> attr_map) -> BaseFunc {
+      if (func->IsInstance<tir::PrimFuncNode>()) {
+        return WithAttrs(Downcast<tir::PrimFunc>(std::move(func)), attr_map);
+      } else if (func->IsInstance<relay::FunctionNode>()) {
+        return WithAttrs(Downcast<relay::Function>(std::move(func)), attr_map);
+      } else if (func->IsInstance<relax::FunctionNode>()) {
+        return WithAttrs(Downcast<relax::Function>(std::move(func)), attr_map);
+      } else {
+        LOG(FATAL) << "Do not support function type " << func->GetTypeKey();
+        return func;
+      }
+    });
+
 TVM_REGISTER_GLOBAL("ir.BaseFuncWithoutAttr")
     .set_body_typed([](BaseFunc func, String key) -> BaseFunc {
       if (func->IsInstance<tir::PrimFuncNode>()) {

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -538,6 +538,14 @@ TVM_REGISTER_GLOBAL("ir.Module_WithAttr")
       return WithAttr(mod, key, value);
     });
 
+TVM_REGISTER_GLOBAL("ir.Module_WithoutAttr")
+    .set_body_typed([](IRModule mod, String key) -> IRModule { return WithoutAttr(mod, key); });
+
+TVM_REGISTER_GLOBAL("ir.Module_WithAttrs")
+    .set_body_typed([](IRModule mod, Map<String, ObjectRef> attr_map) -> IRModule {
+      return WithAttrs(mod, attr_map);
+    });
+
 TVM_REGISTER_GLOBAL("ir.Module_GetAttr").set_body_typed([](IRModule mod, String key) -> ObjectRef {
   return mod->GetAttr<ObjectRef>(key);
 });

--- a/src/relax/backend/task_extraction.cc
+++ b/src/relax/backend/task_extraction.cc
@@ -61,9 +61,17 @@ class TaskExtractor : public ExprVisitor {
 
   void VisitExpr_(const CallNode* call) final {
     static const Op& call_tir_op = Op::Get("relax.call_tir");
+
+    // TODO(@tvm-team): When we differentiate the call for tir function and packed function,
+    // this logic should be changed accordingly.
     if (!call->op.same_as(call_tir_op)) {
       // Since the Relax function is of A-normal form, the arguments of this call cannot be another
       // Calls. And hence we do not need to recurse into this Call.
+      return;
+    }
+
+    // Do not extract external function
+    if (call->args[0].as<ExternFuncNode>()) {
       return;
     }
 

--- a/src/relax/backend/task_extraction.cc
+++ b/src/relax/backend/task_extraction.cc
@@ -45,19 +45,22 @@ using tvm::meta_schedule::ExtractedTask;
 class TaskExtractor : public ExprVisitor {
  public:
   static Array<ExtractedTask> ExtractTask(IRModule mod, Target target) {
-    TaskExtractor extracor(mod, target);
+    TaskExtractor extractor(mod, target);
     // We go through each Relax function in the module.
     for (const auto& kv : mod->functions) {
       if (const auto* func = kv.second.as<FunctionNode>()) {
-        extracor(GetRef<Function>(func));
+        extractor(GetRef<Function>(func));
       }
     }
-    return std::move(extracor.tasks_);
+    return std::move(extractor.tasks_);
   }
 
  private:
   explicit TaskExtractor(IRModule mod, Target target)
-      : mod_(std::move(mod)), target_(std::move(target)) {}
+      : mod_(std::move(mod)), target_(std::move(target)) {
+    parse_mod_func_ = runtime::Registry::Get("tvm.meta_schedule.tune.parse_mod");
+    ICHECK(parse_mod_func_) << "Parse function is not found.";
+  }
 
   void VisitExpr_(const CallNode* call) final {
     static const Op& call_tir_op = Op::Get("relax.call_tir");
@@ -84,7 +87,7 @@ class TaskExtractor : public ExprVisitor {
       return;
     }
 
-    IRModule tir_mod({{global_var, func}});
+    IRModule tir_mod = (*parse_mod_func_)(func);
     ExtractedTask task(/*task_name=*/global_var->name_hint,  //
                        /*mod=*/tir_mod,                      //
                        /*target=*/target_,                   //
@@ -98,6 +101,7 @@ class TaskExtractor : public ExprVisitor {
   Target target_;
   Array<ExtractedTask> tasks_;
   std::unordered_map<tir::PrimFunc, ExtractedTask, StructuralHash, StructuralEqual> func2task_;
+  const runtime::PackedFunc* parse_mod_func_;
 };
 
 TVM_REGISTER_GLOBAL("relax.backend.MetaScheduleExtractTask")

--- a/src/relax/transform/meta_schedule.cc
+++ b/src/relax/transform/meta_schedule.cc
@@ -34,6 +34,8 @@ class MetaScheduleTuner {
       : target_(target), config_(config), work_dir_(work_dir), database_(database) {
     candgen_func_ = runtime::Registry::Get("relax.tuning_api.default_generate_candidate");
     ICHECK(candgen_func_) << "Default candidate generation function is not found.";
+    parse_mod_func_ = runtime::Registry::Get("tvm.meta_schedule.tune.parse_mod");
+    ICHECK(parse_mod_func_) << "Parse function is not found.";
   }
 
   // TODO(@sunggg): Currently, only supports basic arguments.
@@ -48,32 +50,24 @@ class MetaScheduleTuner {
     ICHECK(candidates.size() == 1);
     Trace best_trace = candidates[0];
     ctx->PushTrace(best_trace);
-    return best_trace->out_mod;
+    // since we separate tuning from application, return original IRModule
+    return mod;
   }
 
   // TODO(@sunggg): Currently, only supports basic arguments.
   tir::PrimFunc TuneTIR(tir::PrimFunc f, transform::PassContext ctx) {
-    auto parse_mod_func = runtime::Registry::Get("tvm.meta_schedule.tune.parse_mod");
-    ICHECK(parse_mod_func) << "Parse function is not found.";
     // TODO(@sunggg): Whenever we tune tir, assume we start a new trace w/o pushing to the trace
     // stack. Revisit later when we collect more usecases.
-    Trace trace = Trace((*parse_mod_func)(f), {}, {});
+    Trace trace = Trace((*parse_mod_func_)(f), {}, {});
 
     Choice choice("meta_schedule.tune_tir_with_tuning_api",
                   {target_, config_, work_dir_, database_},
                   "relax.tuning_api.Choice.default_constr_func", {});
-    Knob knob("meta_schedule.tune_irmod", {{"0", choice}});
+    Knob knob("meta_schedule.tune_primfunc", {{"0", choice}});
     Array<Trace> candidates = (*candgen_func_)(Array<Knob>({knob}), trace);
     ICHECK(candidates.size() == 1);
-    Trace best_trace = candidates[0];
-    auto gvars = best_trace->out_mod->GetGlobalVars();
-    ICHECK(gvars.size() == 1);
-    tvm::BaseFunc new_func = best_trace->out_mod->functions[gvars[0]];
-    ICHECK(new_func->IsInstance<tir::PrimFuncNode>());
-    tir::PrimFunc new_pf = Downcast<tir::PrimFunc>(new_func);
-    // Inherit the attr from the original primfunc
-    return tir::PrimFunc(new_pf->params, new_pf->body, new_pf->ret_type, new_pf->buffer_map,
-                         new_pf->preflattened_buffer_map, f->attrs, new_pf->span);
+    // since we separate tuning from application, return original IRModule
+    return f;
   }
 
  private:
@@ -81,39 +75,58 @@ class MetaScheduleTuner {
   Array<ObjectRef> config_;
   String work_dir_;
   const runtime::PackedFunc* candgen_func_;
+  const runtime::PackedFunc* parse_mod_func_;
   const tvm::meta_schedule::Database& database_;
 };
 
 class MetaScheduleAHB {
  public:
   explicit MetaScheduleAHB(const tvm::meta_schedule::Database& db, Target target)
-      : db_(db), target_(target) {}
+      : db_(db), target_(target) {
+    parse_mod_func_ = runtime::Registry::Get("tvm.meta_schedule.tune.parse_mod");
+    ICHECK(parse_mod_func_) << "Parse function is not found.";
+  }
   IRModule Apply(IRModule mod) {
-    IRModule ret_mod_ = IRModule();
+    IRModule ret_mod_ = IRModule({},         // functions
+                                 {},         // type_definitions
+                                 {},         // import_set
+                                 {},         // map
+                                 mod->attrs  // attrs
+    );
     tvm::meta_schedule::ApplyHistoryBest ahb(db_, nullptr, nullptr);
     for (auto& p : mod->functions) {
       GlobalVar gv = p.first;
       BaseFunc func = p.second;
       BaseFunc newfunc = func;
       if (func->IsInstance<tir::PrimFuncNode>()) {
-        IRModule tir_mod(Map<GlobalVar, BaseFunc>({{gv, func}}));
+        tir::PrimFunc primfunc = Downcast<tir::PrimFunc>(func);
+        // Global symbol has to be defined.
+        Optional<String> gsymbol = primfunc->GetAttr<String>(tvm::attr::kGlobalSymbol);
+        ICHECK(gsymbol.defined());
+
+        IRModule tir_mod = (*parse_mod_func_)(primfunc);
         ObjectRef res =
             ahb->Query(gv->name_hint, mod, target_, Array<IRModule>{tir_mod}, nullptr, nullptr);
         // replace the tir func only when the schedule is found in tuning database.
         if (res.defined()) {
           IRModule newmod = Downcast<IRModule>(res);
           ICHECK_EQ(newmod->functions.size(), 1);
-          newfunc = (*newmod->functions.begin()).second;
+          auto tunedfunc = (*newmod->functions.begin()).second;
+          ICHECK(tunedfunc->IsInstance<tir::PrimFuncNode>());
+          tir::PrimFunc newprimfunc = Downcast<tir::PrimFunc>(tunedfunc);
+          // copy the original attrs
+          newfunc = WithAttrs(std::move(newprimfunc), {primfunc->attrs->dict});
         }
       }
-
       ret_mod_->Add(gv, newfunc);
     }
+
     return ret_mod_;
   }
 
  private:
   const tvm::meta_schedule::Database& db_;
+  const runtime::PackedFunc* parse_mod_func_;
   Target target_;
 };
 

--- a/src/relax/transform/meta_schedule.cc
+++ b/src/relax/transform/meta_schedule.cc
@@ -87,12 +87,12 @@ class MetaScheduleAHB {
     ICHECK(parse_mod_func_) << "Parse function is not found.";
   }
   IRModule Apply(IRModule mod) {
-    IRModule ret_mod_ = IRModule({},         // functions
-                                 {},         // type_definitions
-                                 {},         // import_set
-                                 {},         // map
-                                 mod->attrs  // attrs
-    );
+    IRModule ret_mod_ = IRModule({},           // functions
+                                 {},           // type_definitions
+                                 {},           // import_set
+                                 {},           // map
+                                 mod->attrs);  // attrs
+
     tvm::meta_schedule::ApplyHistoryBest ahb(db_, nullptr, nullptr);
     for (auto& p : mod->functions) {
       GlobalVar gv = p.first;

--- a/src/relax/transform/tuning_api/primitives.cc
+++ b/src/relax/transform/tuning_api/primitives.cc
@@ -148,7 +148,9 @@ Trace::Trace() { data_ = make_object<TraceNode>(); }
 Trace::Trace(IRModule in_mod, Array<Knob> knobs, Array<String> decisions) {
   ICHECK(knobs.size() == decisions.size()) << "Size of knobs and decisions should match";
   // Deep-copy IRModule
-  IRModule out_mod = meta_schedule::DeepCopyIRModule(in_mod);
+  auto func_deepcopy = runtime::Registry::Get("relax.tuning_api.deepcopy_irmodule");
+  ICHECK(func_deepcopy);
+  IRModule out_mod = (*func_deepcopy)(in_mod);
   // Apply the decision history if provided
   int size = knobs.size();
   for (int i = 0; i < size; i++) {

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -509,8 +509,7 @@ String Executable::AsText() const {
           break;
         }
         case Opcode::Goto: {
-          os << std::setw(6) << std::left << "goto"
-             << "goto " << instr.pc_offset << "\n";
+          os << std::setw(6) << std::left << "goto" << instr.pc_offset << "\n";
           break;
         }
         case Opcode::If: {

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -505,8 +505,7 @@ String Executable::AsText() const {
           break;
         }
         case Opcode::Ret: {
-          os << std::setw(6) << std::left << "ret"
-             << "ret " << RegNameToStr(instr.result) << "\n";
+          os << std::setw(6) << std::left << "ret " << RegNameToStr(instr.result) << "\n";
           break;
         }
         case Opcode::Goto: {

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -375,6 +375,7 @@ void VirtualMachine::RunInstrCall(VMFrame* curr_frame, Instruction instr) {
   if (instr.dst != Instruction::kVoidArg) {
     WriteRegister(curr_frame, instr.dst, ret);
   }
+  // curr_frame->caller_return_register = instr.dst;
   pc_++;
 }
 

--- a/tests/python/relax/test_transform_codegen_pass.py
+++ b/tests/python/relax/test_transform_codegen_pass.py
@@ -76,12 +76,12 @@ def check_roundtrip(exec0, dev, inputs, expected):
 
 def gen_ground_truth(mod, target, dev, inputs):
     # Lower and run tuning
-    # Since there is no default schedule for MS, this is necessary
+    # Since there is no default schedule for GPU in MS yet, this is necessary
     with tempfile.TemporaryDirectory() as work_dir:
         with tvm.transform.PassContext(trace=Trace(mod), opt_level=0):
             seq = tvm.transform.Sequential(
                 [
-                    relax.testing.transform.LowerWithRelayOpStrategyPass(target),
+                    transform.LowerWithRelayOpStrategyPass(target),
                     relax.transform.MetaScheduleTuneIRMod(
                         target,
                         config=tune_config,
@@ -98,6 +98,7 @@ def gen_ground_truth(mod, target, dev, inputs):
     return vm["main"](*inputs)
 
 
+@tvm.testing.requires_gpu
 def test_single_annot_func():
     @tvm.script.ir_module
     class InputModule:
@@ -156,6 +157,7 @@ def test_single_annot_func():
     # tvm.ir.assert_structural_equal(mod, new_mod)
 
 
+@tvm.testing.requires_gpu
 def test_mix_use_tensorrt_and_tvm():
     @tvm.script.ir_module
     class InputModule:
@@ -208,7 +210,7 @@ def test_mix_use_tensorrt_and_tvm():
                 [
                     relax.transform.RunCodegen(),
                     relax.transform.RemoveUnusedFunctions(),
-                    relax.testing.transform.LowerWithRelayOpStrategyPass(target),
+                    transform.LowerWithRelayOpStrategyPass(target),
                     relax.transform.MetaScheduleTuneIRMod(
                         target,
                         config=tune_config,

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -954,8 +954,9 @@ def test_recursion():
                 gv0 = relax.call_packed(
                     "test.vm.subtract_one", n, type_args=(Tensor(ndim=1, dtype="float32"))
                 )
+                tmp = recursion(gv0)
                 res = relax.call_packed(
-                    "test.vm.add", recursion(gv0), n, type_args=(Tensor(ndim=1, dtype="float32"))
+                    "test.vm.add", tmp, tmp, type_args=(Tensor(ndim=1, dtype="float32"))
                 )
             return res
 


### PR DESCRIPTION
This PR fixes couple of bugs identified with the test for the codegen pass of mix-using TVM and BYOC code. 

### List of fixes/changes
* Enhance API regarding IRModule/BaseFunc attributes
* Make passes preserve the IRModule/Function attributes
* Support the deepcopy of IRModule with the presence of BYOC `runtime::Module` in the `external_mod` attribute.
* Minor bug fix in `LowerWithRelayOpStrategyPass` to handle non-DNN operators like `PackedFunc`.
* Format unification of input IRModule for `TuneTIR` and `TuneIRModule` - always use `runtime::Registry::Get("tvm.meta_schedule.tune.parse_mod")`
* Bug fix in codegen pass: update the uses of old variable with the new variable. 
* Minor bug fix in Relax VM executable regarding print format of `return` and `goto`
* Bug fix in Relax VM: update the caller return register every function invocation.
* Bug fix in the recursion test in `test_vm.py`

### Future PRs
* will add more exhaustive test cases with the improvements in parser and operator set. See [example](https://github.com/sunggg/relax/blob/b0786b14a44c2064ddda0fbd5ebcc58f43ceb8cb/tests/python/relax/test_transform_codegen_pass.py#L154)

cc. @YuchenJin @yongwww 
