### PR TITLE
[TVMScript] Support cross-function call for relax function

### DIFF
--- a/include/tvm/script/ir_builder/ir/ir.h
+++ b/include/tvm/script/ir_builder/ir/ir.h
@@ -41,9 +41,12 @@ TVM_DLL IRModuleFrame IRModule();
  * \brief Declare a Function without given the specific function implementation.
  * \note It is usually used in cross-function call. And we can specify the function by `DefFunction`
  * \param func_name The function unique name.
+ * \param func_signature A Function w/o body, which used to specify the function signature
+ *                       (i.e. func params and func return type/shape).
  * \return The corresponding GlobalVar.
  */
-TVM_DLL GlobalVar DeclFunction(const String& func_name);
+TVM_DLL GlobalVar DeclFunction(const String& func_name,
+                               const Optional<BaseFunc>& func_signature = NullOpt);
 
 /*!
  * \brief Define the function which is declared before.

--- a/include/tvm/script/ir_builder/relax/frame.h
+++ b/include/tvm/script/ir_builder/relax/frame.h
@@ -94,6 +94,11 @@ class FunctionFrameNode : public SeqExprFrameNode {
    *       If the `ret_type` is not None, check the deduced type is a base type of the given one.
    */
   Optional<Type> ret_type;
+  /*!
+   * \brief The function return shape.
+   * \sa ret_type
+   */
+  Optional<tvm::relax::Expr> ret_shape;
   /*! \brief The function attributes. */
   Map<String, ObjectRef> attrs;
   /*! \brief The block builder to create Relax function. */

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -155,13 +155,13 @@ TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value, 
 /*!
  * \brief Annotate and check the type and shape of relax var.
  * \param var The input var to be annotated.
- * \param type The given type.
- * \param shape The given shape, which can be undefined.
- * \note This function will check if the type of var is compatible with the given type.
+ * \param anno_type The annotated type.
+ * \param anno_shape The annotated shape, which can be undefined.
+ * \note This function will check if the type of var is compatible with the annotated type.
  * And we annotate to the var with more detailed type.
  */
-TVM_DLL void AnnotateTypeShape(const tvm::relax::Var& var, const Type& type,
-                               const Optional<tvm::relax::ShapeExpr>& shape);
+TVM_DLL void AnnotateTypeShape(const tvm::relax::Var& var, const Type& anno_type,
+                               const Optional<tvm::relax::ShapeExpr>& anno_shape);
 
 ///////////////////////////// If Then Else /////////////////////////////
 

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -78,8 +78,7 @@ TVM_DLL FunctionFrame Function();
  * \param shape The shape of the parameter.
  * \return The created function parameter var.
  */
-TVM_DLL tvm::relax::Var Arg(const String& name, const Type& type,
-                            const tvm::relax::ShapeExpr& shape);
+TVM_DLL tvm::relax::Var Arg(const String& name, const Type& type, const tvm::relax::Expr& shape);
 
 /*!
  * \brief Specify the name of the last function frame.
@@ -98,6 +97,12 @@ TVM_DLL void FuncAttrs(Map<String, ObjectRef> attrs);
  * \param ret_type The return type. Note: it's a standard `tvm::Type` instead of TensorType.
  */
 TVM_DLL void FuncRetType(tvm::Type ret_type);
+
+/*!
+ * \brief Specify the return shape of the last function frame.
+ * \param ret_shape The return shape.
+ */
+TVM_DLL void FuncRetShape(tvm::relax::Expr ret_shape);
 
 /*!
  * \brief Specify the return value of the last function frame.
@@ -161,7 +166,7 @@ TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value, 
  * And we annotate to the var with more detailed type.
  */
 TVM_DLL void AnnotateTypeShape(const tvm::relax::Var& var, const Type& anno_type,
-                               const Optional<tvm::relax::ShapeExpr>& anno_shape);
+                               const Optional<tvm::relax::Expr>& anno_shape);
 
 ///////////////////////////// If Then Else /////////////////////////////
 

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -102,6 +102,8 @@ class Var(Expr):
 
     def __call__(self, *args: Any, attrs=None) -> Call:
         if self.checked_type and isinstance(self.checked_type, ty.FuncType):
