### PR TITLE
Enforce i64 index in ShapeExpr

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -28,6 +28,7 @@
 #include <tvm/runtime/container/map.h>
 #include <tvm/runtime/object.h>
 #include <tvm/tir/expr.h>
+#include <tvm/tir/op.h>
 
 namespace tvm {
 namespace relax {

--- a/include/tvm/tir/buffer.h
+++ b/include/tvm/tir/buffer.h
@@ -135,7 +135,7 @@ class BufferNode : public Object {
 
   /*! \return preferred index type for this buffer node */
   DataType DefaultIndexType() const {
-    return shape.size() != 0 ? shape[0].dtype() : DataType::Int(32);
+    return shape.size() != 0 ? shape[0].dtype() : DataType::Int(64);
   }
 
   /*! \brief Determine the offset in the buffer of the given index.

--- a/include/tvm/tir/buffer.h
+++ b/include/tvm/tir/buffer.h
@@ -34,6 +34,18 @@
 namespace tvm {
 namespace tir {
 
+#ifndef TVM_INDEX_DEFAULT_I64
+#define TVM_INDEX_DEFAULT_I64 1
+#endif
+/*! \brief if TVM_INDEX_DEFAULT_I64 is set, return int64, otherwise return int32 */
+inline DataType DefaultIndexType() {
+#if TVM_INDEX_DEFAULT_I64
+  return DataType::Int(64);
+#else
+  return DataType::Int(32);
+#endif
+}
+
 // forward declare Stmt
 class Stmt;
 
@@ -135,7 +147,7 @@ class BufferNode : public Object {
 
   /*! \return preferred index type for this buffer node */
   DataType DefaultIndexType() const {
-    return shape.size() != 0 ? shape[0].dtype() : DataType::Int(64);
+    return shape.size() != 0 ? shape[0].dtype() : tvm::tir::DefaultIndexType();
   }
 
   /*! \brief Determine the offset in the buffer of the given index.

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -353,7 +353,7 @@ class BlockBuilder(Object):
         unbound_tir_vars = self._get_unbound_tir_vars(te_args + outs)
 
         inputs = [*te_args] + outs
-        tir_func = tvm.te.create_prim_func(inputs, unbound_tir_vars)
+        tir_func = tvm.te.create_prim_func(inputs, unbound_tir_vars, "int64")
 
         if primfunc_name_hint:
             gvar = self.add_func(tir_func, primfunc_name_hint)

--- a/src/relax/ir/emit_te.cc
+++ b/src/relax/ir/emit_te.cc
@@ -52,7 +52,7 @@ te::Tensor TETensor(Expr value, std::string name) {
     Array<PrimExpr> shape;
     shape.reserve(ndim);
     for (int i = 0; i < ndim; ++i) {
-      shape.push_back(IntImm(DataType::Int(32), shape_tuple[i]));
+      shape.push_back(IntImm(DataType::Int(64), shape_tuple[i]));
     }
     n->shape = std::move(shape);
     return te::PlaceholderOp(n).output(0);

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -46,9 +46,13 @@ ShapeExpr::ShapeExpr(Array<PrimExpr> values, Span span) {
   Array<PrimExpr> new_values;
   new_values.reserve(values.size());
   for (const PrimExpr& value : values) {
-    ICHECK(value.dtype().is_int() || value.dtype().is_uint())
-        << "Data type of shape must be integer";
-    new_values.push_back(tvm::cast(DataType::Int(64), value));
+    PrimExpr new_value = value;
+    if (value->IsInstance<IntImmNode>()) {
+      new_value = tvm::cast(DataType::Int(64), value);
+    } else if (value.dtype() != DataType::Int(64)) {
+      LOG(FATAL) << "the value in ShapeExpr can only have dtype of int64";
+    }
+    new_values.push_back(new_value);
   }
   n->values = std::move(new_values);
   n->span = span;

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -43,7 +43,14 @@ TVM_REGISTER_NODE_TYPE(ShapeExprNode);
 
 ShapeExpr::ShapeExpr(Array<PrimExpr> values, Span span) {
   ObjectPtr<ShapeExprNode> n = make_object<ShapeExprNode>();
-  n->values = std::move(values);
+  Array<PrimExpr> new_values;
+  new_values.reserve(values.size());
+  for (const PrimExpr& value : values) {
+    ICHECK(value.dtype().is_int() || value.dtype().is_uint())
+        << "Data type of shape must be integer";
+    new_values.push_back(tvm::cast(DataType::Int(64), value));
+  }
+  n->values = std::move(new_values);
   n->span = span;
   n->shape_ = NullOpt;
   n->checked_type_ = ShapeType();

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -69,12 +69,7 @@ TensorType Tensor(Optional<Array<PrimExpr>> shape, DataType dtype, int ndim) {
   }
   Optional<Expr> shape_expr = NullOpt;
   if (shape.defined()) {
-    Array<PrimExpr> _shape;
-    _shape.reserve(shape.value().size());
-    for (const PrimExpr& expr : shape.value()) {
-      _shape.push_back(tvm::cast(DataType::Int(64), expr));
-    }
-    shape_expr = ShapeExpr(_shape);
+    shape_expr = ShapeExpr(shape.value());
   }
   return TensorType(DynTensorType(ndim, dtype), shape_expr);
 }

--- a/src/tir/ir/data_type_rewriter.cc
+++ b/src/tir/ir/data_type_rewriter.cc
@@ -534,7 +534,7 @@ PrimExpr IndexDataTypeNormalizer::VisitExpr_(const VarNode* op) {
   if (auto it = var_remap_.find(GetRef<Var>(op)); it != var_remap_.end()) {
     return (*it).second;
   }
-  if (is_enabled_) {
+  if (is_enabled_ && op->dtype != target_data_type_) {
     Var new_var = GetRef<Var>(op).copy_with_dtype(target_data_type_);
     var_remap_.Set(GetRef<Var>(op), new_var);
     return std::move(new_var);

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -41,8 +41,8 @@ def var_name_set(vars: List[Union[rx.Var, rx.GlobalVar]]) -> Set[str]:
 
 
 def test_dispatch_var():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     v0 = rx.Var("v0", [m, n], type_anno0)
@@ -60,8 +60,8 @@ def test_dispatch_var():
 
 
 def test_post_order_visit():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
@@ -87,8 +87,8 @@ def test_post_order_visit():
 
 
 def test_use_def():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -129,17 +129,17 @@ def test_symbolic_var():
 
 
 def test_symbolic_var_invalid_type():
-    # Error: dim must be of integer type, but got float32
-    dim = tir.Var("dim", "float32")
-    type_anno = rx.DynTensorType(ndim=1, dtype="float32")
-    y = rx.Var("y", [dim], type_anno)
-    gv0 = rx.Var("gv0", [dim], type_anno)
-    call_node = rx.op.add(y, y)
-    bindings = [rx.VarBinding(gv0, call_node)]
-    blocks = [rx.BindingBlock(bindings)]
-    func = build_function(blocks, [y])
-    mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    with pytest.raises(tvm.TVMError, match="Data type of shape must be integer"):
+        dim = tir.Var("dim", "float32")
+        type_anno = rx.DynTensorType(ndim=1, dtype="float32")
+        y = rx.Var("y", [dim], type_anno)
+        gv0 = rx.Var("gv0", [dim], type_anno)
+        call_node = rx.op.add(y, y)
+        bindings = [rx.VarBinding(gv0, call_node)]
+        blocks = [rx.BindingBlock(bindings)]
+        func = build_function(blocks, [y])
+        mod = tvm.IRModule({rx.GlobalVar("foo"): func})
+        assert not rx.analysis.well_formed(mod)
 
 
 def test_seq_expr():

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -19,8 +19,8 @@ import tvm
 from tvm import tir
 from tvm import relax as rx
 
-m = tir.Var("m", "int32")
-n = tir.Var("n", "int32")
+m = tir.Var("m", "int64")
+n = tir.Var("n", "int64")
 type_anno = rx.DynTensorType(ndim=2, dtype="float16")
 bool_type_anno = rx.DynTensorType(ndim=0, dtype="bool")
 x = rx.Var("x", [m, n], type_anno)
@@ -118,7 +118,7 @@ def test_global_var():
 
 def test_symbolic_var():
     # Error: Symbolic Var new_s is not defined
-    new_s = tir.Var("new_s", "int32")
+    new_s = tir.Var("new_s", "int64")
     gv0 = rx.Var("gv0", [m, new_s], type_anno)
     call_node = rx.op.add(x, x)
     bindings = [rx.VarBinding(gv0, call_node)]
@@ -129,7 +129,7 @@ def test_symbolic_var():
 
 
 def test_symbolic_var_invalid_type():
-    with pytest.raises(tvm.TVMError, match="Data type of shape must be integer"):
+    with pytest.raises(tvm.TVMError, match="the value in ShapeExpr can only have dtype of int64"):
         dim = tir.Var("dim", "float32")
         type_anno = rx.DynTensorType(ndim=1, dtype="float32")
         y = rx.Var("y", [dim], type_anno)

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -249,8 +249,8 @@ def test_shape_of():
     s1_str = dump_ast(s1)
     assert s1_str.startswith("ShapeExpr("), s1_str
     assert "values=" in s1_str
-    assert "PrimExpr(value=`96`)" in s1_str
-    assert "PrimExpr(value=`54`)" in s1_str
+    assert "PrimExpr(value=`96i64`)" in s1_str
+    assert "PrimExpr(value=`54i64`)" in s1_str
 
 
 def test_shape_expr():
@@ -258,8 +258,8 @@ def test_shape_expr():
     shape_expr_str = dump_ast(shape_expr)
     assert shape_expr_str.startswith("ShapeExpr(")
     assert "values" in shape_expr_str
-    assert "PrimExpr(value=`10`)" in shape_expr_str
-    assert "PrimExpr(value=`20`)" in shape_expr_str
+    assert "PrimExpr(value=`10i64`)" in shape_expr_str
+    assert "PrimExpr(value=`20i64`)" in shape_expr_str
 
 
 def test_call_packed():

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -89,16 +89,16 @@ def test_dataflow_var() -> None:
 
 def test_match_shape() -> None:
     # match_shape([16, 8], [m, n])
-    m = tir.Var("m", dtype="int32")
-    n = tir.Var("n", dtype="int32")
+    m = tir.Var("m", dtype="int64")
+    n = tir.Var("n", dtype="int64")
     shape = rx.const([16, 8], "int32")
     var = rx.Var("v0", type_annotation=rx.ShapeType())
     b0 = rx.MatchShape(shape, [m, n], var)
     b0_str = dump_ast(b0)
     assert b0_str.startswith("MatchShape(")
     assert "Constant" in b0_str
-    assert "PrimExpr(value=`m: int32`)" in b0_str
-    assert "PrimExpr(value=`n: int32`)" in b0_str
+    assert "PrimExpr(value=`m: int64`)" in b0_str
+    assert "PrimExpr(value=`n: int64`)" in b0_str
     assert "16" in b0_str
     assert "8" in b0_str
     assert b0_str != dump_ast(b0, include_type_annotations=False)
@@ -114,8 +114,8 @@ def test_match_shape() -> None:
     b1 = rx.MatchShape(value, [m, n], var)
     b1_str = dump_ast(b1)
     assert b1_str.startswith("MatchShape(")
-    assert "PrimExpr(value=`m: int32`)" in b1_str
-    assert "PrimExpr(value=`n: int32`)" in b1_str
+    assert "PrimExpr(value=`m: int64`)" in b1_str
+    assert "PrimExpr(value=`n: int64`)" in b1_str
     assert b1_str != dump_ast(b1, include_type_annotations=False, include_shape_annotations=False)
 
 

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -35,8 +35,8 @@ def nop():
 
 
 def test_block_builder():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
@@ -131,8 +131,8 @@ def test_function_multi_blocks():
 
 
 def test_multi_functions():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
@@ -173,9 +173,9 @@ def test_block_builder_input_mod():
         @T.prim_func
         def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
             T.func_attr({"global_symbol": "tir_matmul"})
-            m = T.var("int32")
-            n = T.var("int32")
-            k = T.var("int32")
+            m = T.var("int64")
+            n = T.var("int64")
+            k = T.var("int64")
             A = T.match_buffer(x, (m, n))
             B = T.match_buffer(y, (n, k))
             C = T.match_buffer(z, (m, k))
@@ -306,7 +306,7 @@ def test_emit_match_shape_binding_in_dataflow_block():
     bb = rx.BlockBuilder()
 
     x = rx.Var("x", type_annotation=rx.DynTensorType(-1, "float32"))
-    m = tir.Var("m", dtype="int32")
+    m = tir.Var("m", dtype="int64")
     gv = rx.Var("gv", type_annotation=rx.DynTensorType(-1, "float32"))
     match_shape = rx.MatchShape(x, (m,), gv)
 
@@ -574,8 +574,8 @@ def test_emit_tuple_get_item():
 
 
 def test_nested_function_fail():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
@@ -591,8 +591,8 @@ def test_nested_function_fail():
 
 
 def test_emit_func_output_twice_fail():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
@@ -607,8 +607,8 @@ def test_emit_func_output_twice_fail():
 
 
 def test_func_params_twice_fail():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
@@ -622,8 +622,8 @@ def test_func_params_twice_fail():
 
 
 def test_no_func_params_fail():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -62,8 +62,8 @@ def test_block_builder():
 
 
 def test_function_single_block():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
@@ -93,8 +93,8 @@ def test_function_single_block():
 
 
 def test_function_multi_blocks():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
@@ -213,9 +213,9 @@ def test_block_builder_input_mod():
 
 
 def test_binary_shape_type_deduction():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
-    k = tir.Var("k", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
+    k = tir.Var("k", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, 1], type_anno0)
@@ -260,8 +260,8 @@ def test_binary_shape_type_deduction():
 
 
 def test_emit_match_shape():
-    m = tir.Var("m", dtype="int32")
-    n = tir.Var("n", dtype="int32")
+    m = tir.Var("m", dtype="int64")
+    n = tir.Var("n", dtype="int64")
     type_anno0 = rx.DynTensorType(-1, "float32")
     x = rx.Var("tensor_value", type_annotation=type_anno0)
     shape_anno = [16, 8]
@@ -327,8 +327,8 @@ def test_emit_match_shape_binding_in_dataflow_block():
 
 
 def test_normalize():
-    m = tir.Var("m", "int32")
-    n = tir.Var("n", "int32")
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
     type_anno0 = rx.DynTensorType(ndim=2, dtype="float16")
     type_anno1 = rx.DynTensorType(ndim=1, dtype="float16")
     x = rx.Var("x", [m, n], type_anno0)
@@ -425,7 +425,7 @@ def test_emit_te():
         B = te.placeholder((n, m), dtype="float32", name="B")
         C = te.placeholder((n, m), dtype="float32", name="C")
         out = te_func((A, B), {"C": C}, "")
-        return tvm.te.create_prim_func([A, B, C, out])
+        return tvm.te.create_prim_func([A, B, C, out], index_dtype_override="int64")
 
     # check TIR structure matches expected
     assert_structural_equal(mod["te_func"].body, get_tir_func().body)

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -226,7 +226,7 @@ def test_shape_pattern():
     tvm.ir.structural_equal(pattern.shape, shape)
     assert pattern.match(bindings[0].var)
     assert wildcard().has_shape([32, 32]).match(bindings[0].var)
-    n, m = tir.Var("n", dtype="int32"), tir.Var("m", dtype="int32")
+    n, m = tir.Var("n", dtype="int64"), tir.Var("m", dtype="int64")
     symbolic_shape = rx.ShapeExpr([n, m, n + m])
     symsh_var = rx.Var("x", symbolic_shape, rx.DynTensorType(3, "float32"))
     assert wildcard().has_shape([n, m, n + m]).match(symsh_var)
@@ -246,7 +246,7 @@ def test_prim_arr_pattern():
     assert pattern[1] == 32
     assert isinstance(pattern, PrimArrPattern)
     assert pattern.match(bindings[0].var.shape)
-    n, m = tir.Var("n", dtype="int32"), tir.Var("m", dtype="int32")
+    n, m = tir.Var("n", dtype="int64"), tir.Var("m", dtype="int64")
     symbolic_shape = rx.ShapeExpr([n, m, n + m])
     assert is_shape([n, m, n + m]).match(symbolic_shape)
     assert not is_shape([n, m, n * m]).match(symbolic_shape)
@@ -496,7 +496,8 @@ def test_distiguish_diamond_and_parallel():
         # Due to one-one mathcing:
         # is_call_tir_extern("my_relu") creates the 1st relu
         is_call_tir_extern("my_relu") >> join
-        # is_call_tir_extern("my_relu") creates the another different relu (obj address is different)
+        # is_call_tir_extern("my_relu")
+        # creates the another different relu (obj address is different)
         is_call_tir_extern("my_relu") >> join
 
         assert ctx.match_dfb(parallel)

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -180,6 +180,10 @@ def test_shape_expr():
     assert x.shape_.checked_type == rx.ShapeType()
     assert x.shape_.shape_ is None
 
+    m = tir.Var("m", "int32")
+    with pytest.raises(tvm.TVMError, match="the value in ShapeExpr can only have dtype of int64"):
+        rx.ShapeExpr([m, 3])
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -52,8 +52,8 @@ def test_dataflow_var() -> None:
 
 def test_match_shape() -> None:
     # match_shape([16, 8], [m, n])
-    m = tir.Var("m", dtype="int32")
-    n = tir.Var("n", dtype="int32")
+    m = tir.Var("m", dtype="int64")
+    n = tir.Var("n", dtype="int64")
     shape = rx.const([16, 8], "int32")
     var = rx.Var("v0", type_annotation=rx.ShapeType())
     b0 = rx.MatchShape(shape, [m, n], var)

--- a/tests/python/relax/test_relay_translator.py
+++ b/tests/python/relax/test_relay_translator.py
@@ -233,7 +233,7 @@ def test_multiple_dynamic_dims():
 
 
 def test_layout_transform():
-    shape = (relay.Any(), 3, 224, 224)
+    shape = (1, 3, 224, 224)
     a = relay.var("a", shape=shape)
     b = relay.layout_transform(a, "NCHW", "NHWC")
     relay_mod = tvm.IRModule.from_expr(relay.Function([a], b))

--- a/tests/python/relax/test_structual_equal_hash.py
+++ b/tests/python/relax/test_structual_equal_hash.py
@@ -57,7 +57,7 @@ def test_var_binding():
 def test_match_shape():
     dtype = rx.DynTensorType(1)
     x = rx.Var("x", [10], dtype)
-    m = tir.Var("m", dtype="int32")
+    m = tir.Var("m", dtype="int64")
 
     def generator(x):
         bb = rx.BlockBuilder()

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -473,29 +473,6 @@ def test_vm_shape_lowering_func_param_with_shape():
     assert s5.op.name == "relax.vm.builtin.store_shape"
 
 
-def test_vm_shape_lower_int32_shape():
-    @tvm.script.ir_module
-    class InputModule:
-        @R.function
-        def foo(x: R.Tensor(("d",), "float32")):
-            d = T.var("int64")
-            gv0 = R.call_tir("my_extern", (x,), (T.cast(d, "int32"),), dtype="float32")
-            return gv0
-
-    before_mod = InputModule
-    after_mod = relax.transform.VMShapeLower()(before_mod)
-
-    assert isinstance(after_mod, tvm.IRModule)
-    shape_func = after_mod["shape_func"]
-    assert isinstance(shape_func, tvm.tir.function.PrimFunc)
-    buffer_store_stmt = shape_func.body[0]
-    assert isinstance(buffer_store_stmt, tvm.tir.stmt.BufferStore)
-    # verify that the value in BufferStore stmt is cast to int64 first
-    cast_expr = buffer_store_stmt.value
-    assert isinstance(cast_expr, tvm.tir.expr.Cast)
-    assert cast_expr.dtype == "int64"
-
-
 def test_normalize_function():
     m = tir.Var("m", "int64")
     n = tir.Var("n", "int64")

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -464,12 +464,15 @@ def test_annotation():
         y: R.Tensor(("m"), "float32"),
         r: R.Tensor(dtype="int64"),
     ) -> R.Object:
-        m = T.var("int64")
+        m = T.var("int64", "m")
         z: R.Tensor((32, m), "float32") = R.multiply(x, y)
         w: R.Tensor = R.multiply(z, z)
         q: R.Tensor(ndim=2) = R.add(w, w)
         t = R.add(w, z)
         sh: R.Shape = R.shape_of(t)
+        _: R.Tensor((1, 1), "int8") = R.builtin.alloc_tensor(
+            (1, 1), dtype="int8", runtime_device_index=0
+        )
         o: R.Object = R.call_packed("contrib.tensor_array_stack", x, y, type_args=R.Object)
         return o
 
@@ -491,7 +494,12 @@ def test_annotation():
     _check_type_shape(bindings[2], relax.DynTensorType(ndim=2, dtype=""), RuntimeDepShape())
     _check_type_shape(bindings[3], relax.DynTensorType(dtype=""), RuntimeDepShape())
     _check_type_shape(bindings[4], relax.ShapeType(), None)
-    _check_type_shape(bindings[5], relax.ObjectType(), None)
+    _check_type_shape(
+        bindings[5],
+        relax.DynTensorType(ndim=2, dtype="int8"),
+        relax.ShapeExpr([tvm.tir.IntImm("int64", 1), tvm.tir.IntImm("int64", 1)]),
+    )
+    _check_type_shape(bindings[6], relax.ObjectType(), None)
 
 
 def test_annotate_override():


### PR DESCRIPTION
Ran into [CHECK issue](https://github.com/tlc-pack/relax/blob/relax/src/script/ir_builder/relax/ir.cc#L270-L272) for the test case `test_annotation` in this pr.
@Hzfengsy @YuchenJin 

--- 
Update: Enforce i64 in ShapeExpr as TQ mentioned in #282. and the change will fix the issue above.
