### PR TITLE
[IR][Bugfix] Improvements to the normalizer and well-formed checker

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -134,7 +134,7 @@ class BlockBuilderNode : public Object {
   bool CanProveShapeEqual(const Expr& lhs, const Expr& rhs);
 
   /*!
-   * \brief Resets the memo in the normalizer to prevent false hits when visiting 
+   * \brief Resets the memo in the normalizer to prevent false hits when visiting
    *   the same expression more than once.
    *   Use if before visiting a given expression again.
    */

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -134,6 +134,15 @@ class BlockBuilderNode : public Object {
   bool CanProveShapeEqual(const Expr& lhs, const Expr& rhs);
 
   /*!
+   * \brief Resets the memo in the normalizer to prevent false hits when visiting 
+   *   the same expression more than once.
+   *   Use if before visiting a given expression again.
+   */
+  // TODO(@relax-team): Memoization should be tied to the scope tracking to prevent memo hits
+  // when the associated var is out of scope
+  void ResetMemo();
+
+  /*!
    * \brief Convert an expression to A-normal form, and try to eagerly infer types and shapes.
    * \param expr The input expression.
    * \return The normalized expression.

--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -122,6 +122,23 @@ TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
 TVM_DLL bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank = true,
                               bool permit_unknown_dtype = true);
 
+
+/*!
+ * \brief Check if the given expression is a "leaf" node for normalization purposes.
+ *    The following expressions are defined as leaf nodes: Var, Constant, ShapeExpr,
+ *    GlobalVar, RuntimeDepShape, Op, ExternFunc, and Tuple.
+ *    Tuples are included in this list mainly for convenience in grouping operator arguments.
+ *    *Note*: Since tuples can contain nested expressions, it is necessary to ensure that
+ *    values nested inside them are also leaves.
+ *
+ * \param expr The input expression
+ * 
+ * \return True iff the input expression is a "leaf" node (a value allowed to appear 
+ *    inline without being bound to a var during normalization).
+ */
+TVM_DLL bool IsLeafExpr(const Expr& expr);
+
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -122,7 +122,6 @@ TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
 TVM_DLL bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank = true,
                               bool permit_unknown_dtype = true);
 
-
 /*!
  * \brief Check if the given expression is a "leaf" node for normalization purposes.
  *    The following expressions are defined as leaf nodes: Var, Constant, ShapeExpr,
@@ -132,12 +131,11 @@ TVM_DLL bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank = true,
  *    values nested inside them are also leaves.
  *
  * \param expr The input expression
- * 
- * \return True iff the input expression is a "leaf" node (a value allowed to appear 
+ *
+ * \return True iff the input expression is a "leaf" node (a value allowed to appear
  *    inline without being bound to a var during normalization).
  */
 TVM_DLL bool IsLeafExpr(const Expr& expr);
-
 
 }  // namespace relax
 }  // namespace tvm

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -208,13 +208,16 @@ class ASTPrinter(ExprFunctor):
         )
 
     def visit_if_(self, op: relax.If) -> str:
-        return self.build_expr(
-            op,
-            "If",
-            cond=self.visit_expr(op.cond),
-            true_branch=self.visit_expr(op.true_branch),
-            false_branch=self.visit_expr(op.false_branch),
-        )
+        # if is copied from Relay's AST, so it cannot have a Shape
+        # TODO(@relax-team): We should eventually assign a shape_ to If
+        fields = {
+            "cond": self.visit_expr(op.cond),
+            "true_branch": self.visit_expr(op.true_branch),
+            "false_branch": self.visit_expr(op.false_branch),
+        }
+        if op._checked_type_ and self.include_type_annotations:
+            fields["checked_type_"] = self.visit_type_(op.checked_type)
+        return self.build_ast_node("If", **fields)
 
     def visit_op_(self, op: tvm.ir.Op) -> str:
         # TODO: List other attributes?

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -230,12 +230,15 @@ class ASTPrinter(ExprFunctor):
         return self.build_ast_node("PrimExpr", value=f"`{str(prim_expr)}`")
 
     def visit_tuple_getitem_(self, op: relax.TupleGetItem) -> str:
-        return self.build_expr(
-            op,
-            "TupleGetItem",
-            tuple_value=self.visit_expr(op.tuple_value),
-            index=str(op.index),
-        )
+        # TupleGetItem is copied from Relay's AST, so it cannot have a Shape
+        # TODO(@relax-team): We should eventually assign a shape_ to TupleGetItem
+        fields = {
+            "tuple_value": self.visit_expr(op.tuple_value),
+            "index": str(op.index),
+        }
+        if op._checked_type_ and self.include_type_annotations:
+            fields["checked_type_"] = self.visit_type_(op.checked_type)
+        return self.build_ast_node("TupleGetItem", **fields)
 
     def visit_type_(self, type_node: relax.Type) -> str:
         """

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -190,12 +190,12 @@ class WellFormedChecker : public relax::ExprVisitor {
 
   void VisitExpr_(const IfNode* op) {
     this->VisitExpr(op->cond);
-    std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> previous_var_set_ = var_set_;
-    std::unordered_set<tir::Var, ObjectPtrHash, ObjectPtrEqual> previous_symbolic_var_set_ =
-        prim_expr_visitor_.symbolic_var_set_;
     auto true_seq = op->true_branch.as<SeqExprNode>();
     auto false_seq = op->false_branch.as<SeqExprNode>();
     if (true_seq && false_seq) {
+      std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> previous_var_set_ = var_set_;
+      std::unordered_set<tir::Var, ObjectPtrHash, ObjectPtrEqual> previous_symbolic_var_set_ =
+          prim_expr_visitor_.symbolic_var_set_;
       this->VisitSeqExpr(true_seq);
       var_set_ = previous_var_set_;
       prim_expr_visitor_.symbolic_var_set_ = previous_symbolic_var_set_;

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -33,9 +33,20 @@
  *    6. SeqExpr only serves as function body, or in the true and
  *       false branches in IfNode.
  *    7. The IR is in ANF:
- *       (a) No nested call
- *       (b) The fields of the Tuple can only be Var/DataflowVar/Constant/
- *           ShapeExpr/RuntimeDepShape/Tuple
+ *       (a) Expressions cannot contain nested complex expressions.
+ *           Here are the expressions that may be nested inside other expressions:
+ *           Var, DataflowVar, GlobalVar, Constant, ShapeExpr, RuntimeDepShape,
+ *           Op, Tuple (we call these "leaf" expressions).
+ *       (b) The right-hand side of a binding may contain a non-leaf expression 
+ *           (where all expressions nested in it are leaf expressions),
+ *           other than SeqExprs (see rule 6)
+ *       (c) Exceptions: The body of a Function node and the true branch
+ *           and false branch of If nodes *must* be SeqExprs.
+ *       (d) Places where non-leaf expressions cannot appear:
+ *           * The tuple_value field of TupleGetItem nodes
+ *           * The cond field of If nodes
+ *           * The op or args fields of Call nodes
+ *           * Inside the fields of Tuple nodes
  *    8. Expr always has checked_type_ (with the exception of Op).
  */
 #include <tvm/relax/analysis.h>

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -108,8 +108,7 @@ class WellFormedChecker : public relax::ExprVisitor {
   void VisitExpr_(const TupleNode* op) {
     for (size_t i = 0; i < op->fields.size(); i++) {
       Expr expr = op->fields[i];
-      if (expr.as<VarNode>() || expr.as<DataflowVarNode>() || expr.as<ShapeExprNode>() ||
-          expr.as<RuntimeDepShapeNode>() || expr.as<ConstantNode>() || expr.as<TupleNode>()) {
+      if (IsLeafExpr(expr)) {
         this->VisitExpr(expr);
       } else {
         Malformed(Diagnostic::Error(expr->span)

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -121,6 +121,15 @@ class WellFormedChecker : public relax::ExprVisitor {
     }
   }
 
+  void VisitExpr_(const TupleGetItemNode* op) {
+    if (IsLeafExpr(op->tuple)) {
+      this->VisitExpr(op->tuple);
+    } else {
+      Malformed(Diagnostic::Error(op->span)
+                << "The tuple value in a TupleGetItem node must be a leaf expression.");
+    }
+  }
+
   void VisitExpr_(const VarNode* op) {
     Var var = GetRef<Var>(op);
     if (var_set_.count(var) == 0) {
@@ -188,7 +197,12 @@ class WellFormedChecker : public relax::ExprVisitor {
   }
 
   void VisitExpr_(const IfNode* op) {
-    this->VisitExpr(op->cond);
+    if (IsLeafExpr(op->cond)) {
+      this->VisitExpr(op->cond);
+    } else {
+      Malformed(Diagnostic::Error(op->span)
+                << "The condition for an if node must be a leaf expression.");
+    }
     auto true_seq = op->true_branch.as<SeqExprNode>();
     auto false_seq = op->false_branch.as<SeqExprNode>();
     if (true_seq && false_seq) {

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -41,6 +41,7 @@
 #include <tvm/relax/analysis.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/expr_functor.h>
+#include <tvm/relax/utils.h>
 #include <tvm/tir/expr_functor.h>
 
 #include <unordered_set>
@@ -170,9 +171,7 @@ class WellFormedChecker : public relax::ExprVisitor {
   void VisitExpr_(const CallNode* op) {
     for (size_t i = 0; i < op->args.size(); i++) {
       Expr arg = op->args[i];
-      if (arg.as<GlobalVarNode>() || arg.as<ExternFuncNode>() || arg.as<TupleNode>() ||
-          arg.as<ShapeExprNode>() || arg.as<VarNode>() || arg.as<DataflowVarNode>() ||
-          arg.as<ConstantNode>()) {
+      if (IsLeafExpr(arg)) {
         this->VisitExpr(arg);
       } else {
         Malformed(Diagnostic::Error(arg->span)

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -173,11 +173,11 @@ class WellFormedChecker : public relax::ExprVisitor {
     }
     if (auto seq = op->body.as<SeqExprNode>()) {
       this->VisitSeqExpr(seq);
-      var_set_ = previous_var_set_;
-      prim_expr_visitor_.symbolic_var_set_.clear();
     } else {
       Malformed(Diagnostic::Error(op->span) << "Function bodies must be sequence expressions");
     }
+    var_set_ = previous_var_set_;
+    prim_expr_visitor_.symbolic_var_set_.clear();
   }
 
   void VisitExpr_(const CallNode* op) {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -392,6 +392,8 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     return new_block;
   }
 
+  void ResetMemo() { expr_memo_.Reset(); }
+
  private:
   /*!
    * \brief Memoization map for expressions using Id for equality of variables.
@@ -419,6 +421,11 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
       } else {
         expr_memo_[pre] = post;
       }
+    }
+
+    void Reset() {
+      var_memo_ = std::unordered_map<Id, Expr, ObjectPtrHash, ObjectPtrEqual>();
+      expr_memo_ = std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual>();
     }
 
    private:
@@ -826,6 +833,8 @@ bool BlockBuilderNode::CanProveShapeEqual(const Expr& lhs, const Expr& rhs) {
   }
   return false;
 }
+
+void BlockBuilderNode::ResetMemo() { normalizer_->ResetMemo(); }
 
 // TODO(@altanh, @yuchen): need an internal Emit_ that doesn't call normalize
 Expr BlockBuilderNode::Normalize(const Expr& expr) {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -158,7 +158,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   }
 
   Expr VisitExpr_(const CallNode* op) final {
-    Expr new_op = this->VisitExpr(op->op);
+    Expr new_op = this->Bind(op->op);
     bool unchanged = new_op.same_as(op->op);
 
     Array<Expr> new_args;

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -274,7 +274,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   }
 
   Expr VisitExpr_(const IfNode* op) final {
-    Expr new_cond = this->VisitExpr(op->cond);
+    Expr new_cond = this->Bind(op->cond);
     Expr new_true = this->VisitWithNewScope(op->true_branch);
     Expr new_false = this->VisitWithNewScope(op->false_branch);
 
@@ -306,7 +306,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   }
 
   Expr VisitExpr_(const TupleGetItemNode* op) final {
-    Expr new_tuple = this->VisitExpr(op->tuple);
+    Expr new_tuple = this->Bind(op->tuple);
     TupleGetItem node;
     if (new_tuple.same_as(op->tuple)) {
       node = GetRef<TupleGetItem>(op);

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -77,5 +77,12 @@ bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank, bool permit_unkn
   return correct_dtype && correct_rank;
 }
 
+bool IsLeafExpr(const Expr& expr) {
+  // NB: tuples are treated as leaf nodes for ergonomics
+  return expr.as<VarNode>() || expr.as<GlobalVarNode>() || expr.as<ConstantNode>() ||
+         expr.as<ShapeExprNode>() || expr.as<RuntimeDepShapeNode>() || expr.as<ExternFuncNode>() ||
+         expr.as<OpNode>() || expr.as<TupleNode>();
+}
+
 }  // namespace relax
 }  // namespace tvm

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -54,6 +54,9 @@ void FunctionFrameNode::ExitWithScope() {
   // Step 1: Create the function.
   CHECK(output.defined()) << "ValueError: A Relax function must have a return value. Please use "
                              "`return` to return an Expr";
+  // Normalizing a second time could result in false hits to the memo
+  // TODO(relax-team): We should fix the memoization not to require this
+  this->block_builder->ResetMemo();
   Expr body = this->block_builder->Normalize(tvm::relax::SeqExpr(binding_blocks, output.value()));
   Expr func_shape = ret_shape.value_or(tvm::relax::RuntimeDepShape());
   if (func_shape->IsInstance<tvm::relax::RuntimeDepShapeNode>()) {

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -453,5 +453,19 @@ def test_if():
     assert "false_branch=SeqExpr(" in body_str
 
 
+def test_tuple_get_item():
+    @R.function
+    def f(x: R.Tuple(R.Tensor((), dtype="int32"))) -> R.Tensor((), dtype="int32"):
+        return x[0]
+
+    body = normalize(f).body
+    assert isinstance(body, rx.SeqExpr)
+    body_str = strip_whitespace(dump_ast(body))
+
+    assert "TupleGetItem" in body_str
+    assert 'tuple_value=Var(name_hint="x"' in body_str
+    assert "index=0" in body_str
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -435,5 +435,23 @@ def test_print_type_annotation_non_var():
     assert type_str in call_str
 
 
+def test_if():
+    @R.function
+    def f(cond: R.Tensor((), dtype="bool")) -> R.Tensor((), dtype="int32"):
+        if cond:
+            x = R.const(1)
+        else:
+            x = R.const(2)
+        return x
+
+    body = normalize(f).body
+    assert isinstance(body, rx.SeqExpr)
+    body_str = strip_whitespace(dump_ast(body))
+    # we expect both branches to be seq exprs
+    assert "If" in body_str
+    assert "true_branch=SeqExpr(" in body_str
+    assert "false_branch=SeqExpr(" in body_str
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -422,7 +422,7 @@ def test_print_type_annotation_non_var():
 
     body = normalize(f).body
     assert isinstance(body, rx.SeqExpr)
-    call = body.body
+    call = body.blocks[-1].bindings[-1].value
     assert isinstance(call, rx.Call)
     arg = call.args[0]
     arg_str = strip_whitespace(dump_ast(arg))

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -385,6 +385,9 @@ def basic_check(expr, visitor_str, mutator_str):
     # skip normalize GlobalVar since it requires context IRModule to get the checked_type_
     if isinstance(expr, relax.Expr) and not isinstance(expr, relax.GlobalVar):
         expr = bb.normalize(expr)
+        print(dump_ast(visit(basic_mutator, expr)))
+        print()
+        print(dump_ast(expr))
         assert_structural_equal(visit(basic_mutator, expr), expr)
 
     # check the output log and return value
@@ -464,7 +467,7 @@ def test_if():
     basic_check(
         if_node,
         "\n".join(["If", "\tVar", "\tVar", "\tVar"]),
-        "\n".join(["Var", "Var", "Var", "If"]),
+        "\n".join(["Var", "Var", "SeqExpr", "Var", "SeqExpr", "If"]),
     )
 
 
@@ -565,7 +568,7 @@ def test_function():
     bindings = [relax.VarBinding(x, relax.const(1))]
     blocks = [relax.BindingBlock(bindings)]
     seq_expr = relax.SeqExpr(blocks, x)
-    ret_type = relax.DynTensorType(-1, "float32")
+    ret_type = relax.DynTensorType(1, "float32")
     ret_shape = relax.RuntimeDepShape()
     func = relax.Function([x], seq_expr, ret_type, ret_shape)
     basic_check(

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -385,9 +385,6 @@ def basic_check(expr, visitor_str, mutator_str):
     # skip normalize GlobalVar since it requires context IRModule to get the checked_type_
     if isinstance(expr, relax.Expr) and not isinstance(expr, relax.GlobalVar):
         expr = bb.normalize(expr)
-        print(dump_ast(visit(basic_mutator, expr)))
-        print()
-        print(dump_ast(expr))
         assert_structural_equal(visit(basic_mutator, expr), expr)
 
     # check the output log and return value

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -238,13 +238,17 @@ def test_if():
     body = ite.true_branch.body
     assert w_bind.var.name_hint == "w"
     check_call(w_bind.value, "relax.add", [x, x])
-    check_call(body, "relax.multiply", [w_bind.var, w_bind.var])
+    body_bind = ite.true_branch.blocks[1].bindings[0]
+    check_call(body_bind.value, "relax.multiply", [w_bind.var, w_bind.var])
+    assert ite.true_branch.body == body_bind.var
 
     w_bind = ite.false_branch.blocks[0].bindings[0]
     body = ite.false_branch.body
     assert w_bind.var.name_hint == "w"
     check_call(w_bind.value, "relax.multiply", [x, x])
-    check_call(body, "relax.add", [w_bind.var, w_bind.var])
+    body_bind = ite.false_branch.blocks[1].bindings[0]
+    check_call(body_bind.value, "relax.add", [w_bind.var, w_bind.var])
+    assert ite.false_branch.body == body_bind.var
 
 
 def test_func_type_annotation_fail():
@@ -766,9 +770,15 @@ def test_class_irmodule():
     func_j = my_module[var_j]
     func_k = my_module[var_k]
 
-    assert len(func_f.body.blocks) == 0
-    assert func_f.body.body.op == var_g
-    assert func_g.body.body.args[0] == var_my_matmul
+    assert len(func_f.body.blocks) == 1
+    assert len(func_f.body.blocks[0].bindings) == 1
+    f_call_var = func_f.body.blocks[0].bindings[0].var
+    assert func_f.body.blocks[0].bindings[0].value.op == var_g
+    assert func_f.body.body == f_call_var
+
+    g_call_var = func_g.body.blocks[0].bindings[-1].var
+    assert func_g.body.blocks[0].bindings[-1].value.args[0] == var_my_matmul
+    assert func_g.body.body == g_call_var
 
     gv_bind = func_j.body.blocks[0].bindings[0]
     assert gv_bind.value.checked_type.ndim == 2

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -27,6 +27,7 @@ from tvm.script import tir as T, relax as R
 
 from tvm.relax.testing import dump_ast
 
+
 def test_fma_rewrite():
     @tvm.script.ir_module
     class Before:
@@ -760,9 +761,9 @@ def test_normalize_tuple_get_item():
     # Not using the parser this time because writing it out correctly results in
     # *one* binding block, whereas the normalized version has *two*
     idx_var = relax.Var(
-        "idx_var", 
+        "idx_var",
         shape_annotation=relax.Tuple([relax.ShapeExpr([])]),
-        type_annotation=relax.TupleType([relax.DynTensorType(ndim=0, dtype="int32")])
+        type_annotation=relax.TupleType([relax.DynTensorType(ndim=0, dtype="int32")]),
     )
     ret_var = relax.Var("ret", [], relax.DynTensorType(ndim=0, dtype="int32"))
     expected_f = relax.Function(

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -668,16 +668,18 @@ def test_if_branch():
         tvm.ir.assert_structural_equal(call.args, args)
 
     w_bind = ite.true_branch.blocks[0].bindings[0]
-    body = ite.true_branch.body
+    # the seq exprts in the branches are normalized to bind any call
+    # in the seq expr "body" to a var
+    y_bind = ite.true_branch.blocks[-1].bindings[-1]
     assert w_bind.var.name_hint == "w"
     check_call(w_bind.value, "relax.add", [x, x])
-    check_call(body, "relax.multiply", [w_bind.var, w_bind.var])
+    check_call(y_bind.value, "relax.multiply", [w_bind.var, w_bind.var])
 
     w_bind = ite.false_branch.blocks[0].bindings[0]
-    body = ite.false_branch.body
+    y_bind = ite.false_branch.blocks[-1].bindings[-1]
     assert w_bind.var.name_hint == "w"
     check_call(w_bind.value, "relax.multiply", [x, x])
-    check_call(body, "relax.add", [w_bind.var, w_bind.var])
+    check_call(y_bind.value, "relax.add", [w_bind.var, w_bind.var])
 
 
 def test_if_inside_dataflow():


### PR DESCRIPTION
This PR addresses the issues discussed in https://github.com/tlc-pack/relax/issues/283. In particular:
1. `If` node and `Function` node bodies are _always_ normalized into `SeqExpr`s.
2. The `body` field of a `SeqExpr` must be a "leaf" node, i.e., not a nested expression (except for tuples, per the discussion in #283).
3. Bug fixes: The normalizer now ensures that the `tuple_value` field in a `TupleGetItem` node and the `cond` field in an `If` node are leaf expressions or are otherwise bound to a var.
4. The well-formed checker makes sure the above constraints are enforced.

The PR also includes some bugfixes in the debug AST printer. Namely, `If` nodes and `TupleGetItem` nodes are shared with the Relay AST and so don't have a `shape_` field, so the AST printer will not check for the `shape_` field (this is arguably a bad thing and a reason to decouple the Relax AST from the Relay one).