+            if self.checked_type.ret_type is None:
+                raise ValueError("Cannot call a function with no return type")
             return Call(self, args, attrs=attrs)
         else:
             raise TypeError("Only vars with function type can be called")

--- a/python/tvm/script/ir_builder/ir/ir.py
+++ b/python/tvm/script/ir_builder/ir/ir.py
@@ -16,6 +16,8 @@
 # under the License.
 """Package tvm.script.ir_builder.ir.ir"""
 
+from typing import Optional
+
 from tvm.ir import BaseFunc, GlobalVar
 
 from . import _ffi_api
@@ -32,12 +34,20 @@ def ir_module() -> IRModuleFrame:
     return _ffi_api.IRModule()  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
-def decl_function(func_name: str) -> GlobalVar:
+def decl_function(
+    func_name: str,
+    func_signature: Optional[BaseFunc] = None,
+) -> GlobalVar:
     """Declare a Function without given the specific function implementation.
     Parameters
     ----------
     func_name : str
         The function unique name.
+
+    func_signature: Optional[BaseFunc]
+        A Function w/o body, which used to specify the function signature
+        (i.e. func params and func return type/shape).
+
     Note
     ----
     It is usually used in cross-function call. And we can specify the function by `DefFunction`
@@ -46,7 +56,10 @@ def decl_function(func_name: str) -> GlobalVar:
     gv : GlobalVar
         The corresponding GlobalVar.
     """
-    return _ffi_api.DeclFunction(func_name)  # pylint: disable=no-member # type: ignore
+
+    return _ffi_api.DeclFunction(  # pylint: disable=no-member # type: ignore
+        func_name, func_signature
+    )
 
 
 def def_function(func_name: str, func: BaseFunc) -> None:

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -157,6 +157,17 @@ def func_ret_type(ret_type: Union[TensorType, Type]) -> None:
     return _ffi_api.FuncRetType(ret_type)  # pylint: disable=no-member # type: ignore
 
 
+def func_ret_shape(ret_shape: Expr) -> None:
+    """Specify the return shape of the last function frame.
+
+    Parameters
+    ----------
+    ret_shape: Expr
+        The function return shape.
+    """
+    return _ffi_api.FuncRetShape(ret_shape)  # pylint: disable=no-member # type: ignore
+
+
 def func_ret_value(value: Expr) -> None:
     """Specify the return value of the last function frame.
     Parameters
@@ -359,6 +370,7 @@ __all__ = [
     "func_attr",
     "func_name",
     "func_ret_type",
+    "func_ret_shape",
     "func_ret_value",
     "function",
     "invoke_closure",

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -287,18 +287,21 @@ def emit_match_shape(
 ############################# Type Deduce ##############################
 
 
-def annotate_type_shape(var: Var, type: Type, shape: ShapeExpr) -> None:
+def annotate_type_shape(var: Var, anno_type: Type, anno_shape: ShapeExpr) -> None:
     """Annotate and check the type of relax var.
     Parameters
     ----------
     var: Var
         The input var to be annotated.
