### PR TITLE
[Debugging][Bugfix] Debug printer improvements: Print `shape_` and `checked_type_` for all nodes and handle non-binding `MatchShape`s

### DIFF
--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -96,9 +96,7 @@ class ASTPrinter(ExprFunctor):
             force_newline=force_newline,
         )
 
-    def build_expr(
-        self, node: relax.Expr, nodename: str, force_newline=False, **kwargs: str
-    ):
+    def build_expr(self, node: relax.Expr, nodename: str, force_newline=False, **kwargs: str):
         """
         Renders a Relax expression as a string using `build_ast_node`.
         Handles whether to include the checked_type_ and shape_ fields.

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -59,7 +59,7 @@ class ASTPrinter(ExprFunctor):
         # have to include this check or else the constructor does not terminate
         if self.include_shape_annotations:
             self.shape_visitor = ASTPrinter(
-                include_type_annotations=include_type_annotations,
+                include_type_annotations=False,
                 include_shape_annotations=False,
                 include_call_attrs=include_call_attrs,
             )

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -104,7 +104,7 @@ class ASTPrinter(ExprFunctor):
         Handles whether to include the checked_type_ and shape_ fields.
         """
         fields = kwargs.copy()
-        if node.shape and self.include_shape_annotations:
+        if node.shape_ and self.include_shape_annotations:
             fields["shape_"] = self.visit_shape_(node.shape)
         if node._checked_type_ and self.include_type_annotations:
             fields["checked_type_"] = self.visit_type_(node.checked_type)

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -43,21 +43,26 @@ class ASTPrinter(ExprFunctor):
 
     def __init__(
         self,
+        indent_str="    ",
         include_type_annotations=True,
         include_shape_annotations=True,
         include_call_attrs=True,
     ):
+        self.indent_str = indent_str
         self.include_type_annotations = include_type_annotations
         self.include_shape_annotations = include_shape_annotations
         self.include_call_attrs = include_call_attrs
 
         # for displaying shape_, we visit exprs just the same but don't include
         # shapes within shapes to avoid infinite recursion
-        self.shape_visitor = ASTPrinter(
-            include_type_annotations=include_type_annotations,
-            include_shape_annotations=False,
-            include_call_attrs=include_call_attrs,
-        )
+        self.shape_visitor = None
+        # have to include this check or else the constructor does not terminate
+        if self.include_shape_annotations:
+            self.shape_visitor = ASTPrinter(
+                include_type_annotations=include_type_annotations,
+                include_shape_annotations=False,
+                include_call_attrs=include_call_attrs,
+            )
 
     def visit_expr(self, expr: relax.Expr) -> str:
         # extend so we also dispatch to bindings and binding blocks,
@@ -91,6 +96,20 @@ class ASTPrinter(ExprFunctor):
             force_newline=force_newline,
         )
 
+    def build_expr(
+        self, node: relax.Expr, nodename: str, force_newline=False, **kwargs: str
+    ):
+        """
+        Renders a Relax expression as a string using `build_ast_node`.
+        Handles whether to include the checked_type_ and shape_ fields.
+        """
+        fields = kwargs.copy()
+        if node.shape and self.include_shape_annotations:
+            fields["shape_"] = self.visit_shape_(node.shape)
+        if node._checked_type_ and self.include_type_annotations:
+            fields["checked_type_"] = self.visit_type_(node.checked_type)
+        return self.build_ast_node(nodename, force_newline=force_newline, **fields)
+
     def build_list(
         self, members: Iterable[str], open_tok="[", close_tok="]", force_newline=False
     ) -> str:
@@ -112,41 +131,32 @@ class ASTPrinter(ExprFunctor):
     def visit_constant_(self, op: relax.Constant) -> str:
         # simple rule of thumb: keep scalars inline, but anything larger goes on a new one
         force_newline = len(op.data.shape) > 0
-        return self.build_ast_node("Constant", force_newline=force_newline, data=str(op.data))
+        return self.build_expr(op, "Constant", force_newline=force_newline, data=str(op.data))
 
     def visit_tuple_(self, op: relax.Tuple) -> str:
