### PR TITLE
[TVMScript] B3: Type annotation checks

### DIFF
--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -74,12 +74,12 @@ TVM_DLL FunctionFrame Function();
 /*!
  * \brief Add a parameter to the last function frame.
  * \param name The name of the parameter.
- * \param shape The shape of the parameter.
  * \param type The type of the parameter.
+ * \param shape The shape of the parameter.
  * \return The created function parameter var.
  */
-TVM_DLL tvm::relax::Var Arg(const String& name, const tvm::relax::ShapeExpr& shape,
-                            const Type& type);
+TVM_DLL tvm::relax::Var Arg(const String& name, const Type& type,
+                            const tvm::relax::ShapeExpr& shape);
 
 /*!
  * \brief Specify the name of the last function frame.

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -153,12 +153,11 @@ TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value, 
 ///////////////////////////// Type Deduce //////////////////////////////
 
 /*!
- * \brief Annotate and check the type and shape of tvm var.
+ * \brief Annotate and check the type and shape of relax var.
  * \param var The input var to be annotated.
  * \param type The given type.
  * \param shape The given shape, which can be undefined.
- * \note This function will check if the type of var is competitive with the given type.
- * i.e. The type of var is the base of the given type, or the given type is the base of another.
+ * \note This function will check if the type of var is compatible with the given type.
  * And we annotate to the var with more detailed type.
  */
 TVM_DLL void AnnotateTypeShape(const tvm::relax::Var& var, const Type& type,

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -78,7 +78,8 @@ TVM_DLL FunctionFrame Function();
  * \param type The type of the parameter.
  * \return The created function parameter var.
  */
-TVM_DLL tvm::relax::Var Arg(const String& name, const tvm::relax::ShapeExpr& shape, const Type& type);
+TVM_DLL tvm::relax::Var Arg(const String& name, const tvm::relax::ShapeExpr& shape,
+                            const Type& type);
 
 /*!
  * \brief Specify the name of the last function frame.

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -74,10 +74,11 @@ TVM_DLL FunctionFrame Function();
 /*!
  * \brief Add a parameter to the last function frame.
  * \param name The name of the parameter.
- * \param type The type and the shape of the parameter.
+ * \param shape The shape of the parameter.
+ * \param type The type of the parameter.
  * \return The created function parameter var.
  */
-TVM_DLL tvm::relax::Var Arg(const String& name, const TensorType& type);
+tvm::relax::Var Arg(const String& name, const tvm::relax::ShapeExpr& shape, const Type& type);
 
 /*!
  * \brief Specify the name of the last function frame.
@@ -147,6 +148,20 @@ TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value, 
                                                  const Array<PrimExpr>& pattern,  //
                                                  bool emit_var,                   //
                                                  bool is_dataflow_var);
+
+///////////////////////////// Type Deduce //////////////////////////////
+
+/*!
+ * \brief Annotate and check the type and shape of tvm var.
+ * \param var The input var to be annotated.
+ * \param type The given type.
+ * \param shape The given shape, which can be undefined.
+ * \note This function will check if the type of var is competitive with the given type.
+ * i.e. The type of var is the base of the given type, or the given type is the base of another.
+ * And we annotate to the var with more detailed type.
+ */
+TVM_DLL void AnnotateTypeShape(const tvm::relax::Var& var, const Type& type,
+                               const Optional<tvm::relax::ShapeExpr>& shape);
 
 }  // namespace relax
 }  // namespace ir_builder

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -78,7 +78,7 @@ TVM_DLL FunctionFrame Function();
  * \param type The type of the parameter.
  * \return The created function parameter var.
  */
