### PR TITLE
[TVMScript] B2: match shape support

### DIFF
--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -126,6 +126,17 @@ TVM_DLL BlockFrame Dataflow();
  */
 TVM_DLL tvm::relax::Var Emit(const tvm::relax::Expr& value);
 
+/*!
+ * \brief Emit a match_shape binding to the last binding block frame.
+ * \param value The value of the MatchShape to be emitted.
+ * \param pattern The pattern of the MatchShape to be emitted.
+ * \param emit_var The flag that indicate if the match_shape contains the emitted var.
+ * \return The emitted var if `emit_var` is true, otherwise, `NullOpt`.
+ */
+TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value,
+                                                 const Array<PrimExpr>& pattern,
+                                                 bool emit_var = true);
+
 }  // namespace relax
 }  // namespace ir_builder
 }  // namespace script

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -200,6 +200,12 @@ def emit(value: Expr) -> Var:
     return _ffi_api.Emit(value)  # type: ignore
 
 
+def emit_match_shape(value: Expr, pattern: List[PrimExpr], emit_var: bool = True) -> Var:
+    return _ffi_api.EmitMatchShape(value, pattern, emit_var)  # type: ignore
+
+
+############################### Importer ###############################
+
 __all__ = [
     "TensorType",
     "add",
@@ -209,6 +215,7 @@ __all__ = [
     "call_tir",
     "dataflow",
     "emit",
+    "emit_match_shape",
     "func_attr",
     "func_name",
     "func_ret_type",

--- a/python/tvm/script/parser/relax/__init__.py
+++ b/python/tvm/script/parser/relax/__init__.py
@@ -18,7 +18,7 @@
 from ...ir_builder.relax import *  # pylint: disable=redefined-builtin
 from ...ir_builder.relax import ir as _relax
 from . import parser as _parser
-from .entry import function, Tensor
+from .entry import function, Tensor, match_shape
 
 
-__all__ = _relax.__all__ + ["function", "Tensor"]
+__all__ = _relax.__all__ + ["function", "Tensor", "match_shape"]

--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -18,7 +18,7 @@
 import inspect
 from typing import Callable, List, Optional, Union, TypeVar
 
-from tvm.relax import Function, Var
+from tvm.relax import Function, Var, Expr
 from tvm.tir import PrimExpr
 
 from ...ir_builder.relax import tensor, TensorType
@@ -54,3 +54,16 @@ class TensorProxy:
 
 
 Tensor = TensorProxy()  # pylint: disable=invalid-name
+
+
+class MatchShapePair:
+    value: Expr
+    pattern: List[PrimExpr]
+
+    def __init__(self, value: Expr, pattern: List[PrimExpr]) -> None:
+        self.value = value
+        self.pattern = pattern
+
+
+def match_shape(value: Expr, pattern: List[PrimExpr]):
+    return MatchShapePair(value, pattern)

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -132,6 +132,10 @@ def visit_return(self: Parser, node: doc.Assign) -> None:
     elif isinstance(value, Tuple):
         if all([isinstance(f, tir.PrimExpr) for f in value]):
             R.func_ret_value(relax.ShapeExpr(value))
+        elif any([isinstance(f, tir.PrimExpr) for f in value]):
+            self.report_error(
+                node, "Return types, with mixed PrimExpr and Relax Expr, is not supported."
+            )
         else:
             R.func_ret_value(relax.Tuple(value))
     else:

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -133,6 +133,6 @@ def visit_return(self: Parser, node: doc.Assign) -> None:
         if all([isinstance(f, tir.PrimExpr) for f in value]):
             R.func_ret_value(relax.ShapeExpr(value))
         else:
-            R.func_ret_value(relax.Tuple(*value))
+            R.func_ret_value(relax.Tuple(value))
     else:
         self.report_error(node, f"Unsupported return value type {type(value)}.")

--- a/python/tvm/script/parser/tir/operation.py
+++ b/python/tvm/script/parser/tir/operation.py
@@ -45,12 +45,12 @@ def _register_expr_op(ty: Type):  # pylint: disable=invalid-name
 
     for i in [0, 1]:
         # Case 1. binop
-        r(doc.Add, i, tir.Add)
-        r(doc.Sub, i, tir.Sub)
-        r(doc.Mult, i, tir.Mul)
-        r(doc.Div, i, tir.Div)
-        r(doc.FloorDiv, i, tir.FloorDiv)
-        r(doc.Mod, i, tir.FloorMod)
+        r(doc.Add, i, lambda a, b: a + b)
+        r(doc.Sub, i, lambda a, b: a - b)
+        r(doc.Mult, i, lambda a, b: a * b)
+        r(doc.Div, i, lambda a, b: a / b)
+        r(doc.FloorDiv, i, lambda a, b: a // b)
+        r(doc.Mod, i, lambda a, b: a % b)
         r(doc.LShift, i, lambda a, b: a << b)
         r(doc.RShift, i, lambda a, b: a >> b)
         r(doc.BitOr, i, lambda a, b: a | b)

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -37,6 +37,7 @@ TVM_STATIC_IR_FUNCTOR(Namer, vtable)
     });
 
 ////////////////////////////// Tensor Type //////////////////////////////
+
 TensorType::TensorType(tvm::relax::DynTensorType type, Optional<tvm::relax::Expr> shape) {
   auto n = make_object<TensorTypeNode>();
   n->type = std::move(type);
@@ -141,7 +142,21 @@ tvm::relax::Var Emit(const tvm::relax::Expr& value) {
   return block_builder->Emit(value);
 }
 
+TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value,   //
+                                                 const Array<PrimExpr>& pattern,  //
+                                                 bool emit_var) {
+  tvm::relax::BlockBuilder block_builder = GetBlockBuilder();
+  if (emit_var) {
+    return block_builder->EmitMatchShape(value, pattern);
+  } else {
+    tvm::relax::MatchShape match_shape(value, pattern, tvm::relax::Var{nullptr});
+    block_builder->EmitMatchShape(match_shape);
+    return NullOpt;
+  }
+}
+
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.Emit").set_body_typed(Emit);
+TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchShape").set_body_typed(EmitMatchShape);
 
 }  // namespace relax
 }  // namespace ir_builder

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -200,6 +200,7 @@ def test_match_shape():
         bb.emit_func_output(relax.ShapeExpr([m, n * 2]))
     _check(foo, bb.get()["foo"])
 
