### PR TITLE
[TVMScript] Update Type Annotation Behavior of the Parser

### DIFF
--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -155,13 +155,13 @@ TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value, 
 /*!
  * \brief Annotate and check the type and shape of relax var.
  * \param var The input var to be annotated.
- * \param type The given type.
- * \param shape The given shape, which can be undefined.
- * \note This function will check if the type of var is compatible with the given type.
+ * \param anno_type The annotated type.
+ * \param anno_shape The annotated shape, which can be undefined.
+ * \note This function will check if the type of var is compatible with the annotated type.
  * And we annotate to the var with more detailed type.
  */
-TVM_DLL void AnnotateTypeShape(const tvm::relax::Var& var, const Type& type,
-                               const Optional<tvm::relax::ShapeExpr>& shape);
+TVM_DLL void AnnotateTypeShape(const tvm::relax::Var& var, const Type& anno_type,
+                               const Optional<tvm::relax::ShapeExpr>& anno_shape);
 
 ///////////////////////////// If Then Else /////////////////////////////
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -287,18 +287,21 @@ def emit_match_shape(
 ############################# Type Deduce ##############################
 
 
-def annotate_type_shape(var: Var, type: Type, shape: ShapeExpr) -> None:
+def annotate_type_shape(var: Var, anno_type: Type, anno_shape: ShapeExpr) -> None:
     """Annotate and check the type of relax var.
     Parameters
     ----------
     var: Var
         The input var to be annotated.
-    type: Type
-        The given type
-    shape: ShapeExpr
-        The given shape
+
+    anno_type: Type
+        The annotated type
+
+    anno_shape: ShapeExpr
+        The annotated shape
+
     """
-    _ffi_api.AnnotateTypeShape(var, type, shape)
+    _ffi_api.AnnotateTypeShape(var, anno_type, anno_shape)
 
 
 def If(condition: Expr) -> frame.IfFrame:  # pylint: disable=invalid-name


### PR DESCRIPTION
This commit changes the behavior of the parser to allow type annotations, as suggested by the community.

The current behavior:
- Use the more refined type/shape between the user-annotated type/shape and deduced ones.

The updated behavior:
- Always use user annotations
- Only checks if the type/shape is valid.

cc @YuchenJin @slyubomirsky 