-        return self.build_ast_node("Tuple", fields=self.build_list(map(self.visit_expr, op.fields)))
+        return self.build_expr(op, "Tuple", fields=self.build_list(map(self.visit_expr, op.fields)))
 
     def visit_dataflow_var_(self, op: relax.DataflowVar) -> str:
-        fields = {"name_hint": wrap_quotes(op.name_hint)}
-        if op.shape_ and self.include_var_shape_annotations:
-            fields["shape_"] = self.visit_expr(op.shape_)
-        if op._checked_type_ and self.include_type_annotations:
-            fields["_checked_type_"] = self.visit_type_(op._checked_type_)
-        return self.build_ast_node("DataflowVar", **fields)
+        return self.build_expr(op, "DataflowVar", name_hint=wrap_quotes(op.name_hint))
 
     def visit_var_(self, op: relax.Var) -> str:
-        fields = {"name_hint": wrap_quotes(op.name_hint)}
-        if op.shape_ and self.include_var_shape_annotations:
-            fields["shape_"] = self.visit_expr(op.shape_)
-        if op._checked_type_ and self.include_type_annotations:
-            fields["_checked_type_"] = self.visit_type_(op._checked_type_)
-        return self.build_ast_node("Var", **fields)
+        return self.build_expr(op, "Var", name_hint=wrap_quotes(op.name_hint))
 
     def visit_shape_expr_(self, op: relax.ShapeExpr) -> str:
-        return self.build_ast_node(
-            "ShapeExpr", values=self.build_list(map(self.visit_prim_expr_, op.values))
+        return self.build_expr(
+            op, "ShapeExpr", values=self.build_list(map(self.visit_prim_expr_, op.values))
         )
 
-    def visit_runtime_dep_shape_(self, _: relax.RuntimeDepShape) -> str:
-        # no fields, apparently?
-        return self.build_ast_node("RuntimeDepShape")
+    def visit_runtime_dep_shape_(self, op: relax.RuntimeDepShape) -> str:
+        return self.build_expr(op, "RuntimeDepShape")
 
     def visit_extern_func_(self, op: relax.ExternFunc) -> str:
+        # ExternFunc does not inherit from relax.Expr either,
+        # so it doesn't have checked_type_ or shape_ fields and we don't use build_expr
         return self.build_ast_node("ExternFunc", global_symbol=wrap_quotes(op.global_symbol))
 
     def visit_global_var_(self, op: relax.GlobalVar) -> str:
-        return self.build_ast_node("GlobalVar", name_hint=wrap_quotes(op.name_hint))
+        return self.build_expr(op, "GlobalVar", name_hint=wrap_quotes(op.name_hint))
 
     def visit_function_(self, op: relax.Function) -> str:
         fields = {
@@ -165,7 +175,7 @@ class ASTPrinter(ExprFunctor):
                 open_tok="{",
                 close_tok="}",
             )
-        return self.build_ast_node("Function", **fields)
+        return self.build_expr(op, "Function", **fields)
 
     def visit_call_(self, op: relax.Call) -> str:
         fields = {
@@ -189,17 +199,19 @@ class ASTPrinter(ExprFunctor):
                 open_tok="{",
                 close_tok="}",
             )
-        return self.build_ast_node("Call", **fields)
+        return self.build_expr(op, "Call", **fields)
 
     def visit_seq_expr_(self, op: relax.SeqExpr) -> str:
-        return self.build_ast_node(
+        return self.build_expr(
+            op,
             "SeqExpr",
             blocks=self.build_list(map(self.visit_binding_block_, op.blocks)),
             body=self.visit_expr(op.body),
         )
 
     def visit_if_(self, op: relax.If) -> str:
-        return self.build_ast_node(
+        return self.build_expr(
+            op,
             "If",
             cond=self.visit_expr(op.cond),
             true_branch=self.visit_expr(op.true_branch),
@@ -208,6 +220,8 @@ class ASTPrinter(ExprFunctor):
 
     def visit_op_(self, op: tvm.ir.Op) -> str:
         # TODO: List other attributes?
+        # op is not actually a Relax expr and does not have checked_type_
+        # or shape_ fields, so we don't use build_expr here
         return self.build_ast_node("Op", name=wrap_quotes(op.name))
 
     def visit_prim_expr_(self, prim_expr: PrimExpr) -> str:
@@ -215,7 +229,8 @@ class ASTPrinter(ExprFunctor):
         return self.build_ast_node("PrimExpr", value=f"`{str(prim_expr)}`")
 
     def visit_tuple_getitem_(self, op: relax.TupleGetItem) -> str:
-        return self.build_ast_node(
+        return self.build_expr(
+            op,
             "TupleGetItem",
             tuple_value=self.visit_expr(op.tuple_value),
             index=str(op.index),
@@ -250,6 +265,12 @@ class ASTPrinter(ExprFunctor):
                 # TODO: skipping type params and type constraints
             )
         raise ValueError(f"Invalid Relax Type {type_node} ({type(type_node)})")
+
+    def visit_shape_(self, expr: relax.Expr) -> str:
+        # used only for rendering the shape_ annotation, if it's intended to be included
+        if self.include_shape_annotations:
+            return self.shape_visitor.visit_expr(expr)
+        return ""
 
     def visit_binding_block_(self, block: relax.BindingBlock) -> str:
         """

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -304,12 +304,14 @@ class ASTPrinter(ExprFunctor):
         """
         Handle match shape
         """
-        return self.build_ast_node(
-            "MatchShape",
-            value=self.visit_expr(match_shape.value),
-            pattern=self.build_list(map(self.visit_prim_expr_, match_shape.pattern)),
-            var=self.visit_expr(match_shape.var),
-        )
+        fields = {
+            "value": self.visit_expr(match_shape.value),
+            "pattern": self.build_list(map(self.visit_prim_expr_, match_shape.pattern)),
+        }
+        # not always defined
+        if match_shape.var:
+            fields["var"] = self.visit_expr(match_shape.var)
+        return self.build_ast_node("MatchShape", **fields)
 
     def visit_var_binding_(self, var_binding: relax.VarBinding) -> str:
         """

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -102,6 +102,20 @@ def test_match_shape() -> None:
     assert b1_str != dump_ast(b1, include_type_annotations=False, include_shape_annotations=False)
 
 
+def test_match_shape_unbound() -> None:
+    @R.function
+    def func(x: Tensor) -> Tensor:
+        R.match_shape(x, (1, 1))
+        return x
+
+    # no var field on the match shape!
+    func_str = strip_whitespace(dump_ast(func))
+    assert "MatchShape" in func_str
+    assert 'value=Var(' in func_str
+    assert "pattern=[PrimExpr(" in func_str
+    assert "var=" not in func_str
+
+
 def test_var_binding() -> None:
     v0 = rx.Var("v0")
     val = rx.const(np.random.rand(24, 56))

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -38,7 +38,7 @@ def strip_whitespace(text: str) -> str:
 
 def test_var() -> None:
     v0 = rx.Var("v0")
-    v0_str = dump_ast(v0, include_type_annotations=False, include_shape_annotations=False)
+    v0_str = dump_ast(v0)
     assert v0_str == 'Var(name_hint="v0")'
 
     shape_anno = [54, 96]
@@ -55,7 +55,7 @@ def test_var() -> None:
 
 def test_dataflow_var() -> None:
     v0 = rx.DataflowVar("v0")
-    v0_str = dump_ast(v0, include_type_annotations=False, include_shape_annotations=False)
+    v0_str = dump_ast(v0)
     assert v0_str == 'DataflowVar(name_hint="v0")'
 
     shape_anno = [54, 96]

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -121,7 +121,7 @@ def test_match_shape() -> None:
 
 def test_match_shape_unbound() -> None:
     @R.function
-    def func(x: Tensor) -> Tensor:
+    def func(x: R.Tensor) -> R.Tensor:
         R.match_shape(x, (1, 1))
         return x
 
@@ -397,7 +397,7 @@ def test_operators():
 
 def test_print_shape_annotation_non_var():
     @R.function
-    def f() -> Tensor:
+    def f() -> R.Tensor:
         return R.const([1, 2])
 
     body = normalize(f).body
@@ -417,21 +417,22 @@ def test_print_shape_annotation_non_var():
 
 def test_print_type_annotation_non_var():
     @R.function
-    def f() -> Shape:
+    def f() -> R.Shape:
         return R.shape_of(R.const(1))
 
     body = normalize(f).body
-    assert isinstance(body, rx.Call)
-    arg = body.args[0]
+    assert isinstance(body, rx.SeqExpr)
+    call = body.body
+    assert isinstance(call, rx.Call)
+    arg = call.args[0]
     arg_str = strip_whitespace(dump_ast(arg))
     # the constant should have a tensor type
     assert "checked_type_=DynTensorType(ndim=0" in arg_str
 
-    body_str = strip_whitespace(dump_ast(body))
+    call_str = strip_whitespace(dump_ast(call))
     # we expect the shape_of call to have a checked_type_ of ShapeType
     type_str = "checked_type_=ShapeType()"
-    assert type_str in body_str
-
+    assert type_str in call_str
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -434,5 +434,6 @@ def test_print_type_annotation_non_var():
     type_str = "checked_type_=ShapeType()"
     assert type_str in call_str
 
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -38,7 +38,7 @@ def strip_whitespace(text: str) -> str:
 
 def test_var() -> None:
     v0 = rx.Var("v0")
-    v0_str = dump_ast(v0)
+    v0_str = dump_ast(v0, include_type_annotations=False, include_shape_annotations=False)
     assert v0_str == 'Var(name_hint="v0")'
 
     shape_anno = [54, 96]
@@ -50,12 +50,12 @@ def test_var() -> None:
     assert v1_annos != v1_no_annos
     assert "PrimExpr" in v1_annos
     assert "shape_" in v1_annos
-    assert "_checked_type_" in v1_annos
+    assert "checked_type_" in v1_annos
 
 
 def test_dataflow_var() -> None:
     v0 = rx.DataflowVar("v0")
-    v0_str = dump_ast(v0)
+    v0_str = dump_ast(v0, include_type_annotations=False, include_shape_annotations=False)
     assert v0_str == 'DataflowVar(name_hint="v0")'
 
     shape_anno = [54, 96]
@@ -67,7 +67,7 @@ def test_dataflow_var() -> None:
     assert v1_annos != v1_no_annos
     assert "PrimExpr" in v1_annos
     assert "shape_" in v1_annos
-    assert "_checked_type_" in v1_annos
+    assert "checked_type_" in v1_annos
 
 
 def test_match_shape() -> None:
@@ -106,7 +106,7 @@ def test_var_binding() -> None:
     v0 = rx.Var("v0")
     val = rx.const(np.random.rand(24, 56))
     b0 = rx.VarBinding(v0, val)
-    b0_str = dump_ast(b0)
+    b0_str = dump_ast(b0, include_type_annotations=False, include_shape_annotations=False)
     assert b0_str.startswith("VarBinding(")
     assert 'var=Var(name_hint="v0")' in b0_str
     assert "value=" in b0_str

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -111,7 +111,7 @@ def test_match_shape_unbound() -> None:
     # no var field on the match shape!
     func_str = strip_whitespace(dump_ast(func))
     assert "MatchShape" in func_str
-    assert 'value=Var(' in func_str
+    assert "value=Var(" in func_str
     assert "pattern=[PrimExpr(" in func_str
     assert "var=" not in func_str
 


### PR DESCRIPTION
The initial AST printer only included the `shape_` and `checked_type_` fields for variables because of the potential for infinite recursion (`shape_` nodes can contain other expressions, which in turn have `shape_` nodes). This PR cuts off the potential recursion to allow for printing these fields for all Relax expressions, which should be more useful for debugging.

This PR also fixes a bug: The AST printer previously did not handle `MatchShape` bindings that did not bind a new variable. For example:
```python
@R.function
def func(x: Tensor) -> Tensor:
    R.match_shape(x, (10, 10))
    return x
```