### PR TITLE
[Pass] Support Function and If in Normalize pass.

### DIFF
--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -355,7 +355,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
 
    private:
     std::unordered_map<Id, Expr, ObjectPtrHash, ObjectPtrEqual> var_memo_;
-    std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual> expr_memo_;
+    std::unordered_map<Expr, Expr, StructuralHash, StructuralEqual> expr_memo_;
   };
 
   // Helper function to check if a ShapeExpr is constant shape or tuple of constant shape

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -355,7 +355,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
 
    private:
     std::unordered_map<Id, Expr, ObjectPtrHash, ObjectPtrEqual> var_memo_;
-    std::unordered_map<Expr, Expr, StructuralHash, StructuralEqual> expr_memo_;
+    std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual> expr_memo_;
   };
 
   // Helper function to check if a ShapeExpr is constant shape or tuple of constant shape

--- a/src/relax/transform/normalize.cc
+++ b/src/relax/transform/normalize.cc
@@ -40,6 +40,38 @@ class NormalizeMutator : public ExprMutatorBase {
     return builder_->Normalize(ExprMutatorBase::VisitExpr(expr));
   }
 
+  Expr VisitExpr_(const FunctionNode* op) {
+    Expr body = this->VisitWithNewScope(op->body);
+
+    if (body.same_as(op->body)) {
+      return GetRef<Expr>(op);
+    } else {
+      return Function(op->params, body, op->ret_type, op->attrs);
+    }
+  }
+
+  Expr VisitExpr_(const IfNode* op) {
+    Expr guard = this->VisitExpr(op->cond);
+    Expr true_b = this->VisitWithNewScope(op->true_branch);
+    Expr false_b = this->VisitWithNewScope(op->false_branch);
+    if (op->cond.same_as(guard) && op->true_branch.same_as(true_b) &&
+        op->false_branch.same_as(false_b)) {
+      return GetRef<Expr>(op);
+    } else {
+      return If(guard, true_b, false_b, op->span);
+    }
+  }
+
+  Expr VisitWithNewScope(const Expr& expr) {
+    builder_->BeginBindingBlock();
+    Expr ret = this->VisitExpr(expr);
+    BindingBlock prologue = builder_->EndBlock();
+    if (!prologue->bindings.empty()) {
+      ret = SeqExpr({prologue}, ret);
+    }
+    return ret;
+  }
+
   Expr VisitExpr_(const SeqExprNode* op) final {
     bool all_blocks_unchanged = true;
     Array<BindingBlock> blocks;

--- a/src/relax/transform/normalize.cc
+++ b/src/relax/transform/normalize.cc
@@ -46,7 +46,7 @@ class NormalizeMutator : public ExprMutatorBase {
     if (body.same_as(op->body)) {
       return GetRef<Expr>(op);
     } else {
-      return Function(op->params, body, op->ret_type, op->attrs);
+      return Function(op->params, body, op->ret_type, op->ret_shape, op->attrs);
     }
   }
 

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -884,8 +884,7 @@ def test_class_normalize():
         @R.function
         def mul_add(x: Tensor) -> Tensor:
             gv = relax.add(x, x)
-            gv1 = relax.add(x, x)
-            return R.multiply(gv, gv1)
+            return R.multiply(gv, gv)
 
     assert_structural_equal(InputModule, OutputModule)
 

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -884,7 +884,8 @@ def test_class_normalize():
         @R.function
         def mul_add(x: Tensor) -> Tensor:
             gv = relax.add(x, x)
-            return R.multiply(gv, gv)
+            gv1 = relax.add(x, x)
+            return R.multiply(gv, gv1)
 
     assert_structural_equal(InputModule, OutputModule)
 

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -871,5 +871,24 @@ def test_class_irmodule():
     check_shape(gv2_bind.var, ("n", "n"))
 
 
+def test_class_normalize():
+    @tvm.script.ir_module
+    class InputModule:
+        @R.function
+        def mul_add(x: Tensor) -> Tensor:
+            return R.multiply(R.add(x, x), R.add(x, x))
+
+    # The parser automatically normalizes the input AST to the following ANF form
+    @tvm.script.ir_module
+    class OutputModule:
+        @R.function
+        def mul_add(x: Tensor) -> Tensor:
+            gv = relax.add(x, x)
+            gv1 = relax.add(x, x)
+            return R.multiply(gv, gv1)
+
+    assert_structural_equal(InputModule, OutputModule)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -513,8 +513,7 @@ def test_normalize():
         @R.function
         def mul_add(x: Tensor((m, n), "float16")) -> Tensor(None, "float16", ndim=2):
             gv = relax.add(x, x)
-            gv1 = relax.add(x, x)
-            return R.multiply(gv, gv1)
+            return R.multiply(gv, gv)
 
     assert_structural_equal(after_mod, Expected)
 

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -504,6 +504,7 @@ def test_normalize_function():
         [x],
         relax.op.multiply(relax.op.add(x, x), relax.op.add(x, x)),
         ret_type=type_anno,
+        ret_shape=relax.RuntimeDepShape(),
     )
     mul_add = mul_add.with_attr("global_symbol", "mul_add")
     before_mod = tvm.IRModule.from_expr(mul_add)