-tvm::relax::Var Arg(const String& name, const tvm::relax::ShapeExpr& shape, const Type& type);
+TVM_DLL tvm::relax::Var Arg(const String& name, const tvm::relax::ShapeExpr& shape, const Type& type);
 
 /*!
  * \brief Specify the name of the last function frame.

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -190,6 +190,27 @@ def relax_print(*args: List[any]) -> None:
         print(format_str.format(*val_strs))
 
 
+def print(values: Union[Expr, List[Expr]], format: str) -> Expr:
+    """Print op to print the values
+
+    Parameters
+    ----------
+    values : List[Expr]
+        The values to print.
+
+    format_str: str
+        The format string.
+
+    Returns
+    -------
+    result : Expr
+        A relax Call, which will print the value during runtime.
+    """
+    if isinstance(values, Expr):
+        values = [values]
+    return _ffi_api.print(values, format)  # type: ignore # pylint: disable=no-member
+
+
 def shape_of(expr: Expr) -> Expr:
     """Get shape of a tensor.
 
@@ -201,6 +222,6 @@ def shape_of(expr: Expr) -> Expr:
     Returns
     -------
     result : Expr
-        The shape of the input
+        A relax Call, which gets the shape of the input
     """
     return _ffi_api.shape_of(expr)  # type: ignore # pylint: disable=no-member

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -27,6 +27,7 @@ from ...ir import Array
 
 py_print = print
 
+
 def call_tir(
     func: Union[str, Expr],
     args: Union[Expr, Tuple, List[Expr]],

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -25,7 +25,7 @@ from ..expr import Expr, ShapeExpr, Tuple, Call, ExternFunc
 from ..ty import DynTensorType, TupleType
 from ...ir import Array
 
-py_print = print
+py_print = print  # pylint: disable=invalid-name
 
 
 def call_tir(

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -13,6 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
+# pylint: disable=redefined-builtin
 """The base Relax operators."""
 from typing import Union, List, Optional
 
@@ -24,6 +25,7 @@ from ..expr import Expr, ShapeExpr, Tuple, Call, ExternFunc
 from ..ty import DynTensorType, TupleType
 from ...ir import Array
 
+py_print = print
 
 def call_tir(
     func: Union[str, Expr],
@@ -185,9 +187,9 @@ def relax_print(*args: List[any]) -> None:
 
     val_strs = map(render, args[:-1])
     if format_str == "":
-        print(*val_strs)
+        py_print(*val_strs)
     else:
-        print(format_str.format(*val_strs))
+        py_print(format_str.format(*val_strs))
 
 
 def print(values: Union[Expr, List[Expr]], format: str) -> Expr:

--- a/python/tvm/relax/op/tensor.py
+++ b/python/tvm/relax/op/tensor.py
@@ -57,6 +57,11 @@ def unique(
 
     dim: int
         The dimension to apply unique. If negative, the unique of the flattened input is returned.
+
+    Returns
+    -------
+    ret: Expr
+        The created relax call with
     """
 
     return _ffi_api.unique(data, sorted, return_inverse, return_counts, dim)

--- a/python/tvm/relax/op/tensor.py
+++ b/python/tvm/relax/op/tensor.py
@@ -29,8 +29,40 @@ def multiply(lhs: Expr, rhs: Expr) -> Expr:
     return _ffi_api.multiply(lhs, rhs)
 
 
-@tvm.register_func("relax.run.unique")
 def unique(
+    data: Expr,
+    sorted: bool = True,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: int = -1,
+) -> Expr:
+    """Find the unique elements and the new index of each item in a given tensor.
+
+    Parameters
+    ----------
+    data : Expr
+        The input tensor.
+
+    sorted: bool
+        Whether to sort the unique elements in ascending order before
+        returning as output.
+
+    return_inverse: bool
+        Whether to return an additional tensor with indices for where elements in
+        the original input ended up in the returned unique list.
+
+    return_counts: bool
+        Whether to return an additional tensor with counts of each unique elements.
+
+    dim: int
+        The dimension to apply unique. If negative, the unique of the flattened input is returned.
+    """
+
+    return _ffi_api.unique(data, sorted, return_inverse, return_counts, dim)
+
+
+@tvm.register_func("relax.run.unique")
+def numpy_unique(
     a: tvm.nd.array,
     sort: int,
     return_inverse: int,

--- a/python/tvm/relax/op/tensor.py
+++ b/python/tvm/relax/op/tensor.py
@@ -13,6 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
+# pylint: disable=redefined-builtin
 """Basic tensor operations."""
 import numpy as np
 import tvm

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -250,7 +250,7 @@ def call_packed(
             type_args[i] = argument
         else:
             raise TypeError(
-                "call_packed `type_args` is expected to be list of TensorType, "
+                "call_packed `type_args` is expected to be list of TensorType/Type, "
                 f"but got {type(arg)}"
             )
 
@@ -308,7 +308,7 @@ def emit_match_shape(
 
 
 def annotate_type_shape(var: Var, type: Type, shape: ShapeExpr) -> None:
-    """Annotate and check the type of tvm var.
+    """Annotate and check the type of relax var.
 
     Parameters
     ----------
@@ -322,7 +322,7 @@ def annotate_type_shape(var: Var, type: Type, shape: ShapeExpr) -> None:
         The given shape
 
     """
-    return _ffi_api.AnnotateTypeShape(var, type, shape)
+    _ffi_api.AnnotateTypeShape(var, type, shape)
 
 
 ############################### Importer ###############################

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -81,8 +81,8 @@ def tensor(
 
 ############################## Other Types ##############################
 
-Object = ObjectType()
-Shape = ShapeType()
+Object = ObjectType()  # pylint: disable=invalid-name
+Shape = ShapeType()  # pylint: disable=invalid-name
 
 ############################### Function ################################
 
@@ -214,11 +214,11 @@ def call_packed(
         type_args = [type_args]
     elif isinstance(type_args, tuple):
         type_args = list(type_args)
-    for i, arg in enumerate(type_args):
-        if isinstance(arg, TensorType):
-            type_args[i] = arg.type
-        elif isinstance(arg, Type):
-            type_args[i] = arg
+    for i, argument in enumerate(type_args):
+        if isinstance(argument, TensorType):
+            type_args[i] = argument.type
+        elif isinstance(argument, Type):
+            type_args[i] = argument
         else:
             raise TypeError(
                 "call_packed `type_args` is expected to be list of TensorType, "

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -203,10 +203,31 @@ def output(*vars: Tuple[Var]) -> Tuple[Var]:
 
 def call_packed(
     func: str,
-    *args,
+    *args: List[Expr],
     attrs: Optional[Attrs] = None,
     type_args: Optional[Union[TensorType, List[TensorType]]] = None,
-):
+) -> Call:
+    """Create a relax Call, which calls a packed function.
+
+    Parameters
+    ----------
+    func: str
+        The name of extern function.
+
+    args : List[Expr]
+        The arguments.
+
+    attrs: Optional[Attrs]
+        The call attributes
+
+    type_args: Optional[Union[TensorType, List[TensorType]]]
+        List of Types
+
+    Returns
+    -------
+    call: Call
+        The created Relax Call
+    """
     op = ExternFunc(func)
     if type_args is None:
         raise ValueError(f"R.call_packed is required to have type_args")

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -20,16 +20,15 @@
 from typing import Dict, List, Optional, Tuple, Union
 
 from tvm._ffi import register_object as _register_object
-from tvm.ir import Type, Attrs
-from tvm.relax import Expr, Var, ExternFunc, Call, ShapeExpr
+from tvm.ir import Attrs, Type
+from tvm.relax import Call, Expr, ExternFunc, ShapeExpr, Var
 from tvm.relax.op import call_tir
 from tvm.relax.ty import ObjectType, ShapeType
 from tvm.runtime import Object as tvm_Object
 from tvm.tir import PrimExpr
 
-from . import _ffi_api
-from . import frame
 from ..tir import var as _tir_var
+from . import _ffi_api, frame
 
 ############################### Operators ###############################
 from tvm.relax.op import print, shape_of, make_closure, invoke_closure

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -98,7 +98,7 @@ def function() -> frame.FunctionFrame:
     return _ffi_api.Function()  # pylint: disable=no-member # type: ignore
 
 
-def arg(name: str, shape: ShapeExpr, type: Type) -> Var:
+def arg(name: str, type: Union[Type, TensorType], shape: Optional[ShapeExpr] = None) -> Var:
     """Add a parameter to the last function frame.
 
     Parameters
@@ -106,18 +106,26 @@ def arg(name: str, shape: ShapeExpr, type: Type) -> Var:
     name: str
         The name of the parameter.
 
-    shape: Shape
-        The shape of the parameter.
+    type: Union[Type, TensorType]
+        The type of the parameter. It can be a typical TVM Type or a TensorType,
+        which contains both type and shape
 
-    type: Type
-        The type of the parameter.
+    shape: Optional[ShapeExpr]
+        The shape of the parameter.
 
     Returns
     -------
     var: Var
         The created function parameter var.
     """
-    return _ffi_api.Arg(name, shape, type)  # pylint: disable=no-member # type: ignore
+
+    if isinstance(type, TensorType):
+        if shape is not None:
+            raise ValueError("Cannot specify the shape if we use TensorType")
+        shape = type.shape
+        type = type.type
+
+    return _ffi_api.Arg(name, type, shape)  # pylint: disable=no-member # type: ignore
 
 
 def func_name(name: str) -> None:

--- a/python/tvm/script/parser/core/diagnostics.py
+++ b/python/tvm/script/parser/core/diagnostics.py
@@ -148,7 +148,7 @@ class Diagnostics:
         self.ctx = diagnostics.DiagnosticContext(mod, diagnostics.get_renderer())
 
     def _emit(self, node: doc.AST, message: str, level: diagnostics.DiagnosticLevel) -> None:
-        lineno = node.lineno or self.source.start_line
+        lineno = node.lineno or 1
         col_offset = node.col_offset or self.source.start_column
         end_lineno = node.end_lineno or lineno
         end_col_offset = node.end_col_offset or col_offset

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -198,7 +198,7 @@ def visit_arguments(self: Parser, node: doc.arguments) -> None:
         if arg.annotation is None:
             self.report_error(arg, "Type annotation is required for function parameters.")
         param_type, param_shape = self.visit_tvm_annotation(arg.annotation)
-        param = R.arg(arg.arg, param_shape, param_type)
+        param = R.arg(arg.arg, param_type, param_shape)
 
         self.var_table.add(arg.arg, param)
 

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -17,17 +17,17 @@
 # pylint: disable=missing-docstring,
 
 import contextlib
+from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from collections import defaultdict
-from tvm import tir, relax
+from tvm import relax, tir
 from tvm.ir import Type
 from tvm.script.ir_builder.relax.frame import BlockFrame
 
-from ...ir_builder import relax as R, tir as T
+from ...ir_builder import relax as R
 from ...ir_builder.base import IRBuilder
 from .._core import Parser, dispatch, doc
-from .entry import MatchShapePair, TensorType, Tensor
+from .entry import MatchShapePair, Tensor, TensorType
 
 
 class VarDefLoc:
@@ -162,8 +162,8 @@ def visit_function_def(self: Parser, node: doc.FunctionDef) -> None:
         with R.function():
             R.func_name(node.name)
             if node.returns is not None:
-                type, _ = eval_type_annotation(self, node.returns)
-                R.func_ret_type(type)
+                ann_type, _ = eval_type_annotation(self, node.returns)
+                R.func_ret_type(ann_type)
             with self.with_dispatch_token("relax"):
                 self.visit(node.args)
                 self.visit_body(node.body)

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -109,9 +109,9 @@ RELAY_REGISTER_OP("relax.print")
     .set_attr<FInferType>("FInferType", ReturnVoidType)
     .set_attr<FCallPacked>("FCallPacked", "relax.run.print");
 
-Expr MakePrint(Array<Expr> vals, std::string format_str) {
+Expr MakePrint(Array<Expr> vals, std::string format) {
   auto attrs = make_object<PrintAttrs>();
-  attrs->format = format_str;
+  attrs->format = format;
   static const Op& op = Op::Get("relax.print");
   return Call(op, vals, Attrs(attrs));
 }

--- a/src/relax/op/tensor/unary.cc
+++ b/src/relax/op/tensor/unary.cc
@@ -46,7 +46,7 @@ Expr MakeUnique(Expr data, bool sorted, bool return_inverse, bool return_counts,
   attrs->return_inverse = return_inverse;
   attrs->return_counts = return_counts;
   attrs->dim = dim;
-  static const Op& op = Op::Get("unique");
+  static const Op& op = Op::Get("relax.unique");
   return Call(op, {data}, Attrs(attrs));
 }
 

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -79,7 +79,7 @@ FunctionFrame Function() {
   return FunctionFrame(n);
 }
 
-tvm::relax::Var Arg(const String& name, const tvm::relax::ShapeExpr& shape, const Type& type) {
+tvm::relax::Var Arg(const String& name, const Type& type, const tvm::relax::ShapeExpr& shape) {
   FunctionFrame frame = FindFunctionFrame("R.Arg");
   tvm::relax::Var var(name, shape, type);
   frame->params.push_back(var);

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -262,6 +262,8 @@ void AnnotateTypeShape(const tvm::relax::Var& var, const Type& type,
   } else {
     const Type& var_type = var->checked_type();
     if (IsBaseOf(var_type, type)) {
+      LOG(WARNING) << "The type inferred by the block builder is more refined than the annotated "
+                      "one. The system will refine it automatically.";
       var->checked_type_ = type;
     } else if (IsBaseOf(type, var_type)) {
       // The var type is more detailed, do nothing.

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -208,10 +208,10 @@ tvm::relax::Var Emit(const tvm::relax::Expr& expr, bool is_dataflow_var) {
   return var;
 }
 
-TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value,   //
-                                                 const Array<PrimExpr>& pattern,  //
-                                                 bool emit_var,                   //
-                                                 bool is_dataflow_var) {
+Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value,   //
+                                         const Array<PrimExpr>& pattern,  //
+                                         bool emit_var,                   //
+                                         bool is_dataflow_var) {
   BlockFrame block_frame = CheckBlockFrameExistAndUnended();
   tvm::relax::BlockBuilder block_builder = GetBlockBuilder();
 

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -266,7 +266,8 @@ void AnnotateTypeShape(const tvm::relax::Var& var, const Type& type,
     } else if (IsBaseOf(type, var_type)) {
       // The var type is more detailed, do nothing.
     } else {
-      LOG(FATAL) << "TypeError: The var type and the annotated type are not competitive.";
+      LOG(FATAL) << "TypeError: The annotated type and value type are not compatible. "
+                 << "The Type is expected to be " << var_type << " but got annotation: " << type;
     }
   }
 

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -463,8 +463,6 @@ def test_empty_shape():
     assert len(shape_expr.values) == 0
 
 
-
-
 def test_other_cases():
     # They are corner case tests, which is only to check if it can be parsed.
     # No need to add structural equal checks here
@@ -475,6 +473,7 @@ def test_other_cases():
     @R.function
     def bar(x: R.Tensor):
         return R.print(x, format="{}")
+
 
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -360,5 +360,121 @@ def test_function_without_return():
             gv0 = R.call_tir("extern_func", x, (128, 128), dtype="float32")
 
 
+def test_tensor_type_without_args():
+    @R.function
+    def foo(x: R.Tensor((32, 32), "float32")) -> R.Tensor:
+        v = R.call_tir("tir_relu", x, (32, 32), dtype="float32")
+        return v
+
+    x = relax.Var("x", (32, 32), relax.DynTensorType(2, "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", (x)):
+        v = bb.emit(relax.call_tir("tir_relu", x, (32, 32), dtype="float32"))
+        bb.emit_func_output(v)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_direct_return():
+    @R.function
+    def foo(x: R.Tensor((32, 32), "float32")) -> R.Tensor((32, 32), "float32"):
+        return x
+
+    x = relax.Var("x", (32, 32), relax.DynTensorType(2, "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", (x)):
+        bb.emit_func_output(x)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_call_packed():
+    @R.function
+    def foo(x: R.Tensor((32, 32), "float32")) -> R.Tensor:
+        z = R.call_packed("vm.builtin.copy", x, type_args=R.Tensor((32, 32), "float32"))
+        return z
+
+    x = relax.Var("x", (32, 32), relax.DynTensorType(2, "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", (x)):
+        z = bb.emit(
+            relax.Call(
+                relax.ExternFunc("vm.builtin.copy"),
+                (x,),
+                None,
+                type_args=[relax.DynTensorType(2, "float32")],
+            )
+        )
+        bb.emit_func_output(z)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_annotation():
+    @R.function
+    def foo(
+        x: R.Tensor((32, "m"), "float32"),
+        y: R.Tensor(("m"), "float32"),
+        r: R.Tensor(dtype="int64"),
+    ) -> R.Object:
+        m = T.var("int64")
+        z: R.Tensor((32, m), "float32") = R.multiply(x, y)
+        w: R.Tensor = R.multiply(z, z)
+        q: R.Tensor(ndim=2) = R.add(w, w)
+        t = R.add(w, z)
+        sh: R.Shape = R.shape_of(t)
+        o: R.Object = R.call_packed("contrib.tensor_array_stack", x, y, type_args=R.Object)
+        return o
+
+    m = tir.Var("m", "int64")
+    x = relax.Var("x", (32, m), relax.DynTensorType(2, "float32"))
+    y = relax.Var("y", (m,), relax.DynTensorType(1, "float32"))
+    r = relax.Var("r", None, relax.DynTensorType(-1, "int64"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", (x, y, r)):
+        z = bb.emit(R.multiply(x, y))
+        w = bb.emit(R.multiply(z, z))
+        q = bb.emit(R.add(w, w))
+        t = bb.emit(R.add(w, z))
+        sh = bb.emit(R.shape_of(t))
+        o = bb.emit(
+            relax.Call(
+                relax.ExternFunc("contrib.tensor_array_stack"),
+                [x, y],
+                None,
+                type_args=[relax.ObjectType()],
+            )
+        )
+        bb.emit_func_output(o)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_empty_shape():
+    @R.function
+    def foo(x: R.Tensor((), "float32")):
+        z = R.call_tir("scalar_add", x, (), dtype="float32")
+        return z
+
+    (z_bind,) = foo.body.blocks[0].bindings
+    shape_expr = z_bind.value.args[2]
+
+    assert isinstance(shape_expr, relax.ShapeExpr)
+    assert len(shape_expr.values) == 0
+
+
+
+
+def test_other_cases():
+    # They are corner case tests, which is only to check if it can be parsed.
+    # No need to add structural equal checks here
+    @R.function
+    def foo(x: R.Tensor):
+        return R.unique(x, sorted=True)
+
+    @R.function
+    def bar(x: R.Tensor):
+        return R.print(x, format="{}")
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR enables type checking for `a: type = value`, which also includes minor changes:

- Fix Unique operators on Python side
- Fix symbolic shape issue
- Add new Types
- Refactor parser logic for type annotation
- Add `call_packed` support
- Fix a minor error reporting issue

cc @YuchenJin @MasterJH5574 