### PR TITLE
[Refactor][BlockBuilder] Associate BlockBuilder::ExprMemo with the scope to avoid breaking scope rules

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -134,15 +134,6 @@ class BlockBuilderNode : public Object {
   bool CanProveShapeEqual(const Expr& lhs, const Expr& rhs);
 
   /*!
-   * \brief Resets the memo in the normalizer to prevent false hits when visiting
-   *   the same expression more than once.
-   *   Use if before visiting a given expression again.
-   */
-  // TODO(@relax-team): Memoization should be tied to the scope tracking to prevent memo hits
-  // when the associated var is out of scope
-  void ResetMemo();
-
-  /*!
    * \brief Convert an expression to A-normal form, and try to eagerly infer types and shapes.
    * \param expr The input expression.
    * \return The normalized expression.

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -397,8 +397,8 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
    * \brief Memoization map for expressions using Id for equality of variables.
    *        Note: The memo keeps track of scopes because it deals with var nodes
    *        (either mapping vars to exprs or exprs to vars), which are also scoped.
-   *        This ensures that there will never be a false hit to the memo, resulting
-   *        in returning a var outside of its scope.
+   *        This ensures that there will never be a false hit to the memo, 
+   *        which would result in returning a var outside of its scope.
    */
   class ExprMemo {
    public:
@@ -438,13 +438,11 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     }
 
     void PushScope() {
-      std::cout << "Push scope" << std::endl;
       var_memo_.push_back({});
       expr_memo_.push_back({});
     }
 
     void PopScope() {
-      std::cout << "Pop scope" << std::endl;
       var_memo_.pop_back();
       expr_memo_.pop_back();
     }

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -397,7 +397,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
    * \brief Memoization map for expressions using Id for equality of variables.
    *        Note: The memo keeps track of scopes because it deals with var nodes
    *        (either mapping vars to exprs or exprs to vars), which are also scoped.
-   *        This ensures that there will never be a false hit to the memo, 
+   *        This ensures that there will never be a false hit to the memo,
    *        which would result in returning a var outside of its scope.
    */
   class ExprMemo {

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -54,9 +54,6 @@ void FunctionFrameNode::ExitWithScope() {
   // Step 1: Create the function.
   CHECK(output.defined()) << "ValueError: A Relax function must have a return value. Please use "
                              "`return` to return an Expr";
-  // Normalizing a second time could result in false hits to the memo
-  // TODO(relax-team): We should fix the memoization not to require this
-  this->block_builder->ResetMemo();
   Expr body = this->block_builder->Normalize(tvm::relax::SeqExpr(binding_blocks, output.value()));
   Expr func_shape = ret_shape.value_or(tvm::relax::RuntimeDepShape());
   if (func_shape->IsInstance<tvm::relax::RuntimeDepShapeNode>()) {


### PR DESCRIPTION
This PR fixes the issue noted in #288 in which the `BlockBuilder`'s `ExprMemo` can store entries between visits, which resulted in violating scoping rules when an expression was visited twice (the first visit populated the memo and the second visit would find the variable in the memo even though the variable was not bound the second time). In #288, the bug was fixed by manually resetting the memo, breaking the visitor's abstraction. By contrast, this PR automatically removes entries from the memo when they go out of scope, not requiring a manual reset.