### PR TITLE
[Linkage] Cleanup global_symbol attachment and linkage.

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -101,6 +101,13 @@ TVM_DLL Pass ToNonDataflow();
 TVM_DLL Pass CallTIRRewrite();
 
 /*!
+ * \brief Attach global_symbol to Relax functions and TIR Primfuncs for codegen.
+ *
+ * \return The Pass.
+ */
+TVM_DLL Pass AttachGlobalSymbol();
+
+/*!
  * \brief Simplify a Relax module by folding var bindings and match shape nodes.
  * May include other forms of expression simplification in the future.
  * Best used alongside constant folding and eliminating unused bindings.

--- a/python/tvm/relax/testing/relay_translator.py
+++ b/python/tvm/relax/testing/relay_translator.py
@@ -207,4 +207,6 @@ def from_relay(
             bb._begin_dataflow_block()
             relay.analysis.post_order_visit(mod["main"], visit_func)
 
+    relax_mod = bb.get()
+    relax_mod["main"] = relax_mod["main"].with_attr("global_symbol", "main")
     return bb.get()

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -122,6 +122,16 @@ def VMShapeLower() -> tvm.ir.transform.Pass:
     return _ffi_api.VMShapeLower()  # type: ignore
 
 
+def AttachGlobalSymbol() -> tvm.ir.transform.Pass:
+    """Attach global_symbol to Relax functions and TIR Primfuncs for codegen.
+
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
+    return _ffi_api.AttachGlobalSymbol()  # type: ignore
+
+
 def Normalize() -> tvm.ir.transform.Pass:
     """Transforming Relax IR to normal form, i.e., the expressions are normalized(no nesting
     and hence the AST is in ANF), and all checked_type_ and shape_ of expressions are available.

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -503,6 +503,7 @@ def build(
     passes.append(relax.transform.CallTIRRewrite())
     passes.append(relax.transform.VMMemoryLower())
     passes.append(relax.transform.VMShapeLower())
+    passes.append(relax.transform.AttachGlobalSymbol())
     seq = tvm.transform.Sequential(passes)
     new_mod = seq(mod)
 

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -349,9 +349,14 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::SeqExprNode* op) {
 
 Doc RelaxScriptPrinter::VisitNode_(const relax::FunctionNode* op) {
   Optional<String> gsymbol = op->GetAttr<String>(tvm::attr::kGlobalSymbol);
-  ICHECK(gsymbol.defined());
-  return PrintFunctionDef(Doc::Text(gsymbol.value()), GetRef<relax::Function>(op),
-                          /*is_global=*/true);
+  if (gsymbol) {
+    ICHECK_EQ(gsymbol.value(), relax_func_name_);
+    return PrintFunctionDef(Doc::Text(relax_func_name_), GetRef<relax::Function>(op),
+                            /*is_global=*/true);
+  } else {
+    return PrintFunctionDef(Doc::Text(relax_func_name_), GetRef<relax::Function>(op),
+                            /*is_global=*/true);
+  }
 }
 
 Doc RelaxScriptPrinter::VisitNode_(const relax::ExternFuncNode* op) {
@@ -530,6 +535,7 @@ Doc RelaxScriptPrinter::PrintIRModule(const IRModule& mod) {
     if (pr.second.as<tir::PrimFuncNode>()) {
       func = PrintPrimFunc(pr.first->name_hint, Downcast<tir::PrimFunc>(pr.second));
     } else {
+      relax_func_name_ = pr.first->name_hint;
       func = Print(pr.second);
     }
     doc << Doc::Indent(4, Doc::NewLine() << func);

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -254,8 +254,10 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   bool show_meta_data_;
   /*! \brief A counter for naming local functions. */
   size_t local_func_counter_ = 0;
-  /*! \brief meta data context */
+  /*! \brief meta data context. */
   TextMetaDataContext* meta_;
+  /*! \brief the current relax function name. */
+  String relax_func_name_ = "foo";
   /*!
    * \brief A bool flag to indicate if we print symbolic shape as str, usually for global
    * function.

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -882,7 +882,6 @@ GlobalVar BlockBuilderNode::AddFunction(const BaseFunc& func, const String& func
     GlobalVar gvar = GlobalVar(func_name);
     if (const tir::PrimFuncNode* prim_func = func.as<tir::PrimFuncNode>()) {
       tir::PrimFunc fn = GetRef<tir::PrimFunc>(prim_func);
-      fn = WithAttr(std::move(fn), "global_symbol", func_name);
       ICHECK(fn->checked_type_.defined())
           << "The function to be added does not have checked_type_.";
       gvar->checked_type_ = fn->checked_type_;

--- a/src/relax/transform/attach_global_symbol.cc
+++ b/src/relax/transform/attach_global_symbol.cc
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file src/relax/transform/attach_global_symbol.cc
+ * \brief Attach global_symbol to Relax functions and TIR Primfuncs for codegen.
+ */
+
+#include <tvm/relax/transform.h>
+#include <tvm/tir/function.h>
+
+namespace tvm {
+namespace relax {
+
+class GlobalSymbolAttacher {
+ public:
+  explicit GlobalSymbolAttacher(IRModule mod) : mod_(mod) {}
+
+  IRModule Attach() {
+    IRModule ret;
+    for (auto& p : mod_->functions) {
+      BaseFunc func = p.second;
+      if (auto* prim_func = func.as<tir::PrimFuncNode>()) {
+        func = WithAttr(GetRef<tir::PrimFunc>(prim_func), "global_symbol", p.first->name_hint);
+      } else if (auto* relax_func = func.as<FunctionNode>()) {
+        func = WithAttr(GetRef<Function>(relax_func), "global_symbol", p.first->name_hint);
+      } else {
+        LOG(FATAL) << "Unsupported function type: " << func->GetTypeKey();
+        throw;
+      }
+      ret->Add(p.first, func);
+    }
+    return ret;
+  }
+ private:
+  IRModule mod_;
+};
+
+namespace transform {
+
+Pass AttachGlobalSymbol() {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =
+      [=](IRModule mod, PassContext pc) { return GlobalSymbolAttacher(mod).Attach(); };
+  return CreateModulePass(pass_func, 0, "AttachGlobalSymbol", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.AttachGlobalSymbol").set_body_typed(AttachGlobalSymbol);
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/transform/attach_global_symbol.cc
+++ b/src/relax/transform/attach_global_symbol.cc
@@ -47,6 +47,7 @@ class GlobalSymbolAttacher {
     }
     return ret;
   }
+
  private:
   IRModule mod_;
 };

--- a/src/relax/transform/fma_rewrite.cc
+++ b/src/relax/transform/fma_rewrite.cc
@@ -127,8 +127,7 @@ class EwiseFuseFMAMutator : public ExprMutator {
 
         String func_name = "ewise_fma_fused";
         Function func = Function({x, y, z}, body, call->args[1]->checked_type_, RuntimeDepShape());
-        Expr ewise_fma_fused = WithAttr(std::move(func), "global_symbol", func_name);
-        Expr normalized = builder_->Normalize(ewise_fma_fused);
+        Expr normalized = builder_->Normalize(func);
         GlobalVar global_var1 =
             builder_->AddFunction(Downcast<BaseFunc>(normalized), "ewise_fma_fused");
 

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -444,7 +444,6 @@ class FunctionCreator : public ExprMutator {
     body = builder_->Normalize(body);
     body = builder_->Normalize(SeqExpr({new_block}, body));
     Map<String, ObjectRef> attrs;
-    attrs.Set(tvm::attr::kGlobalSymbol, name_hint_);
     attrs.Set(tvm::relax::attr::kPrimitive, Integer(1));
     function_ = Function(/*params=*/params_,  //
                          /*body=*/body,       //

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -522,8 +522,6 @@ class FusedTIRConstructor : public ExprVisitor {
     Map<String, ObjectRef> attr_map;
     attr_map.Set("tir.noalias", tir::const_true());
     ICHECK(func_info_.global_name != "fused");
-    // TODO(relax-team): remove global_symbol later.
-    attr_map.Set("global_symbol", String(func_info_.global_name));
     // Remove output buffers from func_info_.alloc_buffers
     Array<tir::Buffer> alloc_buffers;
     for (const tir::Buffer& buf : func_info_.alloc_buffers) {

--- a/src/relax/transform/lambda_lift.cc
+++ b/src/relax/transform/lambda_lift.cc
@@ -176,7 +176,6 @@ class LambdaLifter : public ExprMutator {
         param_types.push_back(param->checked_type_);
       }
     }
-    lifted_func = WithAttr(std::move(lifted_func), tvm::attr::kGlobalSymbol, lift_func_name);
 
     ICHECK(lifted_func.defined());
 

--- a/src/relax/transform/meta_schedule.cc
+++ b/src/relax/transform/meta_schedule.cc
@@ -112,9 +112,6 @@ Pass MetaScheduleApplyDatabase(Optional<String> work_dir) {
       BaseFunc base_func = iter.second;
       if (const auto* prim_func_node = base_func.as<tir::PrimFuncNode>()) {
         tir::PrimFunc prim_func = GetRef<tir::PrimFunc>(prim_func_node);
-        // Global symbol has to be defined.
-        Optional<String> gsymbol = prim_func->GetAttr<String>(tvm::attr::kGlobalSymbol);
-        ICHECK(gsymbol.defined());
 
         IRModule tir_mod = (*normalize_mod_func_)(prim_func);
         if (Optional<tir::Schedule> sch = database->QuerySchedule(tir_mod, target, gv->name_hint)) {
@@ -128,7 +125,7 @@ Pass MetaScheduleApplyDatabase(Optional<String> work_dir) {
           result.Set(gv, new_prim_func);
           continue;
         } else {
-          LOG(WARNING) << "Tuning record is not found for primfunc: " << gsymbol.value();
+          LOG(WARNING) << "Tuning record is not found for primfunc: " << gv->name_hint;
         }
       }
       result.Set(gv, base_func);

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -64,13 +64,12 @@ void FunctionFrameNode::ExitWithScope() {
     // TODO(relax-team): enable the following line when fixing ret_shape issue in block builder
     // func_shape = tvm::relax::DeriveFuncRetShape(params, body);
   }
+  auto dict_attrs = attrs.empty() ? NullValue<DictAttrs>() : DictAttrs(attrs);
   tvm::relax::Function func(/*params=*/params,
                             /*body=*/body,
                             /*ret_type=*/ret_type.value_or(Type()),
                             /*ret_shape=*/func_shape,
-                            /*attrs=*/DictAttrs(attrs));
-  // TODO(relax-team): remove this line
-  func = WithAttr(func, "global_symbol", name.value());
+                            /*attrs=*/dict_attrs);
   // Step 2: Update IRModule.
   if (builder->frames.empty()) {
     // Case 0. No outer frame, return function directly

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -544,7 +544,6 @@ PrimFunc CreatePrimFunc(const Array<te::Tensor>& arg_list,
   return CreatePrimFuncWithConstants(arg_list, {}, tir_var_list, index_dtype_override);
 }
 
-// TVM_REGISTER_GLOBAL("te.CreatePrimFunc").set_body_typed(CreatePrimFunc);
 TVM_REGISTER_GLOBAL("te.CreatePrimFunc").set_body([](TVMArgs args, TVMRetValue* ret) {
   Array<te::Tensor> arg_list = args[0];
   Optional<Array<tir::Var>> tir_var_list = args[1];

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -122,7 +122,6 @@ def test_function_multi_blocks():
     assert gv2.checked_type.dtype == "float16"
     assert func.params[0] == x
     assert func.params[1] == y
-    assert func.attrs["global_symbol"] == "func"
     assert func.body.body == gv2
     assert len(func.body.blocks) == 3
     assert len(func.body.blocks[0].bindings) == 2
@@ -158,12 +157,10 @@ def test_multi_functions():
     func1 = mod["func1"]
     assert func1.params[0] == x
     assert func1.params[1] == y
-    assert func1.attrs["global_symbol"] == "func1"
     assert len(func1.body.blocks) == 1
     func2 = mod["func2"]
     assert func2.params[0] == x
     assert func2.params[1] == y
-    assert func2.attrs["global_symbol"] == "func2"
     assert len(func2.body.blocks) == 1
 
 
@@ -392,7 +389,6 @@ def test_call_te():
     assert rx_func.params[0] == x
     assert rx_func.params[1] == y
     assert rx_func.params[2] == z
-    assert rx_func.attrs["global_symbol"] == "rx_func"
     assert rx_func.body.body == out
     assert len(rx_func.body.blocks) == 1
     assert len(rx_func.body.blocks[0].bindings) == 1
@@ -434,7 +430,6 @@ def test_emit_te():
     assert rx_func.params[0] == x
     assert rx_func.params[1] == y
     assert rx_func.params[2] == z
-    assert rx_func.attrs["global_symbol"] == "rx_func"
     assert rx_func.body.body == out
     assert len(rx_func.body.blocks) == 1
     assert len(rx_func.body.blocks[0].bindings) == 1
@@ -501,7 +496,6 @@ def test_emit_te_multiple_output():
 
     # check call tir output shape is a Tuple of ShapeExpr
     assert rx_func.params[0] == x
-    assert rx_func.attrs["global_symbol"] == "rx_func"
     call_node = rx_func.body.blocks[0].bindings[0].value
     assert call_node.op == relay.op.get("relax.call_tir")
     assert call_node.args[0].name_hint == "te_func"

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -835,6 +835,39 @@ def test_class_irmodule():
     check_shape(gv2_bind.var, ("n", "n"))
 
 
+def test_function_attrs():
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
+            T.func_attr({"global_symbol": "tir_matmul"})
+            m = T.var("int64")
+            n = T.var("int64")
+            k = T.var("int64")
+            A = T.match_buffer(x, (m, n))
+            B = T.match_buffer(y, (n, k))
+            C = T.match_buffer(z, (m, k))
+
+            for i, j, k in T.grid(m, k, n):
+                with T.block("matmul"):
+                    vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                    with T.init():
+                        C[vi, vj] = T.float32(0)
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+
+        @R.function
+        def main(
+            x: R.Tensor(("m", "n"), "float32"), w: R.Tensor(("n", "k"), "float32")
+        ) -> R.Tensor:
+            R.func_attr({"global_symbol": "main"})
+            m, n, k = T.var("int64"), T.var("int64"), T.var("int64")
+            gv0 = R.call_tir("tir_matmul", (x, w), (m, k), dtype="float32")
+            return gv0
+
+    assert InputModule["main"].attrs["global_symbol"] == "main"
+    assert InputModule["tir_matmul"].attrs["global_symbol"] == "tir_matmul"
+
+
 def test_class_normalize():
     @tvm.script.ir_module
     class InputModule:

--- a/tests/python/relax/test_relay_translator.py
+++ b/tests/python/relax/test_relay_translator.py
@@ -99,6 +99,8 @@ def verify_e2e_translation(target_str, layout, batch_size, image_shape):
     input_shape = (1, *image_shape)
     data = tvm.nd.array(np.random.rand(*input_shape).astype(np.float32), dev)
     relax_mod = relay_translator.from_relay(relay_mod["main"], target, params)
+    assert relax_mod["main"].attrs["global_symbol"] == "main"
+
     _, _, relay_out = relay_build_and_run(relay_mod, target, dev, params, data)
     _, _, relax_out = relax_build_and_run(relax_mod, target, dev, params, data)
     tvm.testing.assert_allclose(relay_out, relax_out, atol=1e-5, rtol=1e-5)

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -489,7 +489,6 @@ def test_normalize_function():
         ret_type=type_anno,
         ret_shape=relax.RuntimeDepShape(),
     )
-    mul_add = mul_add.with_attr("global_symbol", "mul_add")
     before_mod = tvm.IRModule.from_expr(mul_add)
 
     after_mod = relax.transform.Normalize()(before_mod)
@@ -502,7 +501,7 @@ def test_normalize_function():
             gv1 = R.add(x, x)
             return R.multiply(gv, gv1)
 
-    assert_structural_equal(after_mod, Expected)
+    assert_structural_equal(after_mod["main"], Expected["mul_add"])
 
 
 def test_normalize_if():
@@ -536,7 +535,6 @@ def test_normalize_if():
         ret_shape=relax.RuntimeDepShape(),
     )
 
-    f = f.with_attr("global_symbol", "f")
     before_mod = tvm.IRModule.from_expr(f)
     after_mod = relax.transform.Normalize()(before_mod)
 
@@ -556,7 +554,7 @@ def test_normalize_if():
                 y = R.add(gv, gv1)
             return y
 
-    assert_structural_equal(after_mod, Expected)
+    assert_structural_equal(after_mod["main"], Expected["f"])
 
 
 def test_normalize_no_op():
@@ -602,7 +600,6 @@ def test_normalize_seq_body():
         ret_type=relax.DynTensorType(ndim=0, dtype="int32"),
         ret_shape=relax.RuntimeDepShape(),
     )
-    f = f.with_attr("global_symbol", "f")
     before_mod = tvm.IRModule.from_expr(f)
     after_mod = relax.transform.Normalize()(before_mod)
 
@@ -616,7 +613,7 @@ def test_normalize_seq_body():
             z = R.add(x, y)
             return z
 
-    assert_structural_equal(after_mod, Expected)
+    assert_structural_equal(after_mod["main"], Expected["f"])
 
 
 def test_normalize_func_body():
@@ -629,7 +626,6 @@ def test_normalize_func_body():
         ret_type=relax.DynTensorType(ndim=0, dtype="int32"),
         ret_shape=relax.RuntimeDepShape(),
     )
-    f = f.with_attr("global_symbol", "f")
     before_mod = tvm.IRModule.from_expr(f)
     after_mod = relax.transform.Normalize()(before_mod)
 
@@ -643,7 +639,7 @@ def test_normalize_func_body():
             z = R.add(x, y)
             return z
 
-    assert_structural_equal(after_mod, Expected)
+    assert_structural_equal(after_mod["main"], Expected["f"])
 
 
 def test_normalize_if_branches():
@@ -664,7 +660,6 @@ def test_normalize_if_branches():
         ret_type=relax.DynTensorType(ndim=0, dtype="int32"),
         ret_shape=relax.RuntimeDepShape(),
     )
-    f = f.with_attr("global_symbol", "f")
     before_mod = tvm.IRModule.from_expr(f)
     after_mod = relax.transform.Normalize()(before_mod)
 
@@ -685,7 +680,7 @@ def test_normalize_if_branches():
                 z = w
             return z
 
-    assert_structural_equal(after_mod, Expected)
+    assert_structural_equal(after_mod["main"], Expected["f"])
 
 
 def test_normalize_if_condition():
@@ -717,7 +712,6 @@ def test_normalize_if_condition():
         ret_type=relax.DynTensorType(1, "float32"),
         ret_shape=relax.RuntimeDepShape(),
     )
-    f = f.with_attr("global_symbol", "f")
     before_mod = tvm.IRModule.from_expr(f)
     after_mod = relax.transform.Normalize()(before_mod)
 
@@ -736,7 +730,7 @@ def test_normalize_if_condition():
                 y = gv
             return y
 
-    assert_structural_equal(after_mod, Expected)
+    assert_structural_equal(after_mod["main"], Expected["f"])
 
 
 def test_normalize_tuple_get_item():

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -489,6 +489,8 @@ def test_normalize_function():
         ret_type=type_anno,
         ret_shape=relax.RuntimeDepShape(),
     )
+
+    # Note: from_expr api names private function (function without global_symbol) as "main"
     before_mod = tvm.IRModule.from_expr(mul_add)
 
     after_mod = relax.transform.Normalize()(before_mod)

--- a/tests/python/relax/test_transform_attach_global_symbol.py
+++ b/tests/python/relax/test_transform_attach_global_symbol.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+import tvm
+from tvm import tir, relax
+from tvm.ir import assert_structural_equal
+
+import tvm.script
+from tvm.script import tir as T, relax as R
+
+
+@tvm.script.ir_module
+class Before:
+    @T.prim_func
+    def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
+        m = T.var("int64")
+        n = T.var("int64")
+        k = T.var("int64")
+        A = T.match_buffer(x, (m, n))
+        B = T.match_buffer(y, (n, k))
+        C = T.match_buffer(z, (m, k))
+
+        for i, j, k in T.grid(m, k, n):
+            with T.block("matmul"):
+                vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                with T.init():
+                    C[vi, vj] = T.float32(0)
+                C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+
+    @R.function
+    def main(x: R.Tensor(("m", "n"), "float32"), w: R.Tensor(("n", "k"), "float32")) -> R.Tensor:
+        m, n, k = T.var("int64"), T.var("int64"), T.var("int64")
+        gv0 = R.call_tir("tir_matmul", (x, w), (m, k), dtype="float32")
+        return gv0
+
+
+def test_basic():
+    @tvm.script.ir_module
+    class Expected:
+        @T.prim_func
+        def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
+            T.func_attr({"global_symbol": "tir_matmul"})
+            m = T.var("int64")
+            n = T.var("int64")
+            k = T.var("int64")
+            A = T.match_buffer(x, (m, n))
+            B = T.match_buffer(y, (n, k))
+            C = T.match_buffer(z, (m, k))
+
+            for i, j, k in T.grid(m, k, n):
+                with T.block("matmul"):
+                    vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                    with T.init():
+                        C[vi, vj] = T.float32(0)
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+
+        @R.function
+        def main(
+            x: R.Tensor(("m", "n"), "float32"), w: R.Tensor(("n", "k"), "float32")
+        ) -> R.Tensor:
+            R.func_attr({"global_symbol": "main"})
+            m, n, k = T.var("int64"), T.var("int64"), T.var("int64")
+            gv0 = R.call_tir("tir_matmul", (x, w), (m, k), dtype="float32")
+            return gv0
+
+    before = Before
+    expected = Expected
+    after = relax.transform.AttachGlobalSymbol()(before)
+    assert_structural_equal(after, expected)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/relax/test_transform_lower_with_op_strategy.py
+++ b/tests/python/relax/test_transform_lower_with_op_strategy.py
@@ -82,5 +82,4 @@ def test_lowering_gpu(target_str="nvidia/nvidia-t4"):
 
 
 if __name__ == "__main__":
-    test_lowering_cpu()
-    test_lowering_gpu()
+    tvm.testing.main()

--- a/tests/python/relax/test_transform_remove_unused_funcs.py
+++ b/tests/python/relax/test_transform_remove_unused_funcs.py
@@ -22,11 +22,6 @@ from tvm import relax
 import tvm.script
 from tvm.script import tir as T, relax as R
 
-# TODO (sunggg):
-# Currently, parser sets each function name as the global symbol by default.
-# And printer uses the global symbol to print out the function name.
-# This is temproray and will improve in the future.
-
 
 def check_if_func_exists(mod, func_name):
     gvs = [str(gv) for gv in mod.get_global_vars()]
@@ -61,16 +56,6 @@ def test_unused_relax_func():
 
     mod = InputModule
     assert mod
-    # RemoveUnusedFunction pass won't remove the function with global symbol for the external reference.
-    new_mod = relax.transform.RemoveUnusedFunctions()(mod)
-    assert check_if_func_exists(new_mod, "main")
-    assert check_if_func_exists(new_mod, "tir_add")
-    assert check_if_func_exists(new_mod, "unused_func")
-
-    # Remove global symbol from the function.
-    mod["unused_func"] = mod["unused_func"].without_attr("global_symbol")
-
-    # Then, this removes the unused function without any global symbol.
     new_mod = relax.transform.RemoveUnusedFunctions()(mod)
     assert check_if_func_exists(new_mod, "main")
     assert check_if_func_exists(new_mod, "tir_add")
@@ -106,17 +91,7 @@ def test_unused_relax_func_custom_entry_func():
     mod = InputModule
     assert mod
 
-    # RemoveUnusedFunction pass won't remove the function with global symbol for the external reference.
     # Test entry function other than "main".
-    new_mod = relax.transform.RemoveUnusedFunctions(entry_functions=["foo"])(mod)
-    assert check_if_func_exists(new_mod, "foo")
-    assert check_if_func_exists(new_mod, "tir_add")
-    assert check_if_func_exists(new_mod, "unused_func")
-
-    # Remove global symbol from the function.
-    mod["unused_func"] = mod["unused_func"].without_attr("global_symbol")
-
-    # Then, this removes the unused function without any global symbol.
     new_mod = relax.transform.RemoveUnusedFunctions(entry_functions=["foo"])(mod)
     assert check_if_func_exists(new_mod, "foo")
     assert check_if_func_exists(new_mod, "tir_add")
@@ -152,16 +127,6 @@ def test_unused_relax_func_symbolic_shape():
     mod = InputModule
     assert mod
 
-    # RemoveUnusedFunction pass won't remove the function with global symbol for the external reference.
-    new_mod = relax.transform.RemoveUnusedFunctions()(mod)
-    assert check_if_func_exists(new_mod, "main")
-    assert check_if_func_exists(new_mod, "tir_add")
-    assert check_if_func_exists(new_mod, "unused_func")
-
-    # Remove global symbol from the unused function
-    mod["unused_func"] = mod["unused_func"].without_attr("global_symbol")
-    # Remove unused function before shape lowering.
-    # Test entry function other than "main".
     new_mod = relax.transform.RemoveUnusedFunctions()(mod)
     assert check_if_func_exists(new_mod, "main")
     assert check_if_func_exists(new_mod, "tir_add")
@@ -207,19 +172,11 @@ def test_unused_prim_func():
 
     mod = InputModule
     assert mod
-    # RemoveUnusedFunction pass won't remove the function with global symbol for the external reference.
     new_mod = relax.transform.RemoveUnusedFunctions()(mod)
     assert check_if_func_exists(new_mod, "main")
     assert check_if_func_exists(new_mod, "relax_add")
+    # RemoveUnusedFunction pass won't remove the function with global symbol for the external linkage.
     assert check_if_func_exists(new_mod, "unused_func")
-
-    # Remove global symbol from the unused function
-    mod["unused_func"] = mod["unused_func"].without_attr("global_symbol")
-
-    new_mod = relax.transform.RemoveUnusedFunctions()(mod)
-    assert check_if_func_exists(new_mod, "main")
-    assert check_if_func_exists(new_mod, "relax_add")
-    assert not check_if_func_exists(new_mod, "unused_func")
 
 
 def test_multiple_unused_funcs():
@@ -254,16 +211,8 @@ def test_multiple_unused_funcs():
 
     new_mod = relax.transform.RemoveUnusedFunctions()(mod)
     assert check_if_func_exists(new_mod, "main")
+    # RemoveUnusedFunction pass won't remove the function with global symbol for the external linkage.
     assert check_if_func_exists(new_mod, "unused_func1")
-    assert check_if_func_exists(new_mod, "unused_func2")
-
-    # Remove global symbol from unused functions
-    mod["unused_func1"] = mod["unused_func1"].without_attr("global_symbol")
-    mod["unused_func2"] = mod["unused_func2"].without_attr("global_symbol")
-
-    new_mod = relax.transform.RemoveUnusedFunctions()(mod)
-    assert check_if_func_exists(new_mod, "main")
-    assert not check_if_func_exists(new_mod, "unused_func1")
     assert not check_if_func_exists(new_mod, "unused_func2")
 
 

--- a/tests/python/relax/test_tvmscript_ir_builder.py
+++ b/tests/python/relax/test_tvmscript_ir_builder.py
@@ -53,7 +53,6 @@ def test_function_simple():
 
     tvm.ir.assert_structural_equal(func, mod["foo"])
     # check names
-    assert func.attrs["global_symbol"] == "foo"
     assert func.params[0].name_hint == "x"
     assert func.body.body.name_hint == "out"
 

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -75,7 +75,7 @@ def test_simple_module():
             x: T.Buffer((T.int64(128), T.int64(128)), "float32"),
             y: T.Buffer((T.int64(128), T.int64(128)), "float32"),
         ):
-            T.func_attr({"global_symbol": "tir_func", "tir.noalias": True})
+            T.func_attr({"tir.noalias": True})
             for i, j in T.grid(T.int64(128), T.int64(128)):
                 with T.block():
                     vi, vj = T.axis.remap("SS", [i, j])


### PR DESCRIPTION
As discussed in #236, the idea is keep as many private functions as possible, so that the compiler can optimize the private functions away if they are not needed.

There are a few invariance in terms of linkage:
- Every function that comes with `global_symbol` is an external linkage;
- By default (during emit_te and parsing) we do not generate functions with global_symbol;
- We have a pass assign `global_symbol` near the end of codegen, when we need to specify the names of the generated external packed_func.

This PR:
- Removes global symbol attachment in internal passes(e.g. fusion, and emit_te, and parsing);
- Use GlobalVar->name_hint instead of global symbol in passes such as MetaSchedule tuning;
- Introduces the global symbol assignment pass (AttachGlobalSymbol) and apply it near at the end of `relax.vm.build`.

Items can be done in followup PRs:
- Add syntax sugar to TVMScript to highlight external or private functions:`R.function(private=True)`
- Introduce a helper merge function to merge two IRModules together and resolve global_symbol name conflicts.

cc @jinhongyii @MasterJH5574 @tqchen 