@@ -549,6 +550,7 @@ def test_normalize_if():
             y,
         ),
         ret_type=relax.DynTensorType(1, "float32"),
+        ret_shape=relax.RuntimeDepShape(),
     )
 
     f = f.with_attr("global_symbol", "f")

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -492,12 +492,14 @@ def test_vm_shape_lower_int32_shape():
     assert cast_expr.dtype == "int64"
 
 
-def test_normalize():
+def test_normalize_function():
     m = tir.Var("m", "int64")
     n = tir.Var("n", "int64")
     type_anno = relax.DynTensorType(ndim=2, dtype="float16")
     x = relax.Var("x", [m, n], type_anno)
 
+    # Note: the parser automatically normalize the IR written in TVMScript,
+    # so we manually construct the function here.
     mul_add = relax.Function(
         [x],
         relax.op.multiply(relax.op.add(x, x), relax.op.add(x, x)),
@@ -512,8 +514,62 @@ def test_normalize():
     class Expected:
         @R.function
         def mul_add(x: Tensor((m, n), "float16")) -> Tensor(None, "float16", ndim=2):
-            gv = relax.add(x, x)
-            return R.multiply(gv, gv)
+            gv = R.add(x, x)
+            gv1 = relax.add(x, x)
+            return R.multiply(gv, gv1)
+
+    assert_structural_equal(after_mod, Expected)
+
+
+def test_normalize_if():
+    cond = relax.Var("cond", [], type_annotation=relax.DynTensorType(0, "bool"))
+    x = relax.Var("x", [tir.IntImm("int64", 1)], type_annotation=relax.DynTensorType(1, "float32"))
+    # TODO(relax-team): add type and shape inference for IfNode
+    y = relax.Var("y")
+
+    # Note: the parser automatically normalize the IR written in TVMScript,
+    # so we manually construct the function and If here.
+    f = relax.Function(
+        [cond, x],
+        relax.SeqExpr(
+            [
+                relax.BindingBlock(
+                    [
+                        relax.VarBinding(
+                            y,
+                            relax.If(
+                                cond,
+                                relax.op.multiply(relax.op.add(x, x), relax.op.add(x, x)),
+                                relax.op.add(relax.op.multiply(x, x), relax.op.multiply(x, x)),
+                            ),
+                        )
+                    ]
+                )
+            ],
+            y,
+        ),
+        ret_type=relax.DynTensorType(1, "float32"),
+    )
+
+    f = f.with_attr("global_symbol", "f")
+    before_mod = tvm.IRModule.from_expr(f)
+    after_mod = relax.transform.Normalize()(before_mod)
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def f(
+            cond: Tensor((), "bool"), x: Tensor((1,), "float32")
+        ) -> Tensor(None, "float32", ndim=1):
+            if cond:
+                gv = R.add(x, x)
+                gv1 = R.add(x, x)
+                y = R.multiply(gv, gv1)
+            else:
+                gv = R.multiply(x, x)
+                gv1 = R.multiply(x, x)
+                y = R.add(gv, gv1)
+            return y
 
     assert_structural_equal(after_mod, Expected)
 


### PR DESCRIPTION
Fix #267. Support normalize a relax function with non-SeqExpr as its body, and IfNode with non-SeqExpr as as its true and false branches.