### PR TITLE
[CI] Enable Mypy type checking for Relax; Fix typing errors to pass Mypy checking.

### DIFF
--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -42,7 +42,7 @@ def post_order_visit(expr, fvisit):
     fvisit : function
         The visitor function to be applied.
     """
-    return _ffi_api.post_order_visit(expr, fvisit)
+    return _ffi_api.post_order_visit(expr, fvisit)  # type: ignore
 
 
 def well_formed(mod: tvm.IRModule) -> bool:
@@ -58,7 +58,7 @@ def well_formed(mod: tvm.IRModule) -> bool:
     ret: bool
         True if the IRModule is well formed, False if not.
     """
-    return _ffi_api.well_formed(mod)
+    return _ffi_api.well_formed(mod)  # type: ignore
 
 
 def get_var2val(func: Function) -> Dict[Var, Expr]:
@@ -75,7 +75,7 @@ def get_var2val(func: Function) -> Dict[Var, Expr]:
     Dict[Var, Expr]
         A mapping from Var to Expr.
     """
-    return _ffi_api.get_var2val(func)
+    return _ffi_api.get_var2val(func)  # type: ignore
 
 
 def udchain(dfb: DataflowBlock) -> Dict[Var, List[Var]]:
@@ -92,12 +92,12 @@ def udchain(dfb: DataflowBlock) -> Dict[Var, List[Var]]:
     Dict[Var, List[Var]]
         A mapping from variable definition to its uses.
     """
-    return _ffi_api.udchain(dfb)
+    return _ffi_api.udchain(dfb)  # type: ignore
 
 
 def name_to_binding(func: Function) -> Dict[str, List[Binding]]:
     """Return a map from variable name to its bindings."""
-    return _ffi_api.name_to_binding(func)
+    return _ffi_api.name_to_binding(func)  # type: ignore
 
 
 def remove_all_unused(func: Function) -> Function:
@@ -113,7 +113,7 @@ def remove_all_unused(func: Function) -> Function:
     Function
         The function with unused variables removed.
     """
-    return _ffi_api.remove_all_unused(func)
+    return _ffi_api.remove_all_unused(func)  # type: ignore
 
 
 def shape_vars(expr: Expr) -> List[tir.Var]:
@@ -133,7 +133,7 @@ def shape_vars(expr: Expr) -> List[tir.Var]:
     ret: List[tir.Var]
         A list of all shape variables (TIR variables) in the expression.
     """
-    return _ffi_api.shape_vars(expr)
+    return _ffi_api.shape_vars(expr)  # type: ignore
 
 
 def derive_func_ret_shape(args: List[Var], body: Expr) -> Expr:
@@ -156,7 +156,7 @@ def derive_func_ret_shape(args: List[Var], body: Expr) -> Expr:
     ret: Expr
         An expression that can serve as the return shape for the function
     """
-    return _ffi_api.derive_func_ret_shape(args, body)
+    return _ffi_api.derive_func_ret_shape(args, body)  # type: ignore
 
 
 def bound_vars(expr: Expr) -> List[Var]:
@@ -176,7 +176,7 @@ def bound_vars(expr: Expr) -> List[Var]:
     ret: List[Var]
         List of bound vars in expr, in post-DFS order
     """
-    return _ffi_api.bound_vars(expr)
+    return _ffi_api.bound_vars(expr)  # type: ignore
 
 
 def free_vars(expr: Expr) -> List[Var]:
@@ -196,7 +196,7 @@ def free_vars(expr: Expr) -> List[Var]:
     ret: List[Var]
         List of free vars in expr, in post-DFS order
     """
-    return _ffi_api.free_vars(expr)
+    return _ffi_api.free_vars(expr)  # type: ignore
 
 
 def all_vars(expr: Expr) -> List[Var]:
@@ -213,7 +213,7 @@ def all_vars(expr: Expr) -> List[Var]:
     ret: List[Var]
         List of vars in expr, in post-DFS order
     """
-    return _ffi_api.all_vars(expr)
+    return _ffi_api.all_vars(expr)  # type: ignore
 
 
 def all_global_vars(expr: Expr) -> List[GlobalVar]:
@@ -230,7 +230,7 @@ def all_global_vars(expr: Expr) -> List[GlobalVar]:
     ret: List[GlobalVar]
         List of global vars in expr, in post-DFS order
     """
-    return _ffi_api.all_global_vars(expr)
+    return _ffi_api.all_global_vars(expr)  # type: ignore
 
 
 def called_global_vars(expr: Expr) -> List[GlobalVar]:
@@ -248,4 +248,4 @@ def called_global_vars(expr: Expr) -> List[GlobalVar]:
         List of global vars that are used recursively in expr,
         in post-DFS order
     """
-    return _ffi_api.called_global_vars(expr)
+    return _ffi_api.called_global_vars(expr)  # type: ignore

--- a/python/tvm/relax/binding_rewrite.py
+++ b/python/tvm/relax/binding_rewrite.py
@@ -51,7 +51,9 @@ class DataflowBlockRewrite(Object):
             The root function of the DataflowBlock.
         """
         self.func_name = root_fn.__name__ if hasattr(root_fn, "__name__") else None
-        self.__init_handle_by_constructor__(_ffi_api.DataflowBlockRewrite, dfb, root_fn)
+        self.__init_handle_by_constructor__(
+            _ffi_api.DataflowBlockRewrite, dfb, root_fn  # type: ignore
+        )
 
     def replace_all_uses(self, old_var: Var, new_var: Var) -> None:
         """
@@ -64,10 +66,10 @@ class DataflowBlockRewrite(Object):
         new_var : Var
             The new variable to replace with.
         """
-        _ffi_api.dfb_rewrite_replace_all_uses(self, old_var, new_var)
+        _ffi_api.dfb_rewrite_replace_all_uses(self, old_var, new_var)  # type: ignore
 
     def add_binding(self, binding: Binding) -> None:
-        return _ffi_api.dfb_rewrite_add_binding(self, binding)
+        return _ffi_api.dfb_rewrite_add_binding(self, binding)  # type: ignore
 
     def add(self, expr: Expr, name: Optional[str] = None, is_dfvar: bool = False) -> None:
         """
@@ -89,7 +91,7 @@ class DataflowBlockRewrite(Object):
         it will be Var. Being Var means the variables are output variables of the DataflowBlock.
         While being DataflowVar means the variables are internal variables of the DataflowBlock.
         """
-        _ffi_api.dfb_rewrite_add(self, expr, name, is_dfvar)
+        _ffi_api.dfb_rewrite_add(self, expr, name, is_dfvar)  # type: ignore
 
     def remove_unused(self, var: Var, allow_undef=False) -> None:
         """
@@ -106,7 +108,7 @@ class DataflowBlockRewrite(Object):
         ------
         TVMError if the variable is used or undefined (allow_undef=False).
         """
-        _ffi_api.dfb_rewrite_remove_unused(self, var, allow_undef)
+        _ffi_api.dfb_rewrite_remove_unused(self, var, allow_undef)  # type: ignore
 
     def remove_all_unused(self) -> None:
         """
@@ -116,7 +118,7 @@ class DataflowBlockRewrite(Object):
         -----
         This could remove unused variables in other DataflowBlocks as well.
         """
-        _ffi_api.dfb_rewrite_remove_all_unused(self)
+        _ffi_api.dfb_rewrite_remove_all_unused(self)  # type: ignore
 
     def mutated_dfb(self) -> DataflowBlock:
         """
@@ -147,7 +149,7 @@ class DataflowBlockRewrite(Object):
         tvm.IRModule
             The updated IRModule.
         """
-        ret = _ffi_api.dfb_rewrite_mutate_irmodule(self, irmodule)
+        ret = _ffi_api.dfb_rewrite_mutate_irmodule(self, irmodule)  # type: ignore
         if hasattr(irmodule, "__name__"):
             ret.__name__ = irmodule.__name__
         return ret

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -137,19 +137,19 @@ class BlockBuilder(Object):
         return BlockBuilder._current
 
     def __init__(self, mod: IRModule = None):
-        self._blocks = []
+        self._blocks: List[BindingBlock] = []
         # a boolean flag that tracks if emit_func_output has been called
         self._is_emit_func_output_called = False
-        self.__init_handle_by_constructor__(_ffi_api.BlockBuilderCreate, mod)
+        self.__init_handle_by_constructor__(_ffi_api.BlockBuilderCreate, mod)  # type: ignore
 
     def _begin_dataflow_block(self) -> None:
-        _ffi_api.BlockBuilderBeginDataflowBlock(self)
+        _ffi_api.BlockBuilderBeginDataflowBlock(self)  # type: ignore
 
     def _begin_binding_block(self) -> None:
-        _ffi_api.BlockBuilderBeginBindingBlock(self)
+        _ffi_api.BlockBuilderBeginBindingBlock(self)  # type: ignore
 
     def _end_block(self) -> BindingBlock:
-        return _ffi_api.BlockBuilderEndBlock(self)
+        return _ffi_api.BlockBuilderEndBlock(self)  # type: ignore
 
     def _enter_function_scope(self, name, params, attrs):
         if BlockBuilder.current() is not None:
@@ -196,7 +196,7 @@ class BlockBuilder(Object):
         te_args_list = []
 
         def _convert_te_arg_helper(arg):
-            if isinstance(arg, Expr):
+            if isinstance(arg, Expr):  # type: ignore
                 arg = te_tensor(arg)
                 te_args_list.append(arg)
                 return arg
@@ -307,7 +307,7 @@ class BlockBuilder(Object):
         ret : tvm.relax.Var
             A newly created variable that gets bound to the input expr.
         """
-        return _ffi_api.BlockBuilderEmit(self, expr)
+        return _ffi_api.BlockBuilderEmit(self, expr)  # type: ignore
 
     def call_te(self, func: Callable, *args: Any, **kwargs: Any) -> Expr:
         """Generate a call node according to the te function.
@@ -521,7 +521,7 @@ class BlockBuilder(Object):
         ret : tvm.relax.Var
             A newly created variable that gets bound to the call code.
         """
-        return _ffi_api.BlockBuilderEmitMatchShape(self, value, pattern)
+        return _ffi_api.BlockBuilderEmitMatchShape(self, value, pattern)  # type: ignore
 
     def emit_output(self, output: Union[Expr, Tuple, List[Expr]]) -> None:
         """Emit output for the current dataflow block or function.
@@ -538,7 +538,7 @@ class BlockBuilder(Object):
         """
         if isinstance(output, (list, tuple)):
             output = Tuple(output)
