### PR TITLE
[Expr] Allow annotating return shape on function nodes

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -57,6 +57,18 @@ TVM_DLL bool WellFormed(const IRModule& m,
 TVM_DLL relay::OpPatternKind AnalyzeOpPatternKind(const tir::PrimFunc& func);
 
 /*!
+ * \brief Gather all shape variables from expression expr.
+ *
+ * This analysis is intended to be called on shape expressions (those set as the shape_ of another
+ * expression).
+ *
+ * \param expr the expression. Meant to be a shape expression.
+ *
+ * \return List of shape variables (tir::Var)
+ */
+TVM_DLL tvm::Array<tir::Var> ShapeVars(const Expr& expr);
+
+/*!
  * \brief Get all bound variables from expression expr.
  *
  * Bound variables are all variables that are declared in the expr.
@@ -165,6 +177,17 @@ std::pair<Map<Var, Array<Var>>, Array<Var>> FunctionUseDef(const Function& fn);
  * \return The function that contains no unused statements in DataflowBlock.
  */
 TVM_DLL Function RemoveAllUnused(const Function fn);
+
+/*!
+ * \brief Given the argument vars and body, derives a return shape for a function with those args
+ * and that body. If the body's shape contains free shape vars (those not used in the args), the
+ * return shape is relaxed to RuntimeDepShape; otherwise, the body's shape is used.
+ *
+ * \param args The argument variables, ideally with the shape_ field filled in
+ * \param body The functino body, ideally with the shape_ field filled in
+ * \return An expression that can serve as the return shape for the function
+ */
+TVM_DLL Expr DeriveFuncRetShape(Array<Var> args, Expr body);
 
 }  // namespace relax
 }  // namespace tvm

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -415,11 +415,14 @@ class FunctionNode : public BaseFuncNode {
   Expr body;
   /*! \brief The return type of the function. */
   Type ret_type;
+  /*! \brief The return shape of the function. */
+  Expr ret_shape;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("params", &params);
     v->Visit("body", &body);
     v->Visit("ret_type", &ret_type);
+    v->Visit("ret_shape", &ret_shape);
     v->Visit("_checked_type_", &checked_type_);
     v->Visit("shape_", &shape_);
     v->Visit("span", &span);
@@ -429,8 +432,9 @@ class FunctionNode : public BaseFuncNode {
   bool SEqualReduce(const FunctionNode* other, SEqualReducer equal) const {
     equal->MarkGraphNode();
     return equal.DefEqual(params, other->params) && equal(body, other->body) &&
-           equal(ret_type, other->ret_type) && equal(checked_type_, other->checked_type_) &&
-           equal(shape_, other->shape_) && equal(attrs, other->attrs);
+           equal(ret_type, other->ret_type) && equal(ret_shape, other->ret_shape) &&
+           equal(checked_type_, other->checked_type_) && equal(shape_, other->shape_) &&
+           equal(attrs, other->attrs);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
@@ -438,6 +442,7 @@ class FunctionNode : public BaseFuncNode {
     hash_reduce.DefHash(params);
     hash_reduce(body);
     hash_reduce(ret_type);
+    hash_reduce(ret_shape);
     hash_reduce(checked_type_);
     hash_reduce(shape_);
     hash_reduce(attrs);
@@ -451,14 +456,14 @@ class FunctionNode : public BaseFuncNode {
 
 class Function : public BaseFunc {
  public:
-  TVM_DLL explicit Function(Array<Var> params, Expr body, Type ret_type,
+  TVM_DLL explicit Function(Array<Var> params, Expr body, Type ret_type, Expr ret_shape,
                             DictAttrs attrs = NullValue<DictAttrs>(), Span span = Span());
 
   /*!
    * \brief Mimics the constructor but without type checking.
    */
   TVM_DLL static Function CreateUnchecked(Array<Var> params, Expr body, Type ret_type,
-                                          DictAttrs attrs = NullValue<DictAttrs>(),
+                                          Expr ret_shape, DictAttrs attrs = NullValue<DictAttrs>(),
                                           Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Function, BaseFunc, FunctionNode);

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -24,6 +24,7 @@ configuring the passes and scripting them in Python.
 from typing import Dict, List
 
 import tvm
+from tvm import tir
 from tvm.relax.expr import DataflowBlock, Var, Expr, Function, Binding
 from . import _ffi_api
 
@@ -113,3 +114,46 @@ def remove_all_unused(func: Function) -> Function:
         The function with unused variables removed.
     """
     return _ffi_api.remove_all_unused(func)
+
+
+def shape_vars(expr: Expr) -> List[tir.Var]:
+    """
+    Returns all shape variables (TIR variables) in the given expression.
+
+    Note that the expression is intended to be a shape expression, i.e.,
+    one used as the `shape_` for another expression.
+
+    Parameters
+    ----------
+    expr : Expr
+        The expression. Meant to be a shape expression.
+
+    Returns
+    -------
+    ret: List[tir.Var]
+        A list of all shape variables (TIR variables) in the expression.
+    """
+    return _ffi_api.shape_vars(expr)
+
+
+def derive_func_ret_shape(args: List[Var], body: Expr) -> Expr:
+    """
+    Given the argument vars and body, derives a return shape for
+    a function with those args and that body.
+    If the body's shape contains free shape vars (those not used in the args), the
+    return shape is relaxed to RuntimeDepShape; otherwise, the body's shape is used.
+
+    Parameters
+    ----------
+    args: List[Var]
+        The argument variables, ideally with the shape_ field filled in
+
+    body: Expr
+        The functino body, ideally with the shape_ field filled in
+
+    Returns
+    -------
+    ret: Expr
+        An expression that can serve as the return shape for the function
+    """
+    return _ffi_api.derive_func_ret_shape(args, body)

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -590,7 +590,8 @@ class BlockBuilder(Object):
 
         # The function's checked_type_ relies on the function body(seqe) to have deduced type
         # TODO(@yuchen): handle the case where the body's checked_type_ is null
-        func = rx.Function(self._func_params, seqe, None)
+        # TODO: Deduce the ret shape too
+        func = rx.Function(self._func_params, seqe, None, rx.RuntimeDepShape())
         func = func.with_attr("global_symbol", self._func_name)
         for key, value in self._func_attrs.items():
             func = func.with_attr(key, value)

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -190,6 +190,7 @@ class Function(BaseFunc):
     params: List[Var]
     body: Expr
     ret_type: Type
+    ret_shape: Expr
     attrs: Optional[tvm.ir.DictAttrs]
 
     def __init__(
@@ -197,21 +198,25 @@ class Function(BaseFunc):
         params: List[Var],
         body: Expr,
         ret_type: Type,
+        ret_shape: Expr,
         attrs: Optional[tvm.ir.DictAttrs] = None,
         span: Optional[Span] = None,
     ) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.Function, params, body, ret_type, attrs, span)
+        self.__init_handle_by_constructor__(
+            _ffi_api.Function, params, body, ret_type, ret_shape, attrs, span
+        )
 
     @staticmethod
     def create_unchecked(
         params: List[Var],
         body: Expr,
         ret_type: Type,
+        ret_shape: Expr,
         attrs: Optional[tvm.ir.DictAttrs] = None,
         span: Optional[Span] = None,
     ):
         """Construct a relax.Function but without type checking."""
-        return _ffi_api.Function_CreateUnchecked(params, body, ret_type, attrs, span)
+        return _ffi_api.Function_CreateUnchecked(params, body, ret_type, ret_shape, attrs, span)
 
     def __call__(self, *args):
         """Invoke the global function.

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -147,6 +147,7 @@ class ASTPrinter(ExprFunctor):
         fields = {
             "params": self.build_list(map(self.visit_expr, op.params)),
             "body": self.visit_expr(op.body),
+            "ret_shape": self.visit_expr(op.ret_shape),
         }
         if op.ret_type:
             fields["ret_type"] = self.visit_type_(op.ret_type)

--- a/python/tvm/relax/transform/fma_rewrite.py
+++ b/python/tvm/relax/transform/fma_rewrite.py
@@ -20,7 +20,7 @@ from tvm.ir import Op
 from tvm.ir.module import IRModule
 from tvm.ir.transform import module_pass
 from ..expr_functor import mutator, PyExprMutator
-from ..expr import Call, Function, Var
+from ..expr import Call, Function, Var, RuntimeDepShape
 from ..transform import dataflowblock_pass
 
 
@@ -113,7 +113,8 @@ class EwiseFuseFMAMutator(PyExprMutator):
                 body = Call(ewise_fma_op, [x, y, z])
 
                 func_name = "ewise_fma_fused"
-                func = Function([x, y, z], body, call.args[1]._checked_type_)
+                # TODO: Possibly fill in the return shape
+                func = Function([x, y, z], body, call.args[1]._checked_type_, RuntimeDepShape())
                 ewise_fma_fused = func.with_attr("global_symbol", func_name)
                 normalized = self.builder_.normalize(ewise_fma_fused)
                 global_var = self.builder_.add_func(normalized, "ewise_fma_fused")

--- a/python/tvm/script/parser_v1/relax/parser.py
+++ b/python/tvm/script/parser_v1/relax/parser.py
@@ -680,6 +680,8 @@ class RelaxTransformer(Transformer):
             params,
             new_body,
             ret_type,
+            # TODO: Parse ret shape
+            relax.RuntimeDepShape(),
             attrs=None,
             span=self.to_tvm_span(func.span),
         )

--- a/src/relax/analysis/func_ret_shape.cc
+++ b/src/relax/analysis/func_ret_shape.cc
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <tvm/relax/analysis.h>
+#include <tvm/relax/expr.h>
+#include <tvm/relax/expr_functor.h>
+
+namespace tvm {
+namespace relax {
+
+Expr DeriveFuncRetShape(Array<Var> args, Expr body) {
+  std::unordered_set<tir::Var, ObjectPtrHash, ObjectPtrEqual> arg_shape_var_set;
+  for (auto v : args) {
+    if (const ExprNode* s = v->shape_.as<ExprNode>()) {
+      Expr shape = GetRef<Expr>(s);
+      Array<tir::Var> arg_shape_vars = ShapeVars(shape);
+      for (auto v : arg_shape_vars) {
+        arg_shape_var_set.insert(v);
+      }
+    }
+  }
+
+  if (const ExprNode* s = body->shape_.as<ExprNode>()) {
+    Expr body_shape = GetRef<Expr>(s);
+    Array<tir::Var> body_shape_vars = ShapeVars(body_shape);
+    for (auto v : body_shape_vars) {
+      // if the body shape contains a free var, then we can't
+      // be more specific than RuntimeDepShape
+      if (arg_shape_var_set.count(v) == 0) {
+        return RuntimeDepShape();
+      }
+    }
+    // all vars are defined in the args, so we can use the body shape
+    return body_shape;
+  }
+  return RuntimeDepShape();
+}
+
+TVM_REGISTER_GLOBAL(("relax.analysis.derive_func_ret_shape")).set_body_typed(DeriveFuncRetShape);
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -121,6 +121,8 @@ class VMShapeLowerMutator : public ExprMutator {
     new_body = builder_->Normalize(SeqExpr(blocks, new_body));
 
     Type ret_type = this->VisitType(node->ret_type);
+    // should not be necessary to do anything with it
+    Expr ret_shape = node->ret_shape;
 
     // Because this pass is the last stage of build, ndim info is no longer needed for tensors.
     // The ret_type is weakened to unknown-dimensional DynTensorType.
@@ -129,7 +131,7 @@ class VMShapeLowerMutator : public ExprMutator {
       ret_type = DynTensorType::CreateUnknownNDim(temp->dtype, Span());
     }
 
-    return Function(node->params, new_body, ret_type, node->attrs);
+    return Function(node->params, new_body, ret_type, ret_shape, node->attrs);
   }
 
   tir::PrimFunc CalculateShape(ShapeExpr s) {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -101,7 +101,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     if (new_body.same_as(op->body)) {
       func = GetRef<Function>(op);
     } else {
-      func = Function(op->params, new_body, op->ret_type, op->attrs);
+      func = Function(op->params, new_body, op->ret_type, op->ret_shape, op->attrs);
     }
 
     // NOTE: the shape_ of Function is left as null for now, to be consitent with

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -199,7 +199,8 @@ TVM_REGISTER_GLOBAL("relax.SeqExpr")
 
 TVM_REGISTER_NODE_TYPE(FunctionNode);
 
-Function::Function(Array<Var> params, Expr body, Type ret_type, DictAttrs attrs, Span span) {
+Function::Function(Array<Var> params, Expr body, Type ret_type, Expr ret_shape, DictAttrs attrs,
+                   Span span) {
   // Set the function type.
   // For function, we take a conservative approach and require the function type
   // to be known at construction time.
@@ -233,6 +234,7 @@ Function::Function(Array<Var> params, Expr body, Type ret_type, DictAttrs attrs,
   n->params = std::move(params);
   n->body = std::move(body);
   n->ret_type = std::move(ret_type);
+  n->ret_shape = std::move(ret_shape);
   n->checked_type_ = std::move(func_type);
   n->attrs = std::move(attrs);
   n->span = std::move(span);
@@ -240,12 +242,13 @@ Function::Function(Array<Var> params, Expr body, Type ret_type, DictAttrs attrs,
 }
 
 TVM_REGISTER_GLOBAL("relax.Function")
-    .set_body_typed([](Array<Var> params, Expr body, Type ret_type, DictAttrs attrs, Span span) {
-      return Function(params, body, ret_type, attrs, span);
+    .set_body_typed([](Array<Var> params, Expr body, Type ret_type, Expr ret_shape, DictAttrs attrs,
+                       Span span) {
+      return Function(params, body, ret_type, ret_shape, attrs, span);
     });
 
-Function Function::CreateUnchecked(Array<Var> params, Expr body, Type ret_type, DictAttrs attrs,
-                                   Span span) {
+Function Function::CreateUnchecked(Array<Var> params, Expr body, Type ret_type, Expr ret_shape,
+                                   DictAttrs attrs, Span span) {
   for (Var param : params) {
     ICHECK(param->checked_type_.defined())
         << "relax.Function requires params to contain checked_type_.";
@@ -256,14 +259,16 @@ Function Function::CreateUnchecked(Array<Var> params, Expr body, Type ret_type, 
   n->params = std::move(params);
   n->body = std::move(body);
   n->ret_type = std::move(ret_type);
+  n->ret_shape = std::move(ret_shape);
   n->attrs = std::move(attrs);
   n->span = std::move(span);
   return Function(std::move(n));
 }
 
 TVM_REGISTER_GLOBAL("relax.Function_CreateUnchecked")
-    .set_body_typed([](Array<Var> params, Expr body, Type ret_type, DictAttrs attrs, Span span) {
-      return Function::CreateUnchecked(params, body, ret_type, attrs, span);
+    .set_body_typed([](Array<Var> params, Expr body, Type ret_type, Expr ret_shape, DictAttrs attrs,
+                       Span span) {
+      return Function::CreateUnchecked(params, body, ret_type, ret_shape, attrs, span);
     });
 
 TVM_REGISTER_NODE_TYPE(ExternFuncNode);

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -251,11 +251,12 @@ Expr ExprMutatorBase::VisitExpr_(const DataflowVarNode* op) { return GetRef<Expr
 
 Expr ExprMutatorBase::VisitExpr_(const FunctionNode* op) {
   Expr body = this->VisitExpr(op->body);
+  Expr ret_shape = this->VisitExpr(op->ret_shape);
 
   if (body.same_as(op->body)) {
     return GetRef<Expr>(op);
   } else {
-    return Function(op->params, body, op->ret_type, op->attrs);
+    return Function(op->params, body, op->ret_type, op->ret_shape, op->attrs);
   }
 }
 
@@ -418,12 +419,14 @@ Expr ExprMutator::VisitExpr_(const FunctionNode* op) {
   }
 
   Type ret_type = this->VisitType(op->ret_type);
+  Expr ret_shape = this->VisitExpr(op->ret_shape);
   Expr body = this->VisitWithNewScope(op->body);
 
-  if (all_params_unchanged && ret_type.same_as(op->ret_type) && body.same_as(op->body)) {
+  if (all_params_unchanged && ret_type.same_as(op->ret_type) && body.same_as(op->body) &&
+      ret_shape.same_as(op->ret_shape)) {
     return GetRef<Expr>(op);
   } else {
-    return Function(params, body, ret_type, op->attrs);
+    return Function(params, body, ret_type, ret_shape, op->attrs);
   }
 }
 

--- a/src/relax/transform/fma_rewrite.cc
+++ b/src/relax/transform/fma_rewrite.cc
@@ -126,7 +126,7 @@ class EwiseFuseFMAMutator : public ExprMutator {
         Expr body = Call(ewise_fma_op, {x, y, z});
 
         String func_name = "ewise_fma_fused";
-        Function func = Function({x, y, z}, body, call->args[1]->checked_type_);
+        Function func = Function({x, y, z}, body, call->args[1]->checked_type_, RuntimeDepShape());
         Expr ewise_fma_fused = WithAttr(std::move(func), "global_symbol", func_name);
         Expr normalized = builder_->Normalize(ewise_fma_fused);
         GlobalVar global_var1 =

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -447,6 +447,7 @@ class FunctionCreator : public ExprMutator {
     function_ = Function(/*params=*/params_,  //
                          /*body=*/body,       //
                          /*ret_type=*/body->checked_type_,
+                         /*ret_shape=*/Expr(),
                          /*attrs=*/DictAttrs(attrs));
   }
 

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -447,7 +447,7 @@ class FunctionCreator : public ExprMutator {
     function_ = Function(/*params=*/params_,  //
                          /*body=*/body,       //
                          /*ret_type=*/body->checked_type_,
-                         /*ret_shape=*/Expr(),
+                         /*ret_shape=*/RuntimeDepShape(),
                          /*attrs=*/DictAttrs(attrs));
   }
 

--- a/src/relax/transform/lambda_lift.cc
+++ b/src/relax/transform/lambda_lift.cc
@@ -132,7 +132,7 @@ class LambdaLifter : public ExprMutator {
       visited_func = GetRef<Expr>(func_node);
     } else if (body->checked_type_.as<ObjectTypeNode>()) {
       // make_closure was introduced
-      // TODO: Determine if we can fill in the return shape
+      // TODO(@sslyu): Determine if we can fill in the return shape
       visited_func =
           Function(params, body, body->checked_type_, RuntimeDepShape(), func_node->attrs);
     } else {

--- a/src/relax/transform/lambda_lift.cc
+++ b/src/relax/transform/lambda_lift.cc
@@ -132,9 +132,10 @@ class LambdaLifter : public ExprMutator {
       visited_func = GetRef<Expr>(func_node);
     } else if (body->checked_type_.as<ObjectTypeNode>()) {
       // make_closure was introduced
-      visited_func = Function(params, body, body->checked_type_, func_node->attrs);
+      // TODO: Determine if we can fill in the return shape
+      visited_func = Function(params, body, body->checked_type_, RuntimeDepShape(), func_node->attrs);
     } else {
-      visited_func = Function(params, body, func_node->ret_type, func_node->attrs);
+      visited_func = Function(params, body, func_node->ret_type, RuntimeDepShape(), func_node->attrs);
     }
     auto new_func = Downcast<Function>(visited_func);
 
@@ -145,6 +146,7 @@ class LambdaLifter : public ExprMutator {
           /*params=*/new_func->params,
           /*body=*/new_func->body,
           /*ret_type=*/new_func->ret_type,
+          /*ret_shape=*/new_func->ret_shape,
           /*attrs=*/new_func->attrs,
           /*span=*/new_func->span);
     } else {
@@ -161,6 +163,7 @@ class LambdaLifter : public ExprMutator {
       lifted_func = Function(/*params=*/closure_params,
                              /*body=*/Bind(new_func->body, rebinding_map),
                              /*ret_type=*/new_func->ret_type,
+                             /*ret_shape=*/new_func->ret_shape,
                              /*attrs=*/new_func->attrs,
                              /*span=*/func->span);
 
@@ -231,7 +234,8 @@ class LambdaLifter : public ExprMutator {
     for (auto pair : glob_funcs) {
       if (auto* n = pair.second.as<FunctionNode>()) {
         auto func = GetRef<Function>(n);
-        func = Function(func->params, VisitExpr(func->body), func->ret_type, func->attrs);
+        func = Function(func->params, VisitExpr(func->body), func->ret_type, func->ret_shape,
+                        func->attrs);
         builder_->UpdateFunction(pair.first, func);
       }
     }

--- a/src/relax/transform/lambda_lift.cc
+++ b/src/relax/transform/lambda_lift.cc
@@ -133,9 +133,11 @@ class LambdaLifter : public ExprMutator {
     } else if (body->checked_type_.as<ObjectTypeNode>()) {
       // make_closure was introduced
       // TODO: Determine if we can fill in the return shape
-      visited_func = Function(params, body, body->checked_type_, RuntimeDepShape(), func_node->attrs);
+      visited_func =
+          Function(params, body, body->checked_type_, RuntimeDepShape(), func_node->attrs);
     } else {
-      visited_func = Function(params, body, func_node->ret_type, RuntimeDepShape(), func_node->attrs);
+      visited_func =
+          Function(params, body, func_node->ret_type, RuntimeDepShape(), func_node->attrs);
     }
     auto new_func = Downcast<Function>(visited_func);
 

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -60,7 +60,8 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
       return expr;
     }
     // The checked_type_ of the new function is deduced from the function body
-    return Function(new_params, new_body, Type(), func->attrs);
+    // TODO: Should infer the shape from the body as well
+    return Function(new_params, new_body, Type(), RuntimeDepShape(), func->attrs);
   } else {
     return ExprBinder(args_map).VisitExpr(expr);
   }

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -60,7 +60,7 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
       return expr;
     }
     // The checked_type_ of the new function is deduced from the function body
-    // TODO: Should infer the shape from the body as well
+    // TODO(@relax-team): Should infer the shape from the body as well
     return Function(new_params, new_body, Type(), RuntimeDepShape(), func->attrs);
   } else {
     return ExprBinder(args_map).VisitExpr(expr);

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -47,6 +47,7 @@ void FunctionFrameNode::ExitWithScope() {
   tvm::relax::Function func(/*params=*/params,
                             /*body=*/body,
                             /*ret_type=*/ret_type.value_or(Type()),
+                            /*ret_shape=*/tvm::relax::RuntimeDepShape(),
                             /*attrs=*/DictAttrs(attrs));
   // TODO(relax-team): remove this line
   func = WithAttr(func, "global_symbol", name.value());

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -186,7 +186,8 @@ def test_func():
     blocks = [rx.BindingBlock(bindings)]
     seqe = rx.SeqExpr(blocks, x)
     ret_type = rx.DynTensorType(-1, "float32")
-    func = rx.Function([x], seqe, ret_type)
+    ret_shape = rx.RuntimeDepShape()
+    func = rx.Function([x], seqe, ret_type, ret_shape)
     func = func.with_attr("global_symbol", "func")
 
     func_str = dump_ast(func)
@@ -194,6 +195,7 @@ def test_func():
     assert "params=" in func_str
     assert "body=" in func_str
     assert "ret_type=" in func_str
+    assert "ret_shape=" in func_str
     assert "attrs=" in func_str
     assert '"global_symbol": "func"' in func_str
     assert "SeqExpr(" in func_str

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -132,8 +132,12 @@ def test_function_pattern():
     ttype = rx.DynTensorType(-1, "float32")
     x = rx.Var("x", type_annotation=ttype)
     y = rx.Var("y", type_annotation=ttype)
-    assert f.match(rx.Function([x, y], rx.op.add(x, y), ret_type=ttype))
-    assert not f.match(rx.Function([x, y], rx.op.multiply(x, y), ret_type=ttype))
+    assert f.match(
+        rx.Function([x, y], rx.op.add(x, y), ret_type=ttype, ret_shape=rx.RuntimeDepShape())
+    )
+    assert not f.match(
+        rx.Function([x, y], rx.op.multiply(x, y), ret_type=ttype, ret_shape=rx.RuntimeDepShape())
+    )
 
 
 def test_tuple_pattern():
@@ -278,7 +282,7 @@ def test_match_call_attr():
     ttype = rx.DynTensorType(-1, "float32")
     x = rx.Var("x", type_annotation=ttype)
     y = rx.Var("y", type_annotation=ttype)
-    fn = rx.Function([x, y], rx.op.add(x, y), ret_type=ttype)
+    fn = rx.Function([x, y], rx.op.add(x, y), ret_type=ttype, ret_shape=rx.RuntimeDepShape())
     annotated_fn = fn.with_attr({"Codegen": "test-codegen", "global_symbol": "test-symbol"})
     xp = is_var("x")
     yp = is_var("y")

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -144,11 +144,13 @@ def test_func():
     blocks = [rx.BindingBlock(bindings)]
     seqe = rx.SeqExpr(blocks, x)
     ret_type = rx.DynTensorType(-1, "float32")
-    func = rx.Function([x], seqe, ret_type)
+    ret_shape = rx.RuntimeDepShape()
+    func = rx.Function([x], seqe, ret_type, ret_shape)
     func = func.with_attr("global_symbol", "func")
     assert func.params[0] == x
     assert func.body == seqe
     assert func.ret_type == ret_type
+    assert func.ret_shape == ret_shape
     assert func.attrs["global_symbol"] == "func"
 
 

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -565,7 +565,8 @@ def test_function():
     blocks = [relax.BindingBlock(bindings)]
     seq_expr = relax.SeqExpr(blocks, x)
     ret_type = relax.DynTensorType(-1, "float32")
-    func = relax.Function([x], seq_expr, ret_type)
+    ret_shape = relax.RuntimeDepShape()
+    func = relax.Function([x], seq_expr, ret_type, ret_shape)
     basic_check(
         func,
         "\n".join(
@@ -584,6 +585,7 @@ def test_function():
             [
                 "ShapeExpr",
                 "VarDef",
+                "RuntimeDepShape",
                 "Constant",
                 "ShapeExpr",
                 "VarDef",

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -49,7 +49,7 @@ def gen_mod(mod, name, binding):
             if k.name_hint == name:
                 # rename to main
                 gv = tvm.ir.GlobalVar("main")
-                funcs[gv] = tvm.relax.Function(v.params, v.body, v.ret_type).with_attr(
+                funcs[gv] = tvm.relax.Function(v.params, v.body, v.ret_type, v.ret_shape).with_attr(
                     "global_symbol", "main"
                 )
         else:

--- a/tests/python/relax/test_transform_well_formed.py
+++ b/tests/python/relax/test_transform_well_formed.py
@@ -32,7 +32,9 @@ def build_function(blocks, params=[]):
     seq_expr = rx.SeqExpr(blocks, blocks[-1].bindings[-1].var)
     ret_type = rx.DynTensorType(ndim=-1, dtype="float32")
     ret_shape = rx.RuntimeDepShape()
-    func = rx.Function([x, cond] + params, seq_expr, ret_type, ret_shape).with_attr("global_symbol", "foo")
+    func = rx.Function([x, cond] + params, seq_expr, ret_type, ret_shape).with_attr(
+        "global_symbol", "foo"
+    )
     return func
 
 

--- a/tests/python/relax/test_transform_well_formed.py
+++ b/tests/python/relax/test_transform_well_formed.py
@@ -31,7 +31,8 @@ def build_function(blocks, params=[]):
     """Returns relax.function with given blocks"""
     seq_expr = rx.SeqExpr(blocks, blocks[-1].bindings[-1].var)
     ret_type = rx.DynTensorType(ndim=-1, dtype="float32")
-    func = rx.Function([x, cond] + params, seq_expr, ret_type).with_attr("global_symbol", "foo")
+    ret_shape = rx.RuntimeDepShape()
+    func = rx.Function([x, cond] + params, seq_expr, ret_type, ret_shape).with_attr("global_symbol", "foo")
     return func
 
 

--- a/tests/python/relax/test_tuning_api.py
+++ b/tests/python/relax/test_tuning_api.py
@@ -77,7 +77,7 @@ def gen_mod(mod, name, binding):
             if k.name_hint == name:
                 # rename to main.
                 gv = tvm.ir.GlobalVar("main")
-                funcs[gv] = tvm.relax.Function(v.params, v.body, v.ret_type).with_attr(
+                funcs[gv] = tvm.relax.Function(v.params, v.body, v.ret_type, v.ret_shape).with_attr(
                     "global_symbol", "main"
                 )
         else:
@@ -758,7 +758,8 @@ def test_passes_with_mixed_granularities():
         x = relax.Var("x", [tvm.tir.Var("n", "int64")], relax.DynTensorType(1, "float32"))
         seq_expr = relax.SeqExpr([block], x)
         ret_type = relax.DynTensorType(-1, "float32")
-        func = relax.Function([x], seq_expr, ret_type)
+        ret_shape = relax.RuntimeDepShape()
+        func = relax.Function([x], seq_expr, ret_type, ret_shape)
         ctx.push_trace(Trace(IRModule.from_expr(func)))
         # Do something
         pass_func(mod, ctx)


### PR DESCRIPTION
This PR adds a `ret_shape` field for specifying the shape of the function's return value. At present, we will not use this information, but by adding it into the AST, we will be able to parse the return shape and use it in the future. Parser V1 in this PR will just always list the `ret_shape` as `RuntimeDepShape`.

I am not entirely sure that adding an extra field is necessary, since functions already have a `shape_` field and we could, in principle, set that based on the shape of the result, so discussion on that might be useful.

This PR unfortunately has to touch many passes that construct function nodes, so it would be good to review and ensure that no unintended behavior will result. It may be the case that we might be able to intelligently fill in shape annotations. In principle, we can get the return shape by getting the `shape_` of the body and removing any free shape variables (those that don't appear in the arguments) from it. @YuchenJin, is there a free vars analysis for TIR that we can use for that? (Or any easy way to gather all TIR vars? Maybe we should add a utility for it.) If so, I could probably get rid of many of the TODOs in the passes.