-    type: Type
-        The given type
-    shape: ShapeExpr
-        The given shape
+
+    anno_type: Type
+        The annotated type
+
+    anno_shape: ShapeExpr
+        The annotated shape
+
     """
-    _ffi_api.AnnotateTypeShape(var, type, shape)
+    _ffi_api.AnnotateTypeShape(var, anno_type, anno_shape)
 
 
 def If(condition: Expr) -> frame.IfFrame:  # pylint: disable=invalid-name

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -388,6 +388,10 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
 
       if (it_func != ctx_mod->functions.end()) {
         if (const auto* func = (*it_func).second.as<FunctionNode>()) {
+          if (!func->body.defined()) {
+            return func->ret_shape;
+          }
+          // TODO(relax-team): migrate shape deduction to `ret_shape`
           Expr func_shape = Downcast<Expr>(func->body->shape_);
           if (IsConstantShapes(func_shape)) {
             // Case 1. Nested tuples of constant shapes

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -205,7 +205,7 @@ Function::Function(Array<Var> params, Expr body, Type ret_type, Expr ret_shape, 
   // For function, we take a conservative approach and require the function type
   // to be known at construction time.
   Array<Type> param_types;
-  for (Var param : params) {
+  for (const Var& param : params) {
     CHECK(param->checked_type_.defined())
         << "relax.Function requires params to contain checked_type_";
     param_types.push_back(param->checked_type_);

--- a/src/script/ir_builder/ir/ir.cc
+++ b/src/script/ir_builder/ir/ir.cc
@@ -34,12 +34,16 @@ IRModuleFrame IRModule() {
   return IRModuleFrame(n);
 }
 
-GlobalVar DeclFunction(const String& func_name) {
+GlobalVar DeclFunction(const String& func_name, const Optional<BaseFunc>& func) {
   IRModuleFrame frame = FindModuleFrame("I.DeclFunction");
   CHECK(!frame->global_var_map.count(func_name))
       << "ValueError: function " << func_name << " already exists";
   GlobalVar gv = GlobalVar(func_name);
+
   frame->global_var_map.Set(func_name, gv);
+  if (func.defined()) {
+    frame->functions.Set(gv, func.value());
+  }
   return gv;
 }
 
@@ -49,9 +53,10 @@ void DefFunction(const String& func_name, const BaseFunc& func) {
   CHECK(it != frame->global_var_map.end())
       << "ValueError: function " << func_name << " does not exist, please declare it first.";
   const GlobalVar& gv = (*it).second;
-  CHECK(frame->functions.find(gv) == frame->functions.end())
-      << "ValueError: function " << func_name << " has already been defined.";
   frame->functions.Set(gv, func);
+  if (func->checked_type_.defined()) {
+    gv->checked_type_ = func->checked_type_;
+  }
 }
 
 TVM_REGISTER_GLOBAL("script.ir_builder.ir.IRModule").set_body_typed(IRModule);

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -24,6 +24,7 @@ from tvm import IRModule, relax, tir
 from tvm.script._parser import ir as I
 from tvm.script._parser import relax as R
 from tvm.script._parser import tir as T
+from tvm.relax import RuntimeDepShape, DynTensorType
 
 
 def _check(
@@ -36,12 +37,12 @@ def _check(
 
 def test_simple_func():
     @R.function
-    def foo(x: R.Tensor((128, 128), "float32")) -> R.Tensor(None, "float32", ndim=2):
+    def foo(x: R.Tensor((128, 128), "float32")) -> R.Tensor((128, 128), "float32"):
         R.func_attr({"Primitive": 1})
         gv0 = R.call_tir("extern_func", x, (128, 128), dtype="float32")
         return gv0
 
-    x = relax.Var("x", [128, 128], relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", [128, 128], DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x,), attrs={"Primitive": 1}):
         out = bb.emit(relax.call_tir("extern_func", x, (128, 128), dtype="float32"))
@@ -71,12 +72,12 @@ def test_simple_module():
                     y[vi, vj] = x[vi, vj] + 1.0
 
         @R.function
-        def foo(x: R.Tensor((128, 128), "float32")) -> R.Tensor(None, "float32", ndim=2):
+        def foo(x: R.Tensor((128, 128), "float32")) -> R.Tensor((128, 128), "float32"):
             # TODO(Siyuan): Need to change to `TestModule.tir_func`
             gv0 = R.call_tir(tir_func, x, (128, 128), dtype="float32")
             return gv0
 
-    x = relax.Var("x", [128, 128], relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", [128, 128], DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x,)):
         out = bb.emit_te(lambda x: x + 1, x, primfunc_name_hint="tir_func")
@@ -87,12 +88,12 @@ def test_simple_module():
 
 def test_relax_tensor_op():
     @R.function
-    def foo(x: R.Tensor((4, 4), "float32")) -> R.Tensor(None, "float32", ndim=2):
+    def foo(x: R.Tensor((4, 4), "float32")) -> R.Tensor((4, 4), "float32"):
         y = R.add(x, x)
         z = R.multiply(x, y)
         return z
 
-    x = relax.Var("x", [4, 4], relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", [4, 4], DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x,)):
         y = bb.emit(relax.op.add(x, x))
@@ -109,7 +110,7 @@ def test_relax_base_op():
         shape = R.shape_of(alloc)
         return shape
 
-    x = relax.Var("x", [4, 4], relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", [4, 4], DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x,)):
         alloc = bb.emit(relax.op.builtin.alloc_tensor(relax.ShapeExpr((4, 4)), "float32", 0))
@@ -121,14 +122,14 @@ def test_relax_base_op():
 
 def test_symbolic_shape():
     @R.function
-    def foo(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(None, "float32", ndim=2):
+    def foo(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
         m = T.var("int64", "m")
         n = T.var("int64", "n")
         gv0 = R.call_tir("extern_func", x, (m, n), dtype="float32")
         return gv0
 
     @R.function
-    def bar(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(None, "float32", ndim=2):
+    def bar(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
         m = T.var("int64")
         n = T.var("int64")
         gv0 = R.call_tir("extern_func", x, (m, n), dtype="float32")
@@ -145,7 +146,7 @@ def test_symbolic_shape():
 
     def _expected(name: str):
         n, m = tir.Var("n", "int64"), tir.Var("m", "int64")
-        x = relax.Var("x", [m, n], relax.DynTensorType(2, "float32"))
+        x = relax.Var("x", [m, n], DynTensorType(2, "float32"))
         bb = relax.BlockBuilder()
         with bb.function(name, (x,)):
             out = bb.emit(relax.call_tir("extern_func", x, (m, n), dtype="float32"))
@@ -167,7 +168,7 @@ def test_shadowing():
         z = y
         return z
 
-    x = relax.Var("x", [4, 4], relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", [4, 4], DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x,)):
         y = bb.emit(relax.op.add(x, x))
@@ -190,8 +191,8 @@ def test_match_shape():
         y1 = R.match_shape(y, (n,))
         return (m, n * 2)
 
-    x = relax.Var("x", type_annotation=relax.DynTensorType(-1, "float32"))
-    y = relax.Var("y", type_annotation=relax.DynTensorType(-1, "float32"))
+    x = relax.Var("x", RuntimeDepShape(), DynTensorType(-1, "float32"))
+    y = relax.Var("y", RuntimeDepShape(), DynTensorType(-1, "float32"))
     m = tir.Var("m", dtype="int64")
     n = tir.Var("n", dtype="int64")
     bb = relax.BlockBuilder()
@@ -209,7 +210,7 @@ def test_tuple_return():
         gv1 = R.call_tir("extern_func_1", x, (4, 4), dtype="float32")
         return (gv0, gv1)
 
-    x = relax.Var("x", [4, 4], relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", [4, 4], DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x,)):
         gv0 = bb.emit(relax.call_tir("extern_func_0", x, (4, 4), dtype="float32"))
@@ -229,7 +230,7 @@ def test_dataflow_block():
             R.output(gv)
         return gv
 
-    x = relax.Var("x", (128, 128), relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", (128, 128), DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x,)):
         with bb.dataflow():
@@ -262,7 +263,7 @@ def test_dataflow_block_advanced():
         gv7 = R.call_tir("extern_func", gv6, (128, 128), dtype="float32")
         return gv7
 
-    x = relax.Var("x", (128, 128), relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", (128, 128), DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     m = tir.Var("m", dtype="int64")
     n = tir.Var("n", dtype="int64")
@@ -336,7 +337,7 @@ def test_return_without_binding():
     def foo(x: R.Tensor((128, 128), "float32")):
         return x
 
-    x = relax.Var("x", (128, 128), relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", (128, 128), DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x,)):
         bb.emit_func_output(x)
@@ -367,7 +368,7 @@ def test_tensor_type_without_args():
         v = R.call_tir("tir_relu", x, (32, 32), dtype="float32")
         return v
 
-    x = relax.Var("x", (32, 32), relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", (32, 32), DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x)):
         v = bb.emit(relax.call_tir("tir_relu", x, (32, 32), dtype="float32"))
@@ -381,7 +382,7 @@ def test_direct_return():
     def foo(x: R.Tensor((32, 32), "float32")) -> R.Tensor((32, 32), "float32"):
         return x
 
-    x = relax.Var("x", (32, 32), relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", (32, 32), DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x)):
         bb.emit_func_output(x)
@@ -395,7 +396,7 @@ def test_call_packed():
         z = R.call_packed("vm.builtin.copy", x, type_args=R.Tensor((32, 32), "float32"))
         return z
 
-    x = relax.Var("x", (32, 32), relax.DynTensorType(2, "float32"))
+    x = relax.Var("x", (32, 32), DynTensorType(2, "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", (x)):
         z = bb.emit(
@@ -403,7 +404,7 @@ def test_call_packed():
                 relax.ExternFunc("vm.builtin.copy"),
                 (x,),
                 None,
-                type_args=[relax.DynTensorType(2, "float32")],
+                type_args=[DynTensorType(2, "float32")],
             )
         )
         bb.emit_func_output(z)
@@ -439,8 +440,8 @@ def test_annotation():
     _check_type_shape(
         bindings[0], relax.DynTensorType(ndim=2, dtype="float32"), relax.ShapeExpr([32, m])
     )
-    _check_type_shape(bindings[1], relax.DynTensorType(dtype=""), None)
-    _check_type_shape(bindings[2], relax.DynTensorType(ndim=2, dtype=""), None)
+    _check_type_shape(bindings[1], relax.DynTensorType(dtype=""), RuntimeDepShape())
+    _check_type_shape(bindings[2], relax.DynTensorType(ndim=2, dtype=""), RuntimeDepShape())
     _check_type_shape(bindings[3], relax.DynTensorType(dtype=""), None)
     _check_type_shape(bindings[4], relax.ShapeType(), None)
     _check_type_shape(bindings[5], relax.ObjectType(), None)
@@ -527,6 +528,58 @@ def test_local_function():
     assert len(bindings) == 2
     tir_func = bindings[0].value
     assert isinstance(tir_func, tir.PrimFunc)
+
+
+def test_cross_function_call():
+    @I.ir_module
+    class Mod0:
+        @R.function
+        def foo(x: R.Tensor((10, 5), "float32")):
+            s = R.add(x, x)
+            return s
+
+        @R.function
+        def main(x: R.Tensor((10, 5), "float32")):
+            inner = foo
+            gv1 = inner(x)
+            gv2 = foo(x)
+            return (inner, gv1, gv2)
+
+    @I.ir_module
+    class Mod1:
+        @R.function
+        def main(x: R.Tensor((10, 5), "float32")):
+            inner = foo
+            gv1 = inner(x)
+            gv2 = foo(x)
+            return (inner, gv1, gv2)
+
+        @R.function
+        def foo(x: R.Tensor((10, 5), "float32")) -> R.Tensor((10, 5), "float32"):
+            s = R.add(x, x)
+            return s
+
+    # TODO(relax-team): enable it after fix block builder
+    # Current error: `gv2.shape` is different: (10, 5) vs RuntimeDepShape()
+    # tvm.ir.assert_structural_equal(Mod0, Mod1)
+
+    with pytest.raises(tvm.error.DiagnosticError):
+
+        @I.ir_module
+        class ErrorMod:
+            @R.function
+            def main(x: R.Tensor((10, 5), "float32")):
+                inner = foo
+                gv1 = inner(x)
+                gv2 = foo(x)
+                return (inner, gv1, gv2)
+
+            @R.function
+            def foo(
+                x: R.Tensor((10, 5), "float32")
+            ):  # need function ret info since it is parse later than `main`
+                s = R.add(x, x)
+                return s
 
 
 def test_if_branch():


### PR DESCRIPTION
This PR adds support for cross-function call for relax function, by declaring a function signature (i.e. an empty function that contains params and return type/shape but w/o body.)

However, the PR meets the issue of block_builder shape deduction, which does not use function `ret_shape` to infer the shape of GlobalVar Calls.