-        return _ffi_api.BlockBuilderEmitOutput(self, output)
+        return _ffi_api.BlockBuilderEmitOutput(self, output)  # type: ignore
 
     def emit_func_output(
         self,
@@ -610,7 +610,7 @@ class BlockBuilder(Object):
         ret : Expr
             The expr with normalized shape and type.
         """
-        return _ffi_api.BlockBuilderNormalize(self, expr)
+        return _ffi_api.BlockBuilderNormalize(self, expr)  # type: ignore
 
     def get(self) -> tvm.IRModule:
         """Return the IRModule being built.
@@ -620,7 +620,7 @@ class BlockBuilder(Object):
         ret : tvm.IRModule
             An IRModule with Relax and TIR functions being built.
         """
-        return _ffi_api.BlockBuilderGetContextIRModule(self)
+        return _ffi_api.BlockBuilderGetContextIRModule(self)  # type: ignore
 
     def get_unique_name(self, name_prefix: str) -> str:
         """Generate a unique name with a specified prefix.
@@ -635,7 +635,7 @@ class BlockBuilder(Object):
         ret : str
             The generated name.
         """
-        return _ffi_api.BlockBuilderGetUniqueName(self, name_prefix)
+        return _ffi_api.BlockBuilderGetUniqueName(self, name_prefix)  # type: ignore
 
     def add_func(self, func: BaseFunc, func_name: str) -> GlobalVar:
         """Add a Relax function or a TIR PrimFunc to the IRModule being built.
@@ -653,7 +653,7 @@ class BlockBuilder(Object):
         gvar : GlobalVar
             The global var bound to the added function.
         """
-        return _ffi_api.BlockBuilderAddFunction(self, func, func_name)
+        return _ffi_api.BlockBuilderAddFunction(self, func, func_name)  # type: ignore
 
     def update_func(self, gv: GlobalVar, updated_func: BaseFunc) -> None:
         """Add a Relax function or a TIR PrimFunc to the IRModule being built.
@@ -666,7 +666,7 @@ class BlockBuilder(Object):
         updated_func : BaseFunc
             The updated function.
         """
-        return _ffi_api.BlockBuilderUpdateFunction(self, gv, updated_func)
+        return _ffi_api.BlockBuilderUpdateFunction(self, gv, updated_func)  # type: ignore
 
     def can_prove_shape_equal(self, lhs: Expr, rhs: Expr) -> bool:
         """Check if two shape expressions can be proven equal at compile time.
@@ -684,7 +684,7 @@ class BlockBuilder(Object):
         ret : bool
             Whether we can prove lhs shape is the same as the rhs shape.
         """
-        return _ffi_api.BlockBuilderCanProveShapeEqual(self, lhs, rhs)
+        return _ffi_api.BlockBuilderCanProveShapeEqual(self, lhs, rhs)  # type: ignore
 
     def current_block_is_dataflow(self) -> bool:
         """Check if the block being built is DataflowBlock or not.
@@ -694,7 +694,7 @@ class BlockBuilder(Object):
         ret : bool
             A boolean that indicates if the block being built is DataflowBlock or not.
         """
-        return _ffi_api.BlockBuilderCurrentBlockIsDataFlow(self)
+        return _ffi_api.BlockBuilderCurrentBlockIsDataFlow(self)  # type: ignore
 
     def emit_var_binding(self, binding: VarBinding) -> Var:
         """Emits a variable binding, and returns the bound Var.
@@ -709,7 +709,7 @@ class BlockBuilder(Object):
         var: Var
             The bound variable.
         """
-        return _ffi_api.BlockBuilderEmitVarBinding(self, binding)
+        return _ffi_api.BlockBuilderEmitVarBinding(self, binding)  # type: ignore
 
     def emit_output_var_binding(self, binding: VarBinding) -> Var:
         """Generate an output for the current dataflow block.
@@ -724,7 +724,7 @@ class BlockBuilder(Object):
         var: Var
             The variable bound to output.
         """
-        return _ffi_api.BlockBuilderEmitOutputVarBinding(self, binding)
+        return _ffi_api.BlockBuilderEmitOutputVarBinding(self, binding)  # type: ignore
 
     def match_shape_binding(self, binding: MatchShape) -> Var:
         """Emit a MatchShape binding.
@@ -739,7 +739,7 @@ class BlockBuilder(Object):
         var: Var
             The variable bound to the MatchShape.
         """
-        return _ffi_api.BlockBuilderEmitMatchShapeBinding(self, binding)
+        return _ffi_api.BlockBuilderEmitMatchShapeBinding(self, binding)  # type: ignore
 
     def lookup_binding(self, var: Var) -> Optional[Expr]:
         """Lookup a var in the binding table binding_table_.
@@ -754,4 +754,4 @@ class BlockBuilder(Object):
         expr: Expr
             The Expr bound to the input var.
         """
-        return _ffi_api.BlockBuilderLookupBinding(self, var)
+        return _ffi_api.BlockBuilderLookupBinding(self, var)  # type: ignore

--- a/python/tvm/relax/dpl/context.py
+++ b/python/tvm/relax/dpl/context.py
@@ -37,16 +37,16 @@ class PatternContext(tvm.runtime.Object):
         incremental : bool, optional
             perform incremental matching based on the recent context, by default False
         """
-        self.__init_handle_by_constructor__(ffi.PatternContext, incremental)
+        self.__init_handle_by_constructor__(ffi.PatternContext, incremental)  # type: ignore
 
     def __enter__(self):
         """Enter the context"""
-        ffi.enter_context(self)
+        ffi.enter_context(self)  # type: ignore
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit the context"""
-        ffi.exit_context(self)
+        ffi.exit_context(self)  # type: ignore
 
     @staticmethod
     def current() -> "PatternContext":
@@ -58,7 +58,7 @@ class PatternContext(tvm.runtime.Object):
         PatternContext
             The current context
         """
-        return ffi.current_context()
+        return ffi.current_context()  # type: ignore
 
     def match_dfb(
         self,
@@ -83,4 +83,4 @@ class PatternContext(tvm.runtime.Object):
         Dict[DFPattern, Var]
             The mapping from DFPattern to matched expression
         """
-        return ffi.match_dfb(self, dfb, start_hint, must_include_hint)
+        return ffi.match_dfb(self, dfb, start_hint, must_include_hint)  # type: ignore

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -20,6 +20,7 @@
 # pylint: disable=pointless-statement
 
 from typing import List, Optional, Dict, Union, Tuple
+import typing
 
 import tvm
 import tvm._ffi as tvm_ffi
@@ -201,7 +202,7 @@ class DFPattern(Node):
         when the recursive pattern matching goes to check lv0. The var2val mapping
         can be computed through the tvm.relax.analysis.get_var2val function.
         """
-        return ffi.match_expr(self, expr, var2val)
+        return ffi.match_expr(self, expr, var2val)  # type: ignore
 
     def has_rt_dep_shape(self) -> "AndPattern":
         """
@@ -267,7 +268,7 @@ class DFPattern(Node):
         DFPattern
             A duplicated pattern
         """
-        return ffi.dup_pattern(self)
+        return ffi.dup_pattern(self)  # type: ignore
 
     def fork_to(self, *args) -> None:
         """Fork the current pattern to multiple pattern branches"""
@@ -280,7 +281,7 @@ class RuntimeDepShapePattern(DFPattern):
     """A pattern matching a Relax RuntimeDepShape."""
 
     def __init__(self, pattern: DFPattern):
-        self.__init_handle_by_constructor__(ffi.RuntimeDepShapePattern, pattern)
+        self.__init_handle_by_constructor__(ffi.RuntimeDepShapePattern, pattern)  # type: ignore
 
 
 @register_df_node
@@ -294,7 +295,7 @@ class ExprPattern(DFPattern):
     """
 
     def __init__(self, expr: Expr):
-        self.__init_handle_by_constructor__(ffi.ExprPattern, expr)
+        self.__init_handle_by_constructor__(ffi.ExprPattern, expr)  # type: ignore
 
 
 @register_df_node
@@ -309,7 +310,7 @@ class VarPattern(DFPattern):
     """
 
     def __init__(self, name_hint: str = ""):
-        self.__init_handle_by_constructor__(ffi.VarPattern, name_hint)
+        self.__init_handle_by_constructor__(ffi.VarPattern, name_hint)  # type: ignore
 
 
 @register_df_node
@@ -324,7 +325,7 @@ class DataflowVarPattern(DFPattern):
     """
 
     def __init__(self, name_hint: str = ""):
-        self.__init_handle_by_constructor__(ffi.DataflowVarPattern, name_hint)
+        self.__init_handle_by_constructor__(ffi.DataflowVarPattern, name_hint)  # type: ignore
 
 
 @register_df_node
@@ -339,7 +340,7 @@ class GlobalVarPattern(DFPattern):
     """
 
     def __init__(self, name_hint: str = ""):
-        self.__init_handle_by_constructor__(ffi.GlobalVarPattern, name_hint)
+        self.__init_handle_by_constructor__(ffi.GlobalVarPattern, name_hint)  # type: ignore
 
 
 @register_df_node
@@ -354,7 +355,7 @@ class ExternFuncPattern(DFPattern):
     """
 
     def __init__(self, global_symbol: str = ""):
-        self.__init_handle_by_constructor__(ffi.ExternFuncPattern, global_symbol)
+        self.__init_handle_by_constructor__(ffi.ExternFuncPattern, global_symbol)  # type: ignore
 
 
 @register_df_node
@@ -362,7 +363,7 @@ class ConstantPattern(DFPattern):
     """A pattern matching a Relax Constant."""
 
     def __init__(self):
-        self.__init_handle_by_constructor__(ffi.ConstantPattern)
+        self.__init_handle_by_constructor__(ffi.ConstantPattern)  # type: ignore
 
 
 @register_df_node
@@ -391,10 +392,12 @@ class CallPattern(DFPattern):
     def __init__(
         self,
         op: "DFPattern",
-        args: List["DFPattern"],
+        args: Union[List["DFPattern"], typing.Tuple["DFPattern", ...]],
         varg_default_wildcard: bool = False,
     ):
-        self.__init_handle_by_constructor__(ffi.CallPattern, op, args, varg_default_wildcard)
+        self.__init_handle_by_constructor__(
+            ffi.CallPattern, op, args, varg_default_wildcard  # type: ignore
+        )
 
 
 @register_df_node
@@ -416,7 +419,7 @@ class FunctionPattern(DFPattern):
         params: List["DFPattern"],
         body: "DFPattern",
     ):
-        self.__init_handle_by_constructor__(ffi.FunctionPattern, params, body)
+        self.__init_handle_by_constructor__(ffi.FunctionPattern, params, body)  # type: ignore
 
 
 @register_df_node
@@ -430,7 +433,7 @@ class TuplePattern(DFPattern):
     """
 
     def __init__(self, fields: Array):
-        self.__init_handle_by_constructor__(ffi.TuplePattern, fields)
+        self.__init_handle_by_constructor__(ffi.TuplePattern, fields)  # type: ignore
 
     def __getitem__(self, index: Optional[int]) -> "TupleGetItemPattern":
         if index is not None:
@@ -458,7 +461,7 @@ class UnorderedTuplePattern(DFPattern):
     """
 
     def __init__(self, fields: Array):
-        self.__init_handle_by_constructor__(ffi.UnorderedTuplePattern, fields)
+        self.__init_handle_by_constructor__(ffi.UnorderedTuplePattern, fields)  # type: ignore
 
     def __len__(self):
         return len(self.fields)
@@ -479,7 +482,9 @@ class TupleGetItemPattern(DFPattern):
 
     def __init__(self, tuple_value: "DFPattern", index: Optional[int] = None):
         match_index = index if index is not None else -1
-        self.__init_handle_by_constructor__(ffi.TupleGetItemPattern, tuple_value, match_index)
+        self.__init_handle_by_constructor__(
+            ffi.TupleGetItemPattern, tuple_value, match_index  # type: ignore
+        )
 
 
 @register_df_node
@@ -495,7 +500,7 @@ class OrPattern(DFPattern):
     """
 
     def __init__(self, left: "DFPattern", right: "DFPattern"):
-        self.__init_handle_by_constructor__(ffi.OrPattern, left, right)
+        self.__init_handle_by_constructor__(ffi.OrPattern, left, right)  # type: ignore
 
 
 @register_df_node
@@ -511,7 +516,7 @@ class AndPattern(DFPattern):
     """
 
     def __init__(self, left: "DFPattern", right: "DFPattern"):
-        self.__init_handle_by_constructor__(ffi.AndPattern, left, right)
+        self.__init_handle_by_constructor__(ffi.AndPattern, left, right)  # type: ignore
 
 
 @register_df_node
@@ -525,7 +530,7 @@ class NotPattern(DFPattern):
     """
 
     def __init__(self, to_reject: "DFPattern"):
-        self.__init_handle_by_constructor__(ffi.NotPattern, to_reject)
+        self.__init_handle_by_constructor__(ffi.NotPattern, to_reject)  # type: ignore
 
 
 @register_df_node
@@ -533,7 +538,7 @@ class WildcardPattern(DFPattern):
     """A pattern which matches anything."""
 
     def __init__(self):
-        self.__init_handle_by_constructor__(ffi.WildcardPattern)
+        self.__init_handle_by_constructor__(ffi.WildcardPattern)  # type: ignore
 
 
 @register_df_node
@@ -550,7 +555,7 @@ class TypePattern(DFPattern):
     """
 
     def __init__(self, pattern: "DFPattern", ttype: tvm.ir.type.Type):
-        self.__init_handle_by_constructor__(ffi.TypePattern, pattern, ttype)
+        self.__init_handle_by_constructor__(ffi.TypePattern, pattern, ttype)  # type: ignore
 
 
 @register_df_node
@@ -567,7 +572,7 @@ class DataTypePattern(DFPattern):
     """
 
     def __init__(self, pattern: "DFPattern", dtype: str):
-        self.__init_handle_by_constructor__(ffi.DataTypePattern, pattern, dtype)
+        self.__init_handle_by_constructor__(ffi.DataTypePattern, pattern, dtype)  # type: ignore
 
 
 @register_df_node
@@ -584,7 +589,7 @@ class ShapePattern(DFPattern):
     """
 
     def __init__(self, pattern: "DFPattern", shape: List[tvm.ir.PrimExpr]):
-        self.__init_handle_by_constructor__(ffi.ShapePattern, pattern, shape)
+        self.__init_handle_by_constructor__(ffi.ShapePattern, pattern, shape)  # type: ignore
 
 
 @register_df_node
@@ -599,7 +604,7 @@ class PrimArrPattern(DFPattern):
     """
 
     def __init__(self, shape: List[tvm.ir.PrimExpr]):
-        self.__init_handle_by_constructor__(ffi.PrimArrPattern, shape)
+        self.__init_handle_by_constructor__(ffi.PrimArrPattern, shape)  # type: ignore
 
     def __getitem__(self, index: int):
         if index >= len(self):
@@ -625,7 +630,7 @@ class AttrPattern(DFPattern):
     """
 
     def __init__(self, pattern: "DFPattern", attrs: tvm.ir.attrs.Attrs):
-        self.__init_handle_by_constructor__(ffi.AttrPattern, pattern, attrs)
+        self.__init_handle_by_constructor__(ffi.AttrPattern, pattern, attrs)  # type: ignore
 
 
 def is_var(name: str = "") -> VarPattern:
@@ -928,7 +933,7 @@ class PatternSeq(Node):
         only_use : bool, optional
             Whether the patterns follows only-used-by relations consecutively, by default False
         """
-        self.__init_handle_by_constructor__(ffi.PatternSeq, patterns, only_use)
+        self.__init_handle_by_constructor__(ffi.PatternSeq, patterns, only_use)  # type: ignore
 
     def used_by(self, other: Union[DFPattern, "PatternSeq"], index=-1) -> "PatternSeq":
         """
@@ -1010,7 +1015,7 @@ class PatternSeq(Node):
         PatternSeq
             A duplicated chain
         """
-        return ffi.dup_seq(self)
+        return ffi.dup_seq(self)  # type: ignore
 
 
 ### Private functions
@@ -1025,7 +1030,7 @@ def _used_by(
         lhs = PatternSeq([lhs])
     if isinstance(rhs, DFPattern):
         rhs = PatternSeq([rhs])
-    return ffi.used_by(lhs, rhs, index)
+    return ffi.used_by(lhs, rhs, index)  # type: ignore
 
 
 def _only_used_by(
@@ -1035,4 +1040,4 @@ def _only_used_by(
         lhs = PatternSeq([lhs])
     if isinstance(rhs, DFPattern):
         rhs = PatternSeq([rhs])
-    return ffi.only_used_by(lhs, rhs, index)
+    return ffi.only_used_by(lhs, rhs, index)  # type: ignore

--- a/python/tvm/relax/exec_builder.py
+++ b/python/tvm/relax/exec_builder.py
@@ -16,6 +16,8 @@
 # under the License.
 # pylint: disable=invalid-name
 """A builder to build Relax VM executable."""
+from __future__ import annotations
+
 from enum import IntEnum
 from typing import Optional, Union, List
 import tvm
@@ -36,7 +38,7 @@ class SpecialReg(IntEnum):
 class VMFuncScope(object):
     """An object corresponds to each VM function, working as a context manager."""
 
-    stack = []
+    stack: List[VMFuncScope] = []
 
     def __enter__(self):
         VMFuncScope.stack.append(self)
@@ -51,19 +53,19 @@ class ExecBuilder(Object):
     """A builder to emit instructions and build executable for the virtual machine."""
 
     def __init__(self) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.ExecBuilderCreate)
+        self.__init_handle_by_constructor__(_ffi_api.ExecBuilderCreate)  # type: ignore
 
     def r(self, idx: int) -> int:
         """set instruction's argument as a register."""
-        return _ffi_api.ExecBuilderR(self, idx)
+        return _ffi_api.ExecBuilderR(self, idx)  # type: ignore
 
     def imm(self, value: int) -> int:
         """set instruction's argument as an immediate."""
-        return _ffi_api.ExecBuilderImm(self, value)
+        return _ffi_api.ExecBuilderImm(self, value)  # type: ignore
 
     def c(self, idx: int) -> int:
         """set instruction's argument as a constant."""
-        return _ffi_api.ExecBuilderC(self, idx)
+        return _ffi_api.ExecBuilderC(self, idx)  # type: ignore
 
     def void_arg(self) -> int:
         return self.r(SpecialReg.VOID_ARG)
@@ -75,7 +77,7 @@ class ExecBuilder(Object):
         self, func_name: str, num_inputs: Optional[int] = 0, param_names: List[str] = None
     ) -> VMFuncScope:
         """annotate a VM function."""
-        _ffi_api.ExecBuilderFunction(self, func_name, num_inputs, param_names)
+        _ffi_api.ExecBuilderFunction(self, func_name, num_inputs, param_names)  # type: ignore
         return VMFuncScope()
 
     def _check_scope(self) -> None:
@@ -83,7 +85,7 @@ class ExecBuilder(Object):
             raise ValueError("emit should happen in a function scope")
 
     def emit_constant(self, const: TVMRetValueHandle) -> int:
-        return _ffi_api.ExecBuilderEmitConstant(self, const)
+        return _ffi_api.ExecBuilderEmitConstant(self, const)  # type: ignore
 
     def emit_call(
         self,
@@ -107,23 +109,23 @@ class ExecBuilder(Object):
                     args_.append(new_arg)
                 else:
                     args_.append(arg)
-        _ffi_api.ExecBuilderEmitCall(self, name, args_, dst)
+        _ffi_api.ExecBuilderEmitCall(self, name, args_, dst)  # type: ignore
 
     def emit_ret(self, result: int) -> None:
         """emit a return instruction"""
         self._check_scope()
-        _ffi_api.ExecBuilderEmitRet(self, result)
+        _ffi_api.ExecBuilderEmitRet(self, result)  # type: ignore
 
     def emit_goto(self, pc_offset):
         """emit a goto instruction"""
         self._check_scope()
-        _ffi_api.ExecBuilderEmitGoto(self, pc_offset)
+        _ffi_api.ExecBuilderEmitGoto(self, pc_offset)  # type: ignore
 
     def emit_if(self, cond, false_offset):
         """emit an if instruction"""
         self._check_scope()
-        _ffi_api.ExecBuilderEmitIf(self, cond, false_offset)
+        _ffi_api.ExecBuilderEmitIf(self, cond, false_offset)  # type: ignore
 
     def get(self) -> Executable:
         """return the executable"""
-        return Executable(_ffi_api.ExecBuilderGet(self))
+        return Executable(_ffi_api.ExecBuilderGet(self))  # type: ignore

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -114,9 +114,9 @@ class ExprFunctor:
     implements memoization.
     """
 
-    def visit_expr(self, expr):
+    def visit_expr(self, expr: Expr) -> Expr:
         """Apply the visitor to an expression."""
-        if isinstance(expr, Constant):
+        if isinstance(expr, Constant):  # type: ignore
             ret = self.visit_constant_(expr)
         elif isinstance(expr, Tuple):
             ret = self.visit_tuple_(expr)
@@ -130,15 +130,15 @@ class ExprFunctor:
             ret = self.visit_runtime_dep_shape_(expr)
         elif isinstance(expr, ExternFunc):
             ret = self.visit_extern_func_(expr)
-        elif isinstance(expr, GlobalVar):
+        elif isinstance(expr, GlobalVar):  # type: ignore
             ret = self.visit_global_var_(expr)
         elif isinstance(expr, Function):
             ret = self.visit_function_(expr)
-        elif isinstance(expr, Call):
+        elif isinstance(expr, Call):  # type: ignore
             ret = self.visit_call_(expr)
         elif isinstance(expr, SeqExpr):
             ret = self.visit_seq_expr_(expr)
-        elif isinstance(expr, If):
+        elif isinstance(expr, If):  # type: ignore
             ret = self.visit_if_(expr)
         elif isinstance(expr, Op):
             ret = self.visit_op_(expr)
@@ -191,25 +191,25 @@ class ExprFunctor:
     def visit_tuple_getitem_(self, op: TupleGetItem):
         raise NotImplementedError()
 
-    def visit_var_binding_(self, binding: VarBinding) -> None:
+    def visit_var_binding_(self, binding: VarBinding):
         raise NotImplementedError()
 
-    def visit_match_shape_(self, binding: MatchShape) -> None:
+    def visit_match_shape_(self, binding: MatchShape):
         raise NotImplementedError()
 
-    def visit_binding_block_(self, block: BindingBlock) -> None:
+    def visit_binding_block_(self, block: BindingBlock):
         raise NotImplementedError()
 
-    def visit_dataflow_block_(self, block: DataflowBlock) -> None:
+    def visit_dataflow_block_(self, block: DataflowBlock):
         raise NotImplementedError()
 
-    def visit_var_def_(self, var: Var) -> None:
+    def visit_var_def_(self, var: Var):
         raise NotImplementedError()
 
-    def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
+    def visit_dataflow_var_def_(self, var: DataflowVar):
         raise NotImplementedError()
 
-    def visit_binding(self, binding: Binding) -> None:
+    def visit_binding(self, binding: Binding):
         if isinstance(binding, MatchShape):
             self.visit_match_shape_(binding)
         elif isinstance(binding, VarBinding):
@@ -217,7 +217,7 @@ class ExprFunctor:
         else:
             raise TypeError("Invalid type: {0}".format(type(binding)))
 
-    def visit_binding_block(self, block: BindingBlock) -> None:
+    def visit_binding_block(self, block: BindingBlock):
         if isinstance(block, DataflowBlock):
             self.visit_dataflow_block_(block)
         elif isinstance(block, BindingBlock):
@@ -277,7 +277,7 @@ class _PyExprVisitor(Object):
         """Constructor."""
 
         self.__init_handle_by_constructor__(
-            _ffi_api.MakePyExprVisitor,
+            _ffi_api.MakePyExprVisitor,  # type: ignore
             f_visit_expr,
             f_visit_constant_,
             f_visit_tuple_,
@@ -314,7 +314,7 @@ class _PyExprVisitor(Object):
         expr : Expr
             The expr to be visited.
         """
-        return _ffi_api.PyExprVisitorVisitExpr(self, expr)
+        return _ffi_api.PyExprVisitorVisitExpr(self, expr)  # type: ignore
 
     def visit_binding(self, binding: Binding) -> None:
         """Generic dispatcher for Binding.
@@ -324,7 +324,7 @@ class _PyExprVisitor(Object):
         binding : Binding
             The binding to be visited.
         """
-        return _ffi_api.PyExprVisitorVisitBinding(self, binding)
+        return _ffi_api.PyExprVisitorVisitBinding(self, binding)  # type: ignore
 
     def visit_binding_block(self, block: BindingBlock) -> None:
         """Generic dispatcher for BindingBlock.
@@ -334,7 +334,7 @@ class _PyExprVisitor(Object):
         block : BindingBlock
             The block to be visited.
         """
-        return _ffi_api.PyExprVisitorVisitBindingBlock(self, block)
+        return _ffi_api.PyExprVisitorVisitBindingBlock(self, block)  # type: ignore
 
     def visit_var_def(self, var: Var) -> None:
         """Generic dispatcher for visiting the var definition site.
@@ -345,7 +345,7 @@ class _PyExprVisitor(Object):
         var : Var
             The var to be visited.
         """
-        return _ffi_api.PyExprVisitorVisitVarDef(self, var)
+        return _ffi_api.PyExprVisitorVisitVarDef(self, var)  # type: ignore
 
 
 class PyExprVisitor:
@@ -407,7 +407,7 @@ class PyExprVisitor:
             The expr to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.PyExprVisitorVisitExpr(self._outer(), expr)
+        return _ffi_api.PyExprVisitorVisitExpr(self._outer(), expr)  # type: ignore
 
     def visit_binding(self, binding: Binding) -> None:
         """Generic dispatcher for Binding.
@@ -420,7 +420,7 @@ class PyExprVisitor:
             The binding to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.PyExprVisitorVisitBinding(self._outer(), binding)
+        return _ffi_api.PyExprVisitorVisitBinding(self._outer(), binding)  # type: ignore
 
     def visit_binding_block(self, block: BindingBlock) -> None:
         """Generic dispatcher for BindingBlock.
@@ -433,7 +433,7 @@ class PyExprVisitor:
             The block to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.PyExprVisitorVisitBindingBlock(self._outer(), block)
+        return _ffi_api.PyExprVisitorVisitBindingBlock(self._outer(), block)  # type: ignore
 
     def visit_var_def(self, var: Var) -> None:
         """Generic dispatcher for visiting the var definition site.
@@ -446,7 +446,7 @@ class PyExprVisitor:
             The var to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.PyExprVisitorVisitVarDef(self._outer(), var)
+        return _ffi_api.PyExprVisitorVisitVarDef(self._outer(), var)  # type: ignore
 
     def visit_constant_(self, op: Constant) -> None:
         """Visit Constant.
@@ -459,7 +459,7 @@ class PyExprVisitor:
             The Constant to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_tuple_(self, op: Tuple) -> None:
         """Visit Tuple.
@@ -472,7 +472,7 @@ class PyExprVisitor:
             The Tuple to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_var_(self, op: Var) -> None:
         """Visit Var.
@@ -485,7 +485,7 @@ class PyExprVisitor:
             The Var to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_dataflow_var_(self, op: DataflowVar) -> None:
         """Visit DataflowVar.
@@ -498,7 +498,7 @@ class PyExprVisitor:
             The DataflowVar to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_shape_expr_(self, op: ShapeExpr) -> None:
         """Visit ShapeExpr.
@@ -511,7 +511,7 @@ class PyExprVisitor:
             The ShapeExpr to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> None:
         """Visit RuntimeDepShape.
@@ -524,7 +524,7 @@ class PyExprVisitor:
             The RuntimeDepShape to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_extern_func_(self, op: ExternFunc) -> None:
         """Visit ExternFunc.
@@ -537,7 +537,7 @@ class PyExprVisitor:
             The ExternFunc to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_global_var_(self, op: GlobalVar) -> None:
         """Visit GlobalVar.
@@ -550,7 +550,7 @@ class PyExprVisitor:
             The GlobalVar to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_function_(self, op: Function) -> None:
         """Visit Function.
@@ -563,7 +563,7 @@ class PyExprVisitor:
             The Function to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_call_(self, op: Call) -> None:
         """Visit Call.
@@ -576,7 +576,7 @@ class PyExprVisitor:
             The Call to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_seq_expr_(self, op: SeqExpr) -> None:
         """Visit SeqExpr.
@@ -589,7 +589,7 @@ class PyExprVisitor:
             The SeqExpr to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_if_(self, op: If) -> None:
         """Visit If.
@@ -602,7 +602,7 @@ class PyExprVisitor:
             The If to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_op_(self, op: Op) -> None:
         """Visit Op.
@@ -615,7 +615,7 @@ class PyExprVisitor:
             The Op to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> None:
         """Visit TupleGetItem.
@@ -628,7 +628,7 @@ class PyExprVisitor:
             The TupleGetItem to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprVisitorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
         """Visit VarBinding.
@@ -641,7 +641,7 @@ class PyExprVisitor:
             The VarBinding to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)
+        return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)  # type: ignore
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
         """Visit MatchShape.
@@ -654,7 +654,7 @@ class PyExprVisitor:
             The MatchShape to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)
+        return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)  # type: ignore
 
     def visit_binding_block_(self, block: BindingBlock) -> None:
         """Visit BindingBlock.
@@ -667,7 +667,7 @@ class PyExprVisitor:
             The BindingBlock to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitBindingBlock(self._outer(), block)
+        return _ffi_api.ExprVisitorVisitBindingBlock(self._outer(), block)  # type: ignore
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> None:
         """Visit DataflowBlock.
@@ -680,7 +680,7 @@ class PyExprVisitor:
             The DataflowBlock to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitBindingBlock(self._outer(), block)
+        return _ffi_api.ExprVisitorVisitBindingBlock(self._outer(), block)  # type: ignore
 
     def visit_var_def_(self, var: Var) -> None:
         """Visit the Var definition site.
@@ -693,7 +693,7 @@ class PyExprVisitor:
             The Var to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitVarDef(self._outer(), var)
+        return _ffi_api.ExprVisitorVisitVarDef(self._outer(), var)  # type: ignore
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> None:
         """Visit the DataflowVar definition site.
@@ -706,7 +706,7 @@ class PyExprVisitor:
             The DataflowVar to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitVarDef(self._outer(), var)
+        return _ffi_api.ExprVisitorVisitVarDef(self._outer(), var)  # type: ignore
 
     def visit_type(self, t: Type) -> None:
         """Visit Type.
@@ -718,7 +718,7 @@ class PyExprVisitor:
             The Type to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitType(self._outer(), t)
+        return _ffi_api.ExprVisitorVisitType(self._outer(), t)  # type: ignore
 
     def visit_span(self, span: Span) -> None:
         """Visit Span.
@@ -730,7 +730,7 @@ class PyExprVisitor:
             The Span to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitSpan(self._outer(), span)
+        return _ffi_api.ExprVisitorVisitSpan(self._outer(), span)  # type: ignore
 
 
 @tvm._ffi.register_object("expr_functor.PyExprMutator")
@@ -777,7 +777,7 @@ class _PyExprMutator(Object):
         """Constructor."""
 
         self.__init_handle_by_constructor__(
-            _ffi_api.MakePyExprMutator,
+            _ffi_api.MakePyExprMutator,  # type: ignore
             builder,
             f_visit_expr,
             f_visit_constant_,
@@ -820,7 +820,7 @@ class _PyExprMutator(Object):
         result : Expr
             The Expr after transformation.
         """
-        return _ffi_api.PyExprMutatorVisitExpr(self, expr)
+        return _ffi_api.PyExprMutatorVisitExpr(self, expr)  # type: ignore
 
     def visit_binding(self, binding: Binding) -> None:
         """Generic dispatcher for Binding.
@@ -830,7 +830,7 @@ class _PyExprMutator(Object):
         binding : Binding
             The binding to be visited.
         """
-        return _ffi_api.PyExprMutatorVisitBinding(self, binding)
+        return _ffi_api.PyExprMutatorVisitBinding(self, binding)  # type: ignore
 
     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
         """Generic dispatcher for BindingBlock.
@@ -845,7 +845,7 @@ class _PyExprMutator(Object):
         result : BindingBlock
             The binding block after transformation.
         """
-        return _ffi_api.PyExprMutatorVisitBindingBlock(self, block)
+        return _ffi_api.PyExprMutatorVisitBindingBlock(self, block)  # type: ignore
 
     def visit_var_def(self, var: Var) -> Var:
         """Generic dispatcher for visiting the var definition site.
@@ -861,7 +861,7 @@ class _PyExprMutator(Object):
         result : Var
             The var after post-order rewritten.
         """
-        return _ffi_api.PyExprMutatorVisitVarDef(self, var)
+        return _ffi_api.PyExprMutatorVisitVarDef(self, var)  # type: ignore
 
 
 class PyExprMutator:
@@ -933,7 +933,7 @@ class PyExprMutator:
             The Expr after transformation.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorVisitExpr(self._outer(), expr)
+        return _ffi_api.PyExprMutatorVisitExpr(self._outer(), expr)  # type: ignore
 
     def visit_binding(self, binding: Binding) -> None:
         """Generic dispatcher for Binding.
@@ -946,7 +946,7 @@ class PyExprMutator:
             The binding to be visited.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorVisitBinding(self._outer(), binding)
+        return _ffi_api.PyExprMutatorVisitBinding(self._outer(), binding)  # type: ignore
 
     def visit_binding_block(self, block: BindingBlock) -> BindingBlock:
         """Generic dispatcher for BindingBlock.
@@ -964,7 +964,7 @@ class PyExprMutator:
             The binding block after transformation.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorVisitBindingBlock(self._outer(), block)
+        return _ffi_api.PyExprMutatorVisitBindingBlock(self._outer(), block)  # type: ignore
 
     def visit_var_def(self, var: Var) -> Var:
         """Generic dispatcher for visiting the var definition site.
@@ -982,7 +982,7 @@ class PyExprMutator:
             The var after post-order rewritten.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorVisitVarDef(self._outer(), var)
+        return _ffi_api.PyExprMutatorVisitVarDef(self._outer(), var)  # type: ignore
 
     def visit_constant_(self, op: Constant) -> Expr:
         """Visit Constant.
@@ -1000,7 +1000,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_tuple_(self, op: Tuple) -> Expr:
         """Visit Tuple.
@@ -1018,7 +1018,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_var_(self, op: Var) -> Expr:
         """Visit Var.
@@ -1036,7 +1036,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_dataflow_var_(self, op: DataflowVar) -> Expr:
         """Visit DataflowVar.
@@ -1054,7 +1054,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_shape_expr_(self, op: ShapeExpr) -> Expr:
         """Visit ShapeExpr.
@@ -1072,7 +1072,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_runtime_dep_shape_(self, op: RuntimeDepShape) -> Expr:
         """Visit RuntimeDepShape.
@@ -1090,7 +1090,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_extern_func_(self, op: ExternFunc) -> Expr:
         """Visit ExternFunc.
@@ -1108,7 +1108,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_global_var_(self, op: GlobalVar) -> Expr:
         """Visit GlobalVar.
@@ -1126,7 +1126,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_function_(self, op: Function) -> Expr:
         """Visit Function.
@@ -1144,7 +1144,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_call_(self, op: Call) -> Expr:
         """Visit Call.
@@ -1162,7 +1162,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_seq_expr_(self, op: SeqExpr) -> Expr:
         """Visit SeqExpr.
@@ -1180,7 +1180,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_if_(self, op: If) -> Expr:
         """Visit If.
@@ -1198,7 +1198,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_op_(self, op: Op) -> Expr:
         """Visit Op.
@@ -1216,7 +1216,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
         """Visit TupleGetItem.
@@ -1234,7 +1234,7 @@ class PyExprMutator:
             The Expr after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)
+        return _ffi_api.ExprMutatorVisitExpr(self._outer(), op)  # type: ignore
 
     def visit_var_binding_(self, binding: VarBinding) -> None:
         """Visit VarBinding.
@@ -1247,7 +1247,7 @@ class PyExprMutator:
             The VarBinding to be visited.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)
+        return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)  # type: ignore
 
     def visit_match_shape_(self, binding: MatchShape) -> None:
         """Visit MatchShape.
@@ -1260,7 +1260,7 @@ class PyExprMutator:
             The MatchShape to be visited.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)
+        return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)  # type: ignore
 
     def visit_binding_block_(self, block: BindingBlock) -> BindingBlock:
         """Visit BindingBlock.
