### PR TITLE
[Call TIR] Fix bug when invoking call_tir with scalar values.

### DIFF
--- a/python/tvm/script/parser_v1/relax/parser.py
+++ b/python/tvm/script/parser_v1/relax/parser.py
@@ -1399,7 +1399,8 @@ class RelaxTransformer(Transformer):
         elif isinstance(expr, ast.Tuple):
             fields = [self.transform_expr(field) for field in expr.values]
 
-            if all([isinstance(f, str) for f in fields]):
+            # Empty shape tuples should be treated as shape expressions.
+            if all([isinstance(f, str) for f in fields]) and len(fields) != 0:
                 return tuple(fields)
 
             # TODO(@altanh): this check might be too weak; we really only accept integral PrimExprs

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -733,9 +733,8 @@ def test_empty_shape():
             with T.block("add"):
                 C[()] = A[()] + B[()]
 
-
         z = relax.call_tir(scalar_add, (x, y), (), dtype="float32")
-        return z    
+        return z
 
     x, y = f.params
     add_bind, z_bind = f.body.blocks[0].bindings


### PR DESCRIPTION
This small PR changes a check in the tvmscript parser to support empty shape tuples which are used to represent scalars. I added a scalar addition test to make sure it works properly.