+
 def test_tuple_return():
     @R.function
     def foo(x: R.Tensor((4, 4), "float32")):

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -200,6 +200,22 @@ def test_match_shape():
         bb.emit_func_output(relax.ShapeExpr([m, n * 2]))
     _check(foo, bb.get()["foo"])
 
+def test_tuple_return():
+    @R.function
+    def foo(x: R.Tensor((4, 4), "float32")):
+        gv0 = R.call_tir("extern_func_0", x, (4, 4), dtype="float32")
+        gv1 = R.call_tir("extern_func_1", x, (4, 4), dtype="float32")
+        return (gv0, gv1)
+
+    x = relax.Var("x", [4, 4], relax.DynTensorType(2, "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", (x,)):
+        gv0 = bb.emit(relax.call_tir("extern_func_0", x, (4, 4), dtype="float32"))
+        gv1 = bb.emit(relax.call_tir("extern_func_1", x, (4, 4), dtype="float32"))
+        bb.emit_func_output(relax.Tuple((gv0, gv1)))
+
+    _check(foo, bb.get()["foo"])
+
 
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -180,5 +180,26 @@ def test_shadowing():
     _check(foo, bb.get()["foo"])
 
 
+def test_match_shape():
+    @R.function
+    def foo(x: R.Tensor(None, "float32"), y: R.Tensor(None, "float32")):
+        m = T.var("int64")
+        n = T.var("int64")
+        R.match_shape(x, (m,))
+        y1 = R.match_shape(y, (n,))
+        return (m, n * 2)
+
+    x = relax.Var("x", type_annotation=relax.DynTensorType(-1, "float32"))
+    y = relax.Var("y", type_annotation=relax.DynTensorType(-1, "float32"))
+    m = tir.Var("m", dtype="int64")
+    n = tir.Var("n", dtype="int64")
+    bb = relax.BlockBuilder()
+    with bb.function("foo", (x, y)):
+        bb.match_shape_binding(relax.MatchShape(x, (m,), var=None))
+        y1 = bb.match_shape(y, (n,))
+        bb.emit_func_output(relax.ShapeExpr([m, n * 2]))
+    _check(foo, bb.get()["foo"])
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR features `match_shape` support, which contains:
- MatchShape support for both var emitting and non-emitting cases
- Allow TIR operators dtype broadcasting. (e.g. `i64 * i32`)

Co-authored-by: Ruihang Lai <lairuihangdongdong@qq.com>

cc @yongwww @YuchenJin 