@@ -1278,7 +1278,7 @@ class PyExprMutator:
             The binding block after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitBindingBlock(self._outer(), block)
+        return _ffi_api.ExprMutatorVisitBindingBlock(self._outer(), block)  # type: ignore
 
     def visit_dataflow_block_(self, block: DataflowBlock) -> BindingBlock:
         """Visit DataflowBlock.
@@ -1296,7 +1296,7 @@ class PyExprMutator:
             The binding block after transformation
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitBindingBlock(self._outer(), block)
+        return _ffi_api.ExprMutatorVisitBindingBlock(self._outer(), block)  # type: ignore
 
     def visit_var_def_(self, var: Var) -> Var:
         """Visit the Var definition site.
@@ -1314,7 +1314,7 @@ class PyExprMutator:
             The var after post-order rewritten.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitVarDef(self._outer(), var)
+        return _ffi_api.ExprMutatorVisitVarDef(self._outer(), var)  # type: ignore
 
     def visit_dataflow_var_def_(self, var: DataflowVar) -> Var:
         """Visit the DataflowVar definition site.
@@ -1332,7 +1332,7 @@ class PyExprMutator:
             The var after post-order rewritten.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitVarDef(self._outer(), var)
+        return _ffi_api.ExprMutatorVisitVarDef(self._outer(), var)  # type: ignore
 
     def visit_type(self, t: Type) -> Type:
         """Visit Type.
@@ -1349,7 +1349,7 @@ class PyExprMutator:
             The type after transformation.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitType(self._outer(), t)
+        return _ffi_api.ExprMutatorVisitType(self._outer(), t)  # type: ignore
 
     def visit_span(self, span: Span) -> Span:
         """Visit Span.
@@ -1380,7 +1380,7 @@ class PyExprMutator:
         result : Expr
             The Expr after post-order rewritten.
         """
-        return _ffi_api.PyExprMutatorVisitExprPostOrder(self._outer(), expr)
+        return _ffi_api.PyExprMutatorVisitExprPostOrder(self._outer(), expr)  # type: ignore
 
     def set_var_remap(self, vid: Id, var: Var) -> None:
         """Remap a var to a new var in use-site.
@@ -1393,7 +1393,7 @@ class PyExprMutator:
             The new var.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorSetVarRemap(self._outer(), vid, var)
+        return _ffi_api.PyExprMutatorSetVarRemap(self._outer(), vid, var)  # type: ignore
 
     def get_var_remap(self, vid: Id) -> Var:
         """Remap a var to a new var in use-site.
@@ -1409,7 +1409,7 @@ class PyExprMutator:
             The remapped var.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorGetVarRemap(self._outer(), vid)
+        return _ffi_api.PyExprMutatorGetVarRemap(self._outer(), vid)  # type: ignore
 
     def visit_with_new_scope(self, expr: Expr) -> Expr:
         """Rewrite the expr with a new scope, used in a Function's body and the branches of If.
@@ -1425,7 +1425,7 @@ class PyExprMutator:
             The expr after visiting.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorVisitWithNewScope(self._outer(), expr)
+        return _ffi_api.PyExprMutatorVisitWithNewScope(self._outer(), expr)  # type: ignore
 
     def lookup_binding(self, var: Var) -> Optional[Expr]:
         """Look up the value bound to a variable.
@@ -1442,7 +1442,7 @@ class PyExprMutator:
             The value bound to the input var.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorLookupBinding(self._outer(), var)
+        return _ffi_api.PyExprMutatorLookupBinding(self._outer(), var)  # type: ignore
 
     def with_shape_and_type(self, var: Var, shape: Optional[Object], t: Type) -> Var:
         """Create a new var with specified shape and type if the original var's shape or type does
@@ -1463,4 +1463,4 @@ class PyExprMutator:
             The var filled with shape and type.
         """
         # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.PyExprMutatorWithShapeAndType(self._outer(), var, shape, t)
+        return _ffi_api.PyExprMutatorWithShapeAndType(self._outer(), var, shape, t)  # type: ignore

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # pylint: disable=redefined-builtin
 """The base Relax operators."""
-from typing import Union, List, Optional
+from typing import Union, List, Optional, Any
 
 import tvm
 from tvm.runtime.object import Object
@@ -66,7 +66,7 @@ def call_tir(
     if isinstance(shape, (list, tuple, Array)):
         shape = ShapeExpr(shape)
 
-    if isinstance(args, Expr):
+    if isinstance(args, Expr):  # type: ignore
         args = Tuple((args,))
 
     if isinstance(args, (list, tuple)):
@@ -81,7 +81,7 @@ def call_tir(
     else:
         raise TypeError("Not supported dtype for call_tir: " + str(type(dtype)))
 
-    return _ffi_api.call_tir(func, args, shape, output_type, tir_vars)
+    return _ffi_api.call_tir(func, args, shape, output_type, tir_vars)  # type: ignore
 
 
 def make_closure(
@@ -109,7 +109,7 @@ def make_closure(
     if isinstance(args, (list, tuple)):
         args = Tuple(args)
 
-    return _ffi_api.make_closure(func, args)
+    return _ffi_api.make_closure(func, args)  # type: ignore
 
 
 def invoke_closure(
@@ -137,7 +137,7 @@ def invoke_closure(
     if isinstance(args, (list, tuple)):
         args = Tuple(args)
 
-    return _ffi_api.invoke_closure(closure, args)
+    return _ffi_api.invoke_closure(closure, args)  # type: ignore
 
 
 def render_object(val: tvm.Object) -> str:
@@ -211,7 +211,7 @@ def print(values: Union[Expr, List[Expr]], format: str) -> Expr:
     result : Expr
         A relax Call, which will print the value during runtime.
     """
-    if isinstance(values, Expr):
+    if isinstance(values, Expr):  # type: ignore
         values = [values]
     return _ffi_api.print(values, format)  # type: ignore # pylint: disable=no-member
 

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # pylint: disable=redefined-builtin
 """The base Relax operators."""
-from typing import Union, List, Optional, Any
+from typing import Union, List, Optional
 
 import tvm
 from tvm.runtime.object import Object

--- a/python/tvm/relax/op/builtin/builtin.py
+++ b/python/tvm/relax/op/builtin/builtin.py
@@ -47,4 +47,4 @@ def alloc_tensor(
         if not isinstance(shape, (tuple, list)):
             shape = (shape,)
         shape = ShapeExpr(shape)
-    return _ffi_api.alloc_tensor(shape, dtype, runtime_device_index)
+    return _ffi_api.alloc_tensor(shape, dtype, runtime_device_index)  # type: ignore

--- a/python/tvm/relax/op/memory/memory.py
+++ b/python/tvm/relax/op/memory/memory.py
@@ -43,7 +43,7 @@ def alloc_storage(size: Expr, virtual_device_index: int, storage_scope: str, dty
     result : Call
         A relax Call, which gets the allocated storage.
     """
-    return _ffi_api.alloc_storage(size, virtual_device_index, storage_scope, dtype)
+    return _ffi_api.alloc_storage(size, virtual_device_index, storage_scope, dtype)  # type: ignore
 
 
 def alloc_tensor(storage: Expr, shape: Expr, offset: int, dtype: str) -> Call:
@@ -68,7 +68,7 @@ def alloc_tensor(storage: Expr, shape: Expr, offset: int, dtype: str) -> Call:
     result : Call
         A relax Call, which gets the allocated tensor.
     """
-    return _ffi_api.alloc_tensor(storage, shape, offset, dtype)
+    return _ffi_api.alloc_tensor(storage, shape, offset, dtype)  # type: ignore
 
 
 def kill_storage(storage: Expr) -> None:
@@ -79,7 +79,7 @@ def kill_storage(storage: Expr) -> None:
     storage : Expr
         The storage to be killed.
     """
-    return _ffi_api.kill_storage(storage)
+    return _ffi_api.kill_storage(storage)  # type: ignore
 
 
 def kill_tensor(tensor: Expr) -> None:
@@ -90,4 +90,4 @@ def kill_tensor(tensor: Expr) -> None:
     tensor : Expr
         The tensor to be killed.
     """
-    return _ffi_api.kill_tensor(tensor)
+    return _ffi_api.kill_tensor(tensor)  # type: ignore

--- a/python/tvm/relax/op/tensor.py
+++ b/python/tvm/relax/op/tensor.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # pylint: disable=redefined-builtin
 """Basic tensor operations."""
-import numpy as np
+import numpy as np  # type: ignore
 import tvm
 
 from . import _ffi_api
@@ -23,11 +23,11 @@ from ..expr import Expr
 
 
 def add(lhs: Expr, rhs: Expr) -> Expr:
-    return _ffi_api.add(lhs, rhs)
+    return _ffi_api.add(lhs, rhs)  # type: ignore
 
 
 def multiply(lhs: Expr, rhs: Expr) -> Expr:
-    return _ffi_api.multiply(lhs, rhs)
+    return _ffi_api.multiply(lhs, rhs)  # type: ignore
 
 
 def unique(
@@ -64,7 +64,7 @@ def unique(
         The created relax call with
     """
 
-    return _ffi_api.unique(data, sorted, return_inverse, return_counts, dim)
+    return _ffi_api.unique(data, sorted, return_inverse, return_counts, dim)  # type: ignore
 
 
 @tvm.register_func("relax.run.unique")

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -22,7 +22,7 @@ It is not a pretty-printer and, in fact, is more of an ugly-printer,
 but it can be useful for tutorials and debugging.
 """
 from __future__ import annotations  # must import to defer parsing of annotations
-from typing import Dict, Iterable
+from typing import Iterable
 import tvm
 from tvm import relax
 from tvm.ir.expr import PrimExpr
@@ -74,7 +74,7 @@ class ASTPrinter(ExprFunctor):
         lines = text.split("\n")
         return self.indent_str + f"\n{self.indent_str}".join(lines)
 
-    def build_ast_node(self, nodename: str, force_newline=False, **kwargs: Dict[str, str]):
+    def build_ast_node(self, nodename: str, force_newline=False, **kwargs: str) -> str:
         """
         Returns 'nodename(..., fields[i][0]=fields[i][1], ...)'
         with appropriate indentation

--- a/python/tvm/relax/testing/nn.py
+++ b/python/tvm/relax/testing/nn.py
@@ -18,8 +18,9 @@
 """PyTorch-like nn.Module API for constructing workloads."""
 
 
-from typing import List, Any, Callable
-import numpy as np
+from typing import List, Any, Callable, Union
+import typing
+import numpy as np  # type: ignore
 
 import tvm
 from tvm import relax, topi, tir
@@ -32,7 +33,9 @@ def emit_te(func: Callable, *args: Any, **kwargs: Any) -> relax.Var:
 class Placeholder(relax.Var):
     """A placeholder variable that can represent model input."""
 
-    def __init__(self, shape, dtype="float32", name="data"):
+    def __init__(
+        self, shape: Union[List[Any], typing.Tuple[Any, ...]], dtype="float32", name="data"
+    ):
         if not isinstance(shape, (list, tuple)):
             raise TypeError("the shape of Placeholder is expected to be a list or a tuple")
         ndim = len(shape)
@@ -43,7 +46,9 @@ class Placeholder(relax.Var):
 class Parameter(relax.Var):
     """A special kind of relax Var that represents model parameter(weight)."""
 
-    def __init__(self, shape, dtype="float32", name="param"):
+    def __init__(
+        self, shape: Union[List[Any], typing.Tuple[Any, ...]], dtype="float32", name="param"
+    ):
         if not isinstance(shape, (list, tuple)):
             raise TypeError("the shape of Parameter is expected to be a list or a tuple")
         ndim = len(shape)

--- a/python/tvm/relax/transform/fma_rewrite.py
+++ b/python/tvm/relax/transform/fma_rewrite.py
@@ -45,7 +45,7 @@ class EwiseFMARewriter(PyExprMutator):
 
         if call.op == add_op:
             value = self.lookup_binding(call.args[0])
-            if isinstance(value, Call) and value.op == multiply_op:
+            if isinstance(value, Call) and value.op == multiply_op:  # type: ignore
                 fma_call = Call(
                     ewise_fma_op, [value.args[0], value.args[1], call.args[1]], None, None
                 )
@@ -104,7 +104,7 @@ class EwiseFuseFMAMutator(PyExprMutator):
 
         if call.op == add_op:
             value = self.lookup_binding(call.args[0])
-            if isinstance(value, Call) and value.op == multiply_op:
+            if isinstance(value, Call) and value.op == multiply_op:  # type: ignore
                 mul = value
                 # construct a subgraph
                 x = Var("x", mul.args[0].shape_, mul.args[0]._checked_type_)

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -19,9 +19,9 @@
 import functools
 import inspect
 import types
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, Union, Optional, List
+import numpy as np  # type: ignore
 
-import numpy as np
 import tvm.ir
 from tvm.runtime import NDArray
 from . import _ffi_api
@@ -46,7 +46,7 @@ def FailTestRewrite() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.FailTestRewrite()
+    return _ffi_api.FailTestRewrite()  # type: ignore
 
 
 def RewriteFMA() -> tvm.ir.transform.Pass:
@@ -56,7 +56,7 @@ def RewriteFMA() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.RewriteFMA()
+    return _ffi_api.RewriteFMA()  # type: ignore
 
 
 def FuseFMA() -> tvm.ir.transform.Pass:
@@ -67,7 +67,7 @@ def FuseFMA() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.FuseFMA()
+    return _ffi_api.FuseFMA()  # type: ignore
 
 
 def LambdaLift():
@@ -78,7 +78,7 @@ def LambdaLift():
     -------
     ret : tvm.ir.transform.Pass
     """
-    return _ffi_api.LambdaLift()
+    return _ffi_api.LambdaLift()  # type: ignore
 
 
 def ToNonDataflow() -> tvm.ir.transform.Pass:
@@ -88,7 +88,7 @@ def ToNonDataflow() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.ToNonDataflow()
+    return _ffi_api.ToNonDataflow()  # type: ignore
 
 
 def CallTIRRewrite() -> tvm.ir.transform.Pass:
@@ -98,7 +98,7 @@ def CallTIRRewrite() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.CallTIRRewrite()
+    return _ffi_api.CallTIRRewrite()  # type: ignore
 
 
 def VMMemoryLower() -> tvm.ir.transform.Pass:
@@ -108,7 +108,7 @@ def VMMemoryLower() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.VMMemoryLower()
+    return _ffi_api.VMMemoryLower()  # type: ignore
 
 
 def VMShapeLower() -> tvm.ir.transform.Pass:
@@ -119,7 +119,7 @@ def VMShapeLower() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.VMShapeLower()
+    return _ffi_api.VMShapeLower()  # type: ignore
 
 
 def Normalize() -> tvm.ir.transform.Pass:
@@ -130,7 +130,7 @@ def Normalize() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.Normalize()
+    return _ffi_api.Normalize()  # type: ignore
 
 
 def CanonicalizeBindings() -> tvm.ir.transform.Pass:
@@ -144,7 +144,7 @@ def CanonicalizeBindings() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.CanonicalizeBindings()
+    return _ffi_api.CanonicalizeBindings()  # type: ignore
 
 
 def ResolveGlobals() -> tvm.ir.transform.Pass:
@@ -156,7 +156,7 @@ def ResolveGlobals() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.ResolveGlobals()
+    return _ffi_api.ResolveGlobals()  # type: ignore
 
 
 def BindParams(
@@ -187,7 +187,7 @@ def BindParams(
         ), f"param values are expected to be TVM.NDArray or numpy.ndarray, but got {type(v)}"
         tvm_params[k] = v
 
-    return _ffi_api.BindParams(func_name, tvm_params)
+    return _ffi_api.BindParams(func_name, tvm_params)  # type: ignore
 
 
 def RemoveUnusedFunctions(entry_functions: Optional[List[str]] = None) -> tvm.ir.transform.Pass:
@@ -205,7 +205,7 @@ def RemoveUnusedFunctions(entry_functions: Optional[List[str]] = None) -> tvm.ir
     """
     if entry_functions is None:
         entry_functions = ["main"]
-    return _ffi_api.RemoveUnusedFunctions(entry_functions)
+    return _ffi_api.RemoveUnusedFunctions(entry_functions)  # type: ignore
 
 
 def RunCodegen(
@@ -227,7 +227,7 @@ def RunCodegen(
     """
     if entry_functions is None:
         entry_functions = ["main"]
-    return _ffi_api.RunCodegen(target_codegens, entry_functions)
+    return _ffi_api.RunCodegen(target_codegens, entry_functions)  # type: ignore
 
 
 def FoldConstant() -> tvm.ir.transform.Pass:
@@ -237,7 +237,7 @@ def FoldConstant() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.FoldConstant()
+    return _ffi_api.FoldConstant()  # type: ignore
 
 
 def AnnotateTIROpPattern() -> tvm.ir.transform.Pass:
@@ -247,7 +247,7 @@ def AnnotateTIROpPattern() -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.AnnotateTIROpPattern()
+    return _ffi_api.AnnotateTIROpPattern()  # type: ignore
 
 
 def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
@@ -269,7 +269,7 @@ def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
     ret : tvm.transform.Pass
         The registered pass for operator fusion.
     """
-    return _ffi_api.FuseOps(fuse_opt_level)
+    return _ffi_api.FuseOps(fuse_opt_level)  # type: ignore
 
 
 def FuseTIR() -> tvm.ir.transform.Pass:
@@ -280,7 +280,7 @@ def FuseTIR() -> tvm.ir.transform.Pass:
     ret : tvm.transform.Pass
         The registered pass for tir fusion.
     """
-    return _ffi_api.FuseTIR()
+    return _ffi_api.FuseTIR()  # type: ignore
 
 
 def MetaScheduleApplyDatabase(
@@ -353,7 +353,9 @@ def _wrap_class_function_pass(pass_cls, pass_info):
             def _pass_func(func, mod, ctx):
                 return inst.transform_function(func, mod, ctx)
 
-            self.__init_handle_by_constructor__(_ffi_api.MakeFunctionPass, _pass_func, pass_info)
+            self.__init_handle_by_constructor__(
+                _ffi_api.MakeFunctionPass, _pass_func, pass_info  # type: ignore
+            )
             self._inst = inst
 
         def __getattr__(self, name):
@@ -476,7 +478,7 @@ def function_pass(
             return _wrap_class_function_pass(pass_arg, info)
         if not isinstance(pass_arg, (types.FunctionType, types.LambdaType)):
             raise TypeError("pass_func must be a callable for Function pass")
-        return _ffi_api.MakeFunctionPass(pass_arg, info)
+        return _ffi_api.MakeFunctionPass(pass_arg, info)  # type: ignore
 
     if pass_func:
         return create_function_pass(pass_func)
@@ -500,7 +502,7 @@ def _wrap_class_dataflowblock_pass(pass_cls, pass_info):
                 return inst.transform_dataflowblock(func, mod, ctx)
 
             self.__init_handle_by_constructor__(
-                _ffi_api.MakeDataflowBlockPass, _pass_func, pass_info
+                _ffi_api.MakeDataflowBlockPass, _pass_func, pass_info  # type: ignore
             )
             self._inst = inst
 
@@ -629,7 +631,7 @@ def dataflowblock_pass(
             return _wrap_class_dataflowblock_pass(pass_arg, info)
         if not isinstance(pass_arg, (types.FunctionType, types.LambdaType)):
             raise TypeError("pass_func must be a callable for DataflowBlock pass")
-        return _ffi_api.MakeDataflowBlockPass(pass_arg, info)
+        return _ffi_api.MakeDataflowBlockPass(pass_arg, info)  # type: ignore
 
     if pass_func:
         return create_dataflowblock_pass(pass_func)

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -295,7 +295,7 @@ def MetaScheduleApplyDatabase(
     ret : tvm.transform.Pass
         The registered pass
     """
-    return _ffi_api.MetaScheduleApplyDatabase(work_dir)
+    return _ffi_api.MetaScheduleApplyDatabase(work_dir)  # type: ignore
 
 
 def MetaScheduleTuneTIR(
@@ -313,7 +313,7 @@ def MetaScheduleTuneTIR(
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.MetaScheduleTuneTIR(work_dir, max_trials_global)
+    return _ffi_api.MetaScheduleTuneTIR(work_dir, max_trials_global)  # type: ignore
 
 
 def MetaScheduleTuneIRMod(
@@ -334,7 +334,7 @@ def MetaScheduleTuneIRMod(
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.MetaScheduleTuneIRMod(params, work_dir, max_trials_global)
+    return _ffi_api.MetaScheduleTuneIRMod(params, work_dir, max_trials_global)  # type: ignore
 
 
 def _wrap_class_function_pass(pass_cls, pass_info):

--- a/python/tvm/relax/transform/tuning_api/default_functions.py
+++ b/python/tvm/relax/transform/tuning_api/default_functions.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional
 import sys
 import itertools
 import logging
-import numpy as np
+import numpy as np  # type: ignore
 
 import tvm
 from tvm.ir.module import IRModule

--- a/python/tvm/relax/transform/tuning_api/primitives.py
+++ b/python/tvm/relax/transform/tuning_api/primitives.py
@@ -16,7 +16,7 @@
 # under the License.
 """Relax Tuning Pass API primitives"""
 
-from typing import Callable, Union, Dict, List, Optional
+from typing import Callable, Union, Dict, List, Optional, Sequence
 import logging
 import tvm
 from tvm.runtime import Object
@@ -100,7 +100,7 @@ class Choice(Object):
             constr_func_args = []
 
         self.__init_handle_by_constructor__(
-            _ffi_api.Choice,
+            _ffi_api.Choice,  # type: ignore
             transform_func_key,
             transform_func_args,
             constr_func_key,
@@ -114,7 +114,7 @@ class Choice(Object):
         ret: Callable
            registered transformation function
         """
-        return _ffi_api.ChoiceGetTransformFunc(self)
+        return _ffi_api.ChoiceGetTransformFunc(self)  # type: ignore
 
     def get_constr_func(self) -> Callable:
         """Getter for constr_func
@@ -123,7 +123,7 @@ class Choice(Object):
         ret: Callable
            registered constraint function
         """
-        return _ffi_api.ChoiceGetConstrFunc(self)
+        return _ffi_api.ChoiceGetConstrFunc(self)  # type: ignore
 
     def apply_transform_func(self, mod: IRModule) -> IRModule:
         """Perform transform_func with its arguments
@@ -132,7 +132,7 @@ class Choice(Object):
         ret: IRModule
            Transformed IRModule
         """
-        return _ffi_api.ChoiceApplyTransformFunc(self, mod)
+        return _ffi_api.ChoiceApplyTransformFunc(self, mod)  # type: ignore
 
     def check_constr(self, mod: IRModule) -> bool:
         """Perform constr_func with its arguments
@@ -141,7 +141,7 @@ class Choice(Object):
         ret: bool
            Returns whether the IRModule satisfies the constraint or not
         """
-        return _ffi_api.ChoiceCheckConstr(self, mod)
+        return _ffi_api.ChoiceCheckConstr(self, mod)  # type: ignore
 
     def as_json(self) -> JSON_TYPE:
         """Serialize the trace as a JSON-style object
@@ -166,7 +166,7 @@ class Choice(Object):
         choice: Choice
             Deserialized choice
         """
-        return _ffi_api.ChoiceFromJSON(json_obj)
+        return _ffi_api.ChoiceFromJSON(json_obj)  # type: ignore
 
     def deepcopy(self):
         return Choice.from_json(self.as_json())
@@ -211,13 +211,13 @@ class Knob(Object):
         """Verify if the decision is valid."""
         if isinstance(decision, int):
             decision = str(decision)
-        return _ffi_api.KnobIsValidDecision(self, decision)
+        return _ffi_api.KnobIsValidDecision(self, decision)  # type: ignore
 
     def apply(self, mod: IRModule, decision: Union[str, int]) -> IRModule:
         """Get choice if a decision is valid."""
         if isinstance(decision, int):
             decision = str(decision)
-        return _ffi_api.KnobApply(self, mod, decision)
+        return _ffi_api.KnobApply(self, mod, decision)  # type: ignore
 
     def as_json(self) -> JSON_TYPE:
         """Serialize the trace as a JSON-style object
@@ -226,7 +226,7 @@ class Knob(Object):
         json: JSON_TYPE
             The JSON-style object
         """
-        return _ffi_api.KnobAsJSON(self)
+        return _ffi_api.KnobAsJSON(self)  # type: ignore
 
     @staticmethod
     def from_json(json_obj: JSON_TYPE) -> "Knob":
@@ -242,7 +242,7 @@ class Knob(Object):
         knob: Knob
             Deserialized knob
         """
-        return _ffi_api.KnobFromJSON(json_obj)
+        return _ffi_api.KnobFromJSON(json_obj)  # type: ignore
 
     def __str__(self) -> str:
         msg = f"{self.name} (# of choices: {len(self.choices)})\n"
@@ -264,7 +264,7 @@ class Trace(Object):
         Input IRModule.
     knobs: Optional[List[Knob]]
         A list of knobs applied in the trace.
-    decisions: Optional[List[Union[str, int]]]
+    decisions: Optional[Sequence[Union[str, int]]]
         A list of decisions made for each knob
 
     Examples
@@ -285,7 +285,7 @@ class Trace(Object):
         self,
         in_mod: IRModule,
         knobs: Optional[List[Knob]] = None,
-        decisions: Optional[List[Union[str, int]]] = None,
+        decisions: Optional[Sequence[Union[str, int]]] = None,
     ):
         """Constructor."""
         knobs = knobs if knobs else list()
@@ -298,21 +298,21 @@ class Trace(Object):
 
     def verify(self) -> bool:
         """Verify if current history is valid."""
-        return _ffi_api.TraceVerify()
+        return _ffi_api.TraceVerify()  # type: ignore
 
     def add(self, knob: Knob, decision: Union[str, int]) -> IRModule:
         """Add & Apply new decision (with knob)."""
         if isinstance(decision, int):
             decision = str(decision)
-        return _ffi_api.TraceAdd(self, knob, decision)
+        return _ffi_api.TraceAdd(self, knob, decision)  # type: ignore
 
     def set_perf(self, perf: float) -> None:
         """Set performance number for the trace."""
-        return _ffi_api.TraceSetPerf(self, perf)
+        return _ffi_api.TraceSetPerf(self, perf)  # type: ignore
 
     def set_out_mod(self, mod: IRModule) -> None:
         """Set out_mod for the trace."""
-        return _ffi_api.TraceSetOutMod(self, mod)
+        return _ffi_api.TraceSetOutMod(self, mod)  # type: ignore
 
     def as_json(self, include_irmod: bool = True) -> JSON_TYPE:
         """Serialize the trace as a JSON-style object.
@@ -326,7 +326,7 @@ class Trace(Object):
         json: JSON_TYPE
             The JSON-style object.
         """
-        obj = _ffi_api.TraceAsJSON(self, include_irmod)
+        obj = _ffi_api.TraceAsJSON(self, include_irmod)  # type: ignore
         return _json_from_tvm(obj)
 
     @staticmethod
@@ -343,7 +343,7 @@ class Trace(Object):
         trace: Trace
             Deserialized trace.
         """
-        return _ffi_api.TraceFromJSON(json_obj)
+        return _ffi_api.TraceFromJSON(json_obj)  # type: ignore
 
     def __str__(self) -> str:
         n = len(self.knobs)
@@ -379,7 +379,7 @@ def get_trace(in_: Union[Trace, IRModule, Expr]) -> Trace:
         return in_
     if isinstance(in_, IRModule):
         return Trace(in_)
-    if isinstance(in_, Expr):
+    if isinstance(in_, Expr):  # type: ignore
         return Trace(tvm.IRModule.from_expr(in_))
 
     raise Exception(f"Invalid input type for trace: {type(in_)}")

--- a/python/tvm/relax/ty.py
+++ b/python/tvm/relax/ty.py
@@ -27,7 +27,7 @@ class ShapeType(Type):
     """The type of shape in Relax."""
 
     def __init__(self, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.ShapeType, span)
+        self.__init_handle_by_constructor__(_ffi_api.ShapeType, span)  # type: ignore
 
 
 @tvm._ffi.register_object("relax.ObjectType")
@@ -36,7 +36,7 @@ class ObjectType(Type):
     values in TVM."""
 
     def __init__(self, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.ObjectType, span)
+        self.__init_handle_by_constructor__(_ffi_api.ObjectType, span)  # type: ignore
 
 
 @tvm._ffi.register_object("relax.DynTensorType")
@@ -55,7 +55,9 @@ class DynTensorType(Type):
     """
 
     def __init__(self, ndim=-1, dtype="float32", span: Span = None) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.DynTensorType, ndim, dtype, span)
+        self.__init_handle_by_constructor__(
+            _ffi_api.DynTensorType, ndim, dtype, span  # type: ignore
+        )
 
 
 @tvm._ffi.register_object("relax.DimType")
@@ -63,7 +65,7 @@ class DimType(Type):
     """The type of indices/shape dimensions in Relax."""
 
     def __init__(self, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.DimType, span)
+        self.__init_handle_by_constructor__(_ffi_api.DimType, span)  # type: ignore
 
 
 def is_base_of(base: Type, derived: Type) -> bool:
@@ -84,4 +86,4 @@ def is_base_of(base: Type, derived: Type) -> bool:
         If derived is a subtype of base or if both are the same type, returns true.
         Otherwise returns false.
     """
-    return _ffi_api.IsBaseOf(base, derived)
+    return _ffi_api.IsBaseOf(base, derived)  # type: ignore

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -17,7 +17,7 @@
 # pylint: disable=invalid-name, redefined-builtin, no-else-return
 """The Relax virtual machine"""
 from typing import Callable, List, Optional, Union, Dict, Tuple
-import numpy as np
+import numpy as np  # type: ignore
 
 from tvm._ffi import base as _base
 import tvm
@@ -202,7 +202,7 @@ class VirtualMachine(object):
         kwargs : Dict[str, Any]
             Any named arguments to package up with the function
         """
-        cargs = []
+        cargs: List[Any] = []
         if kwargs:
             args = self._convert_func_named_args(func_name, args, **kwargs)
         for arg in args:
@@ -228,7 +228,7 @@ class VirtualMachine(object):
         elif isinstance(arg, tvm.runtime.NDArray):
             cargs.append(arg)
         elif isinstance(arg, (tuple, list)):
-            field_args = []
+            field_args: List[Any] = []
             for field in arg:
                 self._convert(field, field_args)
             cargs.append(container.tuple_object(field_args))
@@ -285,7 +285,7 @@ class VirtualMachine(object):
         kwargs: dict of str to tvm.runtime.NDArray or np.ndarray
             Named arguments to the function.
         """
-        cargs = []
+        cargs: List[Any] = []
 
         if kwargs:
             args = self._convert_func_named_args(func_name, args, **kwargs)
@@ -518,7 +518,7 @@ def build(
     if params is None:
         params = {}
 
-    return Executable(_ffi_api.VMCodeGen(rx_mod, lib, ext_libs, target, params))
+    return Executable(_ffi_api.VMCodeGen(rx_mod, lib, ext_libs, target, params))  # type: ignore
 
 
 def _split_tir_relax(mod: tvm.IRModule) -> Tuple[tvm.IRModule, tvm.IRModule]:

--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -89,5 +89,5 @@ else
 fi
 
 #TODO(@yuchen) fix mypy in relax
-# echo "Type checking with MyPy ..."
-# tests/scripts/task_mypy.sh
+echo "Type checking with MyPy ..."
+tests/scripts/task_mypy.sh

--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -88,6 +88,5 @@ else
   shard2
 fi
 
-#TODO(@yuchen) fix mypy in relax
 echo "Type checking with MyPy ..."
 tests/scripts/task_mypy.sh

--- a/tests/scripts/task_mypy.sh
+++ b/tests/scripts/task_mypy.sh
@@ -20,36 +20,36 @@ set -euxo pipefail
 
 source tests/scripts/setup-pytest-env.sh
 
-echo "Checking MyPy Type defs in the TensorIR schedule package."
-mypy  --check-untyped-defs python/tvm/tir/schedule
+# echo "Checking MyPy Type defs in the TensorIR schedule package."
+# mypy  --check-untyped-defs python/tvm/tir/schedule
 
-echo "Checking MyPy Type defs in the meta schedule package."
-mypy  --check-untyped-defs python/tvm/meta_schedule
+# echo "Checking MyPy Type defs in the meta schedule package."
+# mypy  --check-untyped-defs python/tvm/meta_schedule
 
-echo "Checking MyPy Type defs in the analysis package."
-mypy  --check-untyped-defs python/tvm/tir/analysis/
+# echo "Checking MyPy Type defs in the analysis package."
+# mypy  --check-untyped-defs python/tvm/tir/analysis/
 
-echo "Checking MyPy Type defs in the transform package."
-mypy  --check-untyped-defs python/tvm/tir/transform/
+# echo "Checking MyPy Type defs in the transform package."
+# mypy  --check-untyped-defs python/tvm/tir/transform/
 
-echo "Checking MyPy Type defs in the tvmscript printer package."
-mypy  --check-untyped-defs python/tvm/script/printer
+# echo "Checking MyPy Type defs in the tvmscript printer package."
+# mypy  --check-untyped-defs python/tvm/script/printer
 
-echo "Checking MyPy Type defs in the TIR package with unittest"
-MYPYPATH=$TVM_PATH/python mypy --check-untyped-defs tests/python/unittest/test_tvmscript_type.py
+# echo "Checking MyPy Type defs in the TIR package with unittest"
+# MYPYPATH=$TVM_PATH/python mypy --check-untyped-defs tests/python/unittest/test_tvmscript_type.py
 
-echo "Checking MyPy Type defs in tvm.relay.op.contrib"
-mypy --disallow-untyped-defs python/tvm/relay/op/contrib/cublas.py
-mypy --disallow-untyped-defs python/tvm/relay/op/contrib/cudnn.py
-mypy --disallow-untyped-defs python/tvm/relay/op/contrib/te_target.py
-mypy --disallow-untyped-defs python/tvm/relay/op/contrib/tensorrt.py
+# echo "Checking MyPy Type defs in tvm.relay.op.contrib"
+# mypy --disallow-untyped-defs python/tvm/relay/op/contrib/cublas.py
+# mypy --disallow-untyped-defs python/tvm/relay/op/contrib/cudnn.py
+# mypy --disallow-untyped-defs python/tvm/relay/op/contrib/te_target.py
+# mypy --disallow-untyped-defs python/tvm/relay/op/contrib/tensorrt.py
 
-#TODO(@mikepapadim): This is failing atm
-# echo "Checking MyPy Type defs in the tvm.relay.backend.contrib.ethosu package."
-# mypy  --check-untyped-defs python/tvm/relay/backend/contrib/ethosu/
+# #TODO(@mikepapadim): This is failing atm
+# # echo "Checking MyPy Type defs in the tvm.relay.backend.contrib.ethosu package."
+# # mypy  --check-untyped-defs python/tvm/relay/backend/contrib/ethosu/
 
-echo "Checking MyPy Type defs in the tvmscript IRBuilder package."
-mypy  --check-untyped-defs python/tvm/script/ir_builder
+# echo "Checking MyPy Type defs in the tvmscript IRBuilder package."
+# mypy  --check-untyped-defs python/tvm/script/ir_builder
 
 echo "Checking MyPy Type defs in the relax package."
 mypy  --check-untyped-defs python/tvm/relax/

--- a/tests/scripts/task_mypy.sh
+++ b/tests/scripts/task_mypy.sh
@@ -20,20 +20,23 @@ set -euxo pipefail
 
 source tests/scripts/setup-pytest-env.sh
 
-# echo "Checking MyPy Type defs in the TensorIR schedule package."
-# mypy  --check-untyped-defs python/tvm/tir/schedule
+echo "Checking MyPy Type defs in the TensorIR schedule package."
+mypy  --check-untyped-defs python/tvm/tir/schedule
 
-# echo "Checking MyPy Type defs in the meta schedule package."
-# mypy  --check-untyped-defs python/tvm/meta_schedule
+echo "Checking MyPy Type defs in the meta schedule package."
+mypy  --check-untyped-defs python/tvm/meta_schedule
 
-# echo "Checking MyPy Type defs in the analysis package."
-# mypy  --check-untyped-defs python/tvm/tir/analysis/
+echo "Checking MyPy Type defs in the analysis package."
+mypy  --check-untyped-defs python/tvm/tir/analysis/
 
-# echo "Checking MyPy Type defs in the transform package."
-# mypy  --check-untyped-defs python/tvm/tir/transform/
+echo "Checking MyPy Type defs in the transform package."
+mypy  --check-untyped-defs python/tvm/tir/transform/
 
-# echo "Checking MyPy Type defs in the TIR package with unittest"
-# MYPYPATH=$TVM_PATH/python mypy --check-untyped-defs tests/python/unittest/test_tvmscript_type.py
+echo "Checking MyPy Type defs in the tvmscript printer package."
+mypy  --check-untyped-defs python/tvm/script/printer
+
+echo "Checking MyPy Type defs in the TIR package with unittest"
+MYPYPATH=$TVM_PATH/python mypy --check-untyped-defs tests/python/unittest/test_tvmscript_type.py
 
 echo "Checking MyPy Type defs in tvm.relay.op.contrib"
 mypy --disallow-untyped-defs python/tvm/relay/op/contrib/cublas.py
@@ -45,8 +48,8 @@ mypy --disallow-untyped-defs python/tvm/relay/op/contrib/tensorrt.py
 # echo "Checking MyPy Type defs in the tvm.relay.backend.contrib.ethosu package."
 # mypy  --check-untyped-defs python/tvm/relay/backend/contrib/ethosu/
 
-# echo "Checking MyPy Type defs in the tvmscript IRBuilder package."
-# mypy  --check-untyped-defs python/tvm/script/ir_builder
+echo "Checking MyPy Type defs in the tvmscript IRBuilder package."
+mypy  --check-untyped-defs python/tvm/script/ir_builder
 
-# echo "Checking MyPy Type defs in the relax package."
-# mypy  --check-untyped-defs python/tvm/relax/
+echo "Checking MyPy Type defs in the relax package."
+mypy  --check-untyped-defs python/tvm/relax/


### PR DESCRIPTION
Enable Mypy type checking for python files under `python/tvm/relax/`, and fix all typing errors thrown by Mypy.

Lessons learned about type annotation:
- On TVM FFI calls, we need to use `# type: ignore` to ignore type checking: [Example](https://github.com/tlc-pack/relax/compare/mypy?expand=1#diff-db60c2d643e2fd6fbe54a07abf1209608882c6753bc35348c0763bddfb309ce7R61).
- For variable positional arguments (`*args`) and variable keyword arguments (`**kwargs`), we only need to specify the expected value for one such argument: [Example](https://github.com/tlc-pack/relax/compare/mypy?expand=1#diff-06fa5180212492272318397bb12bc2943d0d24031da3f69969832946f90f91c7R77).
- To annotate a variable-length tuple of the same type, for example, use `typing.Tuple[int, ...]` to annotate a tuple of integers. [Example](https://github.com/tlc-pack/relax/compare/mypy?expand=1#diff-911771612edaec6a36498b13ff8684c2f987ab10ae2eae51716c708fbc48a8fbR53).
- TypeAlias is only supported in python3.10 or higher, so currently have to use `Union` for annotating type alias. [Example](https://github.com/tlc-pack/relax/compare/mypy?expand=1#diff-911771612edaec6a36498b13ff8684c2f987ab10ae2eae51716c708fbc48a8fbR36). One caveat is we have to use [type ignore](https://github.com/tlc-pack/relax/compare/mypy?expand=1#diff-2ec405534d7c2e68aff1c55f4143fb78b02b888bde7899b9024ae2b7243fb158R69) when using `isinstance(args, AliasedType)`, otherwise mypy will throw an error.

