### PR TITLE
[ARCH][REFACTOR] Refactor BlockBuilder with functionality categorizations

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -202,7 +202,7 @@ class BlockBuilderNode : public Object {
    * \param expr The input expression.
    * \return The normalized expression.
    *
-   * \note Invariance: If any of the sub expr have a shape field,
+   * \note Invariant: If any of the sub expr have a shape field,
    *       they are required to already be in the normal form.
    *       This is because we cannot normalize shape in argument values.
    */

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -24,67 +24,134 @@
 #ifndef TVM_RELAX_BLOCK_BUILDER_H_
 #define TVM_RELAX_BLOCK_BUILDER_H_
 
-#include <tvm/ir/expr.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/utils.h>
-#include <tvm/relay/expr.h>
 #include <tvm/runtime/object.h>
-#include <tvm/runtime/registry.h>
-#include <tvm/support/with.h>
-
-#include <memory>
-#include <stack>
-#include <string>
-#include <unordered_map>
 
 namespace tvm {
 namespace relax {
 
-class BlockBuilder;
-
 /*!
- * \brief A builder that provides APIs to build Relax binding blocks.
+ * \brief A builder to build Relax binding blocks.
+ *
+ * BlockBuilder provides the following three categories
+ * of main functionalities for IR building and transformations:
+ *
+ * - Global context management: manages the IRModule,
+ *   allowing query, update the surrounding global context.
+ *   Provide context tools for analysis.
+ * - Scope management:
+ *   - Manages block scopes for bulding nested blocks.
+ *   - Emit bindings to the current scope.
+ *   - Construct blocks by calling EndScope.
+ * - Normalization: Take an Expr, normalize it
+ *   to deduce shape/type, turn things into normal forms.
+ *
+ * Importantly, these three categories of features can be dependent
+ * on each other. For example, when we emit into scope we will call
+ * normalize to ensure the code is in normal form. Similarly, when we
+ * normalize we could choose to emit into the current context.
+ *
+ * We would encourage the developers to keep these three category
+ * in mind when using and developing BlockBuilder, we can group
+ * the code in a logically clean way.
+ *
+ * BlockBuilderNode is implemented as a virtual interface to
+ * allow logically grouped implementation and internal data
+ * structures that are hidden from the users.
  */
 class BlockBuilderNode : public Object {
  public:
-  BlockBuilderNode();
+  //-------------------------------
+  // Global Context management
+  //-------------------------------
+  /*!
+   * \brief Get the name table for generating unique names.
+   *
+   * \return The name table.
+   */
+  virtual NameTable* name_table() = 0;
 
-  ~BlockBuilderNode();
+  /*!
+   * \brief Check if two shape expressions can be proven equal at compile time.
+   * \param lhs The input lhs shape.
+   * \param rhs The input rhs shape.
+   * \return Whether we can prove lhs shape is the same as the rhs shape.
+   */
+  virtual bool CanProveShapeEqual(const Expr& lhs, const Expr& rhs) = 0;
+
+  /*!
+   * \brief Get the context IRModule in this builder.
+   *
+   * \note The context
+   * \return The IRModule in this BlockBuilder.
+   */
+  virtual IRModule GetContextIRModule() const = 0;
+
+  /*!
+   * \brief Add a Relax function or a TIR PrimFunc to internal context module.
+   * \param func The function to be added.
+   * \param func_name_hint The name hint of the function to be added.
+   * \note If the function to be added already exists, return its
+   * GlobalVar directly.
+   * \return The global var bound to the added function.
+   */
+  virtual GlobalVar AddFunction(const BaseFunc& func, String func_name_hint) = 0;
+
+  /*!
+   * \brief Update a Relax function or a TIR PrimFunc in the internal context module.
+   * \param gv The global var referring the function to be updated.
+   * \param function The updated function.
+   */
+  virtual void UpdateFunction(const GlobalVar& gv, BaseFunc function) = 0;
+
+  //-------------------------------
+  // Scope management
+  //-------------------------------
+  /*!
+   * \brief Lookup the binding value that var binds to in the current emitted sequences.
+   * \param var The input var.
+   * \return The Expr bound to the input \p var.
+   * \note For function parameters, this function returns NullOpt.
+   */
+  virtual Optional<Expr> LookupBinding(const Var& var) = 0;
 
   /*! \brief Begin to build a DataflowBlock. */
-  void BeginDataflowBlock();
+  virtual void BeginDataflowBlock() = 0;
 
   /*! \brief Begin to build a BindingBlock. */
-  void BeginBindingBlock();
-
+  virtual void BeginBindingBlock() = 0;
   /*!
    * \brief End building a BindingBlock.
    * \return The BindingBlock being built.
    */
-  BindingBlock EndBlock();
+  virtual BindingBlock EndBlock() = 0;
 
   /*!
    * \brief Check if the block being built is DataflowBlock or not.
    * \return A boolean that indicates if the block being built is DataflowBlock or not.
    */
-  inline bool CurrentBlockIsDataFlow() { return CurrentFrame()->is_dataflow; }
+  virtual bool CurrentBlockIsDataFlow() = 0;
 
   /*!
    * \brief Emits an Expr, and returns the variable it is bound to.
    * \param expr The Expr to be emitted.
    * \param name_hint Name hint for the bound variable.
-   * \note This Emit function normalizes the \p expr, and performs shape and type deductions by
-   * calling Normalize.
    * \return The new variable that \p expr is bound to.
+   *
+   * \note This Emit function normalizes the \p expr, and
+   *       performs shape and type deductions by calling Normalize.
    */
-  virtual Var Emit(const Expr& expr, std::string name_hint = "");
+  virtual Var Emit(Expr expr, String name_hint = "") = 0;
 
   /*!
    * \brief Emits a variable binding, and returns the bound Var.
    * \param binding The variable binding.
    * \return The bound variable.
+   *
+   * \note This function requires binding to be pre-normalized.
    */
-  virtual Var Emit(const VarBinding& binding);
+  virtual Var Emit(VarBinding binding) = 0;
 
   /*!
    * \brief Emit a MatchShape.
@@ -93,14 +160,16 @@ class BlockBuilderNode : public Object {
    * \param name_hint Name hint for the bound variable.
    * \return The variable bound to the MatchShape.
    */
-  Var EmitMatchShape(const Expr& value, const Array<PrimExpr>& pattern, std::string name_hint = "");
+  virtual Var EmitMatchShape(Expr value, Array<PrimExpr> pattern, String name_hint = "") = 0;
 
   /*!
    * \brief Emit a MatchShape binding.
    * \param binding The MatchShape binding to be emitted.
    * \return The variable bound to the MatchShape.
+   *
+   * \note This function requires binding to be pre-normalized.
    */
-  Var EmitMatchShape(const MatchShape& binding);
+  virtual Var EmitMatchShape(MatchShape binding) = 0;
 
   /*!
    * \brief Generate an output for the current dataflow block.
@@ -108,155 +177,55 @@ class BlockBuilderNode : public Object {
    * \param name_hint Name hint for the bound variable.
    * \return The variable bound to \p output.
    */
-  Var EmitOutput(const Expr& output, std::string name_hint = "");
+  virtual Var EmitOutput(Expr output, String name_hint = "") = 0;
 
   /*!
    * \brief Generate an output for the current dataflow block.
    * \param binding The output binding to output.
    * \return The variable bound to \p output.
+   *
+   * \note This function requires binding to be pre-normalized.
    */
-  Var EmitOutput(const VarBinding& binding);
+  virtual Var EmitOutput(VarBinding binding) = 0;
 
   /*!
-   * \brief Lookup a var in the binding table \p binding_table_.
-   * \param var The input var.
-   * \return The Expr bound to the input \p var.
-   * \note For function parameters, this function returns NullOpt.
+   * \brief Emit a binding that is already normalized.
+   *
+   * \param binding A binding whose value is already normalized.
+   *
+   * \note This function requires binding to be pre-normalized.
    */
-  Optional<Expr> LookupBinding(const Var& var);
+  virtual void EmitNormalized(Binding normalized_binding) = 0;
 
   /*!
-   * \brief Check if two shape expressions can be proven equal at compile time.
-   * \param lhs The input lhs shape.
-   * \param rhs The input rhs shape.
-   * \return Whether we can prove lhs shape is the same as the rhs shape.
-   */
-  bool CanProveShapeEqual(const Expr& lhs, const Expr& rhs);
-
-  /*!
-   * \brief Resets the memo in the normalizer to prevent false hits when visiting
-   *   the same expression more than once.
-   *   Use if before visiting a given expression again.
-   */
-  // TODO(@relax-team): Memoization should be tied to the scope tracking to prevent memo hits
-  // when the associated var is out of scope
-  void ResetMemo();
-
-  /*!
-   * \brief Convert an expression to A-normal form, and try to eagerly infer types and shapes.
+   * \brief Convert an expression to normal form, and try to eagerly infer types and shapes.
    * \param expr The input expression.
    * \return The normalized expression.
-   */
-  Expr Normalize(const Expr& expr);
-
-  /*!
-   * \brief Get the name table for generating unique names.
    *
-   * \return The name table.
+   * \note Invariance: If any of the sub expr have a shape field,
+   *       they are required to already be in the normal form.
+   *       This is because we cannot normalize shape in argument values.
    */
-  NameTable* name_table();
-
-  /*!
-   * \brief Add a Relax function or a TIR PrimFunc to \p context_mod_.
-   * \param func The function to be added.
-   * \param func_name_hint The name hint of the function to be added.
-   * \note If the function to be added already exists in \p context_mod_, return its
-   * GlobalVar directly.
-   * \return The global var bound to the added function.
-   */
-  GlobalVar AddFunction(const BaseFunc& func, const String& func_name_hint);
-
-  /*!
-   * \brief Update a Relax function or a TIR PrimFunc in \p context_mod_.
-   * \param gv The global var referring the function to be updated.
-   * \param function The updated function.
-   */
-  void UpdateFunction(const GlobalVar& gv, BaseFunc function);
-
-  /*!
-   * \brief Get the context IRModule being built.
-   * \return The IRModule being built by BlockBuilder.
-   */
-  IRModule GetContextIRModule() const;
-
-  void VisitAttrs(AttrVisitor* v) {}
+  virtual Expr Normalize(const Expr& expr) = 0;
 
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
   static constexpr const char* _type_key = "relax.BlockBuilder";
   TVM_DECLARE_BASE_OBJECT_INFO(BlockBuilderNode, Object);
-
- private:
-  /*!
-   * \brief Emits an Expr, and returns the variable it is bound to.
-   * \param expr The Expr to be emitted.
-   * \param is_dataflow Is the bound variable a DataflowVar or not(i.e. Var).
-   * \param name_hint Name hint for the bound variable.
-   * \note This Emit function normalizes the \p expr, and performs shape and type deductions by
-   * calling Normalize.
-   * \return The new variable that \p expr is bound to.
-   */
-  Var Emit(const Expr& expr, bool is_dataflow, std::string name_hint);
-
-  /*! \brief The IRModule being built by the BlockBuilder. */
-  IRModule context_mod_;
-
-  /*!
-   * \brief A hashmap to store the mapping of Relax functions and TIR PrimFuncs
-   * in \p _context_mod to their GlobalVar to avoid generating duplicated functions.
-   */
-  std::unordered_map<BaseFunc, GlobalVar, StructuralHash, StructuralEqual> func_map_;
-
- protected:
-  /*!
-   * \brief A representation of a block frame.
-   *
-   * A block frame is a record containing the bindings needed
-   * to build a binding block, and a boolean to indicate if the
-   * block being built is a DataflowBlock or not.
-   */
-  struct BlockFrame {
-    Array<Binding> bindings;
-    bool is_dataflow;
-  };
-
-  /*!
-   * \brief Utility class for performing IR normalization (conversion to ANF, eager forward shape
-   * and type inference).
-   */
-  class ExprNormalizer;
-
-  friend class BlockBuilder;
-
-  /*!
-   * \brief Get the current block frame.
-   * \return The current block frame.
-   */
-  BlockFrame* CurrentFrame();
-
-  /*! \brief A stack to store block frames. */
-  std::stack<BlockFrame> block_stack_;
-
-  /*! \brief A diagnostic context for reporting errors. */
-  DiagnosticContext diag_ctx_ = DiagnosticContext::Default(IRModule({}, {}));
-
-  /*! \brief A binding table that maps var to value. */
-  std::unordered_map<Id, Expr, ObjectPtrHash, ObjectPtrEqual> binding_table_;
-
-  /*! \brief A name table to get unique names for IR construction. */
-  std::unique_ptr<NameTable> name_table_;
-
-  /*! \brief The internal normalizer used for ANF conversion. */
-  std::unique_ptr<ExprNormalizer> normalizer_;
 };
 
 class BlockBuilder : public ObjectRef {
  public:
   /*!
    * \brief Create a BlockBuilder.
-   * \param mod Optional before-transformation IRModule for rewriting.
+   *
+   * \param ctx_mod Optional before-transformation context module for rewriting.
    * \return The created BlockBuilder.
+   *
+   * \note When rewriting an existing IRModule, it is important to pass it in as
+   *       ctx_mod so you can lookup the context functions for cross function
+   *       call analysis.
    */
-  TVM_DLL static BlockBuilder Create(Optional<IRModule> mod);
+  TVM_DLL static BlockBuilder Create(Optional<IRModule> ctx_mod);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(BlockBuilder, ObjectRef, BlockBuilderNode);
 };

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -138,6 +138,8 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     return vtable(n, this, std::forward<Args>(args)...);
   }
   // Functions that can be overriden by subclass
+  // NOTE: cross dialect calls are invoked through global var
+  // We do not expect inline PrimFunc to appear in relax IR.
   virtual R VisitExpr_(const ConstantNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const TupleNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const VarNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -152,7 +152,6 @@ class ExprFunctor<R(const Expr& n, Args...)> {
   virtual R VisitExpr_(const IfNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const OpNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const TupleGetItemNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
-  virtual R VisitExpr_(const tir::PrimFuncNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExprDefault_(const Object* op, Args...) {
     LOG(FATAL) << "Do not have a default for " << op->GetTypeKey();
     throw;
@@ -161,8 +160,6 @@ class ExprFunctor<R(const Expr& n, Args...)> {
  private:
   // initialize the vtable.
   static FType InitVTable() {
-    using tir::PrimFuncNode;
-
     FType vtable;
     // Set dispatch
     RELAX_EXPR_FUNCTOR_DISPATCH(ConstantNode);
@@ -179,7 +176,6 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     RELAX_EXPR_FUNCTOR_DISPATCH(IfNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(OpNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(TupleGetItemNode);
-    RELAX_EXPR_FUNCTOR_DISPATCH(PrimFuncNode);
     return vtable;
   }
 };

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -33,6 +33,7 @@
 #include <tvm/relay/expr.h>
 #include <tvm/relay/function.h>
 #include <tvm/relay/op.h>
+#include <tvm/tir/function.h>
 
 #include <deque>
 #include <string>
@@ -151,6 +152,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
   virtual R VisitExpr_(const IfNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const OpNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const TupleGetItemNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
+  virtual R VisitExpr_(const tir::PrimFuncNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExprDefault_(const Object* op, Args...) {
     LOG(FATAL) << "Do not have a default for " << op->GetTypeKey();
     throw;
@@ -159,6 +161,8 @@ class ExprFunctor<R(const Expr& n, Args...)> {
  private:
   // initialize the vtable.
   static FType InitVTable() {
+    using tir::PrimFuncNode;
+
     FType vtable;
     // Set dispatch
     RELAX_EXPR_FUNCTOR_DISPATCH(ConstantNode);
@@ -175,6 +179,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     RELAX_EXPR_FUNCTOR_DISPATCH(IfNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(OpNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(TupleGetItemNode);
+    RELAX_EXPR_FUNCTOR_DISPATCH(PrimFuncNode);
     return vtable;
   }
 };
@@ -369,8 +374,6 @@ class ExprMutator : public ExprMutatorBase {
   virtual Var VisitVarDef_(const DataflowVarNode* var);
 
  protected:
-  class ExprNormalizer;
-
   /*!
    * \brief Try to remit binding and bind it to a new_value
    *

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -20,7 +20,6 @@
 /*!
  * \file src/relax/block_builder.cc
  */
-
 #include <tvm/arith/analyzer.h>
 #include <tvm/relax/block_builder.h>
 #include <tvm/relax/expr_functor.h>
@@ -29,82 +28,489 @@
 #include <tvm/relax/type_analysis.h>
 #include <tvm/relax/utils.h>
 #include <tvm/relay/op.h>
+#include <tvm/runtime/registry.h>
 #include <tvm/tir/function.h>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+// Block builder have three categories of logics that are interdependent with each other.
+//
+// The logics are somewhat interdependent with each other.
+// To help us implement a block builder in two parts:
+//
+// - BlockBuilderImpl: implements ctx and scope management, with no normalization.
+// - BlockBuilderImplWithNormalize: subclasses BlockBuilderImpl and implements normalization.
+//
+// The final blockbuilder create will be backed by BlockBuilderWithNormalize
 
 namespace tvm {
 namespace relax {
 
-// ================================
-// BlockBuilderNode::ExprNormalizer
-// Invariance:
-// After Normalize: an Expr always have checked_type (with the exception of Op).
-class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
+//---------------------------------------
+// ctx and scope management.
+//---------------------------------------
+class BlockBuilderImpl : public BlockBuilderNode {
  public:
-  ExprNormalizer(BlockBuilderNode* builder) : builder_(builder) {}
+  explicit BlockBuilderImpl(IRModule context_mod) : context_mod_(std::move(context_mod)) {}
 
+  ~BlockBuilderImpl() {
+    if (!block_stack_.empty()) {
+      LOG(WARNING) << "BlockBuilder destroyed with remaining blocks!";
+    }
+  }
+
+  //-------------------------------
+  // Global Context management
+  //-------------------------------
+  NameTable* name_table() final { return name_table_.get(); }
+
+  bool CanProveShapeEqual(const Expr& lhs, const Expr& rhs) final {
+    if (lhs.same_as(rhs)) {
+      return true;
+    }
+
+    // TODO(relax-team): revisit this logic after struct info.
+    if (lhs->IsInstance<RuntimeDepShapeNode>() && rhs->IsInstance<RuntimeDepShapeNode>()) {
+      return true;
+    }
+
+    // try run symbolic shape proves that two shape equals each other.
+    if (lhs->IsInstance<ShapeExprNode>() && rhs->IsInstance<ShapeExprNode>()) {
+      const auto* lhs_shape = lhs.as<ShapeExprNode>();
+      const auto* rhs_shape = rhs.as<ShapeExprNode>();
+      size_t lhs_ndim = lhs_shape->values.size();
+      size_t rhs_ndim = rhs_shape->values.size();
+      if (lhs_ndim != rhs_ndim) {
+        return false;
+      }
+      for (size_t i = 0; i < lhs_ndim; ++i) {
+        PrimExpr lhs_dim = lhs_shape->values[i];
+        PrimExpr rhs_dim = rhs_shape->values[i];
+        if (lhs_dim.dtype() != rhs_dim.dtype() || !analyzer_.CanProveEqual(lhs_dim, rhs_dim)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    // tuple comparison
+    // TODO(relax-team): can be removed later after struct info.
+    if (lhs->IsInstance<TupleNode>() && rhs->IsInstance<TupleNode>()) {
+      const auto* lhs_tuple = lhs.as<TupleNode>();
+      const auto* rhs_tuple = rhs.as<TupleNode>();
+      if (lhs_tuple->fields.size() != rhs_tuple->fields.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < lhs_tuple->fields.size(); ++i) {
+        if (!CanProveShapeEqual(lhs_tuple->fields[i], rhs_tuple->fields[i])) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  IRModule GetContextIRModule() const final { return context_mod_; }
+
+  GlobalVar AddFunction(const BaseFunc& func, String func_name_hint) final {
+    LazyInitCtxFuncDedupMap();
+    auto it = ctx_func_dedup_map_->find(func);
+    if (it == ctx_func_dedup_map_->end()) {
+      context_mod_.CopyOnWrite();
+
+      String func_name = name_table_->GetUniqueName(func_name_hint);
+      while (context_mod_->ContainGlobalVar(func_name)) {
+        func_name = name_table_->GetUniqueName(func_name_hint);
+      }
+      GlobalVar gvar = GlobalVar(func_name);
+
+      ICHECK(func->checked_type_.defined())
+          << "The function to be added does not have checked_type_.";
+      gvar->checked_type_ = func->checked_type_;
+      context_mod_->Add(gvar, func);
+
+      ctx_func_dedup_map_->emplace(func, gvar);
+      return gvar;
+    } else {
+      return it->second;
+    }
+  }
+
+  void UpdateFunction(const GlobalVar& gv, BaseFunc function) final {
+    context_mod_.CopyOnWrite();
+
+    // invalidate old dedup map
+    if (ctx_func_dedup_map_ != nullptr) {
+      auto it = context_mod_->functions.find(gv);
+      if (it != context_mod_->functions.end()) {
+        BaseFunc old_func = (*it).second;
+        auto ptr = ctx_func_dedup_map_->find(old_func);
+        ICHECK(ptr != ctx_func_dedup_map_->end());
+        ctx_func_dedup_map_->erase(ptr);
+      }
+    }
+
+    context_mod_->Update(gv, function);
+
+    // add new dedup map item.
+    if (ctx_func_dedup_map_ != nullptr) {
+      ctx_func_dedup_map_->emplace(function, gv);
+    }
+  }
+
+  //-------------------------------
+  // Scope management
+  //-------------------------------
+  Optional<Expr> LookupBinding(const Var& var) final {
+    auto it = binding_table_.find(var->vid);
+    if (it == binding_table_.end()) return NullOpt;
+    return it->second;
+  }
+
+  void BeginDataflowBlock() final { block_stack_.emplace_back(BlockFrame{{}, true}); }
+
+  void BeginBindingBlock() final { block_stack_.emplace_back(BlockFrame{{}, false}); }
+
+  BindingBlock EndBlock() final {
+    BlockFrame* cur_frame = CurrentFrame();
+    BindingBlock ret = cur_frame->is_dataflow ? DataflowBlock(cur_frame->bindings)
+                                              : BindingBlock(cur_frame->bindings);
+    block_stack_.pop_back();
+    return ret;
+  }
+
+  bool CurrentBlockIsDataFlow() final { return CurrentFrame()->is_dataflow; }
+
+  Var Emit(Expr expr, String name_hint) final {
+    return this->Emit(expr, CurrentFrame()->is_dataflow, name_hint);
+  }
+
+  Var Emit(VarBinding binding) final {
+    BlockFrame* cur_frame = CurrentFrame();
+    if (cur_frame->is_dataflow) {
+      ICHECK(binding->var.as<DataflowVarNode>())
+          << "Emit can only be used for local bindings in a dataflow block, use EmitOutput for "
+             "output bindings instead";
+    }
+    cur_frame->bindings.push_back(binding);
+    binding_table_[binding->var->vid] = binding->value;
+    return binding->var;
+  }
+
+  Var EmitMatchShape(Expr value, Array<PrimExpr> pattern, String name_hint) final {
+    value = this->Normalize(value);
+
+    BlockFrame* cur_frame = CurrentFrame();
+    Var var = CreateVar(cur_frame->is_dataflow, name_hint);
+
+    if (value->checked_type().as<ShapeTypeNode>()) {
+      UpdateType(var, ShapeType());
+    } else if (const DynTensorTypeNode* tty = value->checked_type().as<DynTensorTypeNode>()) {
+      ShapeExpr shape = ShapeExpr(pattern);
+      UpdateShape(var, shape);
+      DataType dtype = tty->dtype;
+      UpdateType(var, DynTensorType(pattern.size(), dtype));
+    } else {
+      this->diag_ctx_.EmitFatal(
+          Diagnostic::Error(value->span)
+          << "The value passed to EmitMatchShape must be of DynTensorType or ShapeType.");
+    }
+
+    MatchShape match_shape = MatchShape(value, pattern, var);
+    cur_frame->bindings.push_back(match_shape);
+    // NOTE match shape do not follow simple binding rule
+    // as a result should not appear in binding table.
+    return var;
+  }
+
+  Var EmitMatchShape(MatchShape binding) final {
+    BlockFrame* cur_frame = CurrentFrame();
+    // NOTE match shape do not follow simple binding rule
+    // as a result should not appear in binding table.
+    cur_frame->bindings.push_back(binding);
+    return binding->var;
+  }
+
+  Var EmitOutput(Expr output, String name_hint) final {
+    BlockFrame* cur_frame = CurrentFrame();
+
+    ICHECK(cur_frame->is_dataflow) << "EmitOutput has to be called inside dataflow block.";
+
+    return Emit(output, false, name_hint);
+  }
+
+  Var EmitOutput(VarBinding binding) final {
+    BlockFrame* cur_frame = CurrentFrame();
+
+    ICHECK(cur_frame->is_dataflow) << "EmitOutput has to be called inside dataflow block.";
+    ICHECK(!binding->var.as<DataflowVarNode>()) << "EmitOutput can only emit Var bindings.";
+
+    cur_frame->bindings.push_back(binding);
+    binding_table_[binding->var->vid] = binding->value;
+    return binding->var;
+  }
+
+  void EmitNormalized(Binding binding) final {
+    BlockFrame* cur_frame = CurrentFrame();
+
+    if (auto* var_binding = binding.as<VarBindingNode>()) {
+      if (!cur_frame->is_dataflow) {
+        ICHECK(!var_binding->var.as<DataflowVarNode>())
+            << "Cannot emit dataflowvar in non-dataflow block";
+      }
+      cur_frame->bindings.push_back(binding);
+      binding_table_[var_binding->var->vid] = var_binding->value;
+    } else {
+      auto* ptr = binding.as<MatchShapeNode>();
+      ICHECK(ptr);
+      if (!cur_frame->is_dataflow) {
+        ICHECK(!ptr->var.as<DataflowVarNode>()) << "Cannot emit dataflowvar in non-dataflow block";
+      }
+      // NOTE match shape do not follow simple binding rule
+      // as a result should not appear in binding table.
+      cur_frame->bindings.push_back(binding);
+    }
+  }
+
+ protected:
+  /*!
+   * \brief A representation of a block frame.
+   *
+   * A block frame is a record containing the bindings needed
+   * to build a binding block, and a boolean to indicate if the
+   * block being built is a DataflowBlock or not.
+   */
+  struct BlockFrame {
+    /*!
+     * \brief List of bindings
+     */
+    Array<Binding> bindings;
+    /*! \brief Whether current block is dataflow block. */
+    bool is_dataflow;
+    /*!
+     * \brief Binding map used by normalizer.
+     *
+     * \note The normalizer only caches resue in the current scope
+     *       and will not cache bindings from parent scope.
+     */
+    std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> normalize_binding_map;
+  };
+
+  /*! \brief A stack to store block frames. */
+  std::vector<BlockFrame> block_stack_;
+
+  /*! \brief A diagnostic context for reporting errors. */
+  DiagnosticContext diag_ctx_ = DiagnosticContext::Default(IRModule({}, {}));
+
+  /*! \brief A binding table that maps var to value. */
+  std::unordered_map<Id, Expr, ObjectPtrHash, ObjectPtrEqual> binding_table_;
+
+  /*! \brief A name table to get unique names for IR construction. */
+  std::unique_ptr<NameTable> name_table_ = std::make_unique<NameTable>();
+
+  /*! \brief The IRModule being built by the BlockBuilder. */
+  IRModule context_mod_;
+
+  /*! \brief Internal analzyer */
+  arith::Analyzer analyzer_;
+
+  /*!
+   * \return The current frame.
+   * \note Never hold the value of current frame between Normalize
+   *       or other scope calls this value can change if the block stack get updated,
+   *       then the block frame is no longer valid.
+   */
+  BlockFrame* CurrentFrame() {
+    ICHECK(!block_stack_.empty()) << "no block is being built";
+    return &block_stack_.back();
+  }
+
+  /*!
+   * \brief Emits an Expr, and returns the variable it is bound to.
+   * \param expr The Expr to be emitted.
+   * \param is_dataflow Is the bound variable a DataflowVar or not(i.e. Var).
+   * \param name_hint Name hint for the bound variable.
+   * \note This Emit function normalizes the \p expr,
+   *       and performs shape/type deductions by calling Normalize.
+   * \return The new variable that \p expr is bound to.
+   */
+  Var Emit(Expr expr, bool is_dataflow, String name_hint) {
+    expr = this->Normalize(expr);
+
+    Var var = CreateVar(is_dataflow, name_hint);
+
+    // set the values
+    UpdateType(var, expr->checked_type_);
+    UpdateShape(var, expr->shape_);
+
+    CurrentFrame()->bindings.push_back(VarBinding(var, expr));
+
+    // update the binding table
+    binding_table_[var->vid] = expr;
+
+    return var;
+  }
+
+  /*!
+   * \brief Create var for bindings
+   * \param is_dataflow Is the bound variable a DataflowVar or not(i.e. Var).
+   * \param name_hint Name hint for the bound variable.
+   * \return The created var.
+   */
+  Var CreateVar(bool is_dataflow, String name_hint) {
+    if (name_hint.empty()) {
+      name_hint = is_dataflow ? "lv" : "gv";
+    }
+    Id vid = Id(name_table_->GetUniqueName(name_hint));
+    return is_dataflow ? DataflowVar(vid, NullOpt, NullOpt) : Var(vid, NullOpt, NullOpt);
+  }
+
+ private:
+  /*!
+   * \brief A hashmap to store the mapping of Relax functions and TIR PrimFuncs
+   * in context_mod to their GlobalVar to avoid generating duplicated functions.
+   */
+  std::unique_ptr<std::unordered_map<BaseFunc, GlobalVar, StructuralHash, StructuralEqual>>
+      ctx_func_dedup_map_ = nullptr;
+
+  /*!
+   * \brief lazily initialize function dedeup map.
+   */
+  void LazyInitCtxFuncDedupMap() {
+    if (ctx_func_dedup_map_ != nullptr) return;
+    ctx_func_dedup_map_ = std::make_unique<
+        std::unordered_map<BaseFunc, GlobalVar, StructuralHash, StructuralEqual>>();
+    for (const auto& kv : context_mod_->functions) {
+      const GlobalVar gv = kv.first;
+      const BaseFunc func = kv.second;
+      ctx_func_dedup_map_->emplace(func, gv);
+    }
+  }
+};
+
+//---------------------------------------
+// Normalization
+//---------------------------------------
 #define RELAX_EXPR_NORMALIZER_LEAF(OP) \
   Expr VisitExpr_(const OP* op) final { return GetRef<Expr>(op); }
+
+// Invariance: If an Expr have a shape_ field, it must have already been normalized.
+class BlockBuilderImplWithNormalize : public BlockBuilderImpl,
+                                      private ExprFunctor<Expr(const Expr&)> {
+ public:
+  explicit BlockBuilderImplWithNormalize(IRModule context_mod) : BlockBuilderImpl(context_mod) {}
+
+  Expr Normalize(const Expr& expr) final {
+    Expr normalized = this->VisitExpr(expr);
+    // Invariance:
+    // After Normalize: an Expr always have checked_type (with the exception of Op).
+    if (!normalized->IsInstance<OpNode>()) {
+      ICHECK(normalized->checked_type_.defined())
+          << "The checked_type_ of an Expr except OpNode after "
+             "normalization must not be nullptr. However, this Expr does not have checked_type_: "
+          << normalized;
+    }
+
+    return normalized;
+  }
+
+  /*!
+   * \brief Normalize Argument values to call and other IR sub-fields.
+   * \param arg The argument.
+   * \return The normalized value.
+   *
+   * \note This function create a new binding for non-leaf expressions except for tuple.
+   */
+  Expr NormalizeArgument(Expr arg) {
+    if (!block_stack_.empty()) {
+      // cache lookup
+      BlockFrame* cur_frame = CurrentFrame();
+      auto it = cur_frame->normalize_binding_map.find(arg);
+      if (it != cur_frame->normalize_binding_map.end()) {
+        return it->second;
+      }
+    }
+    // skip visit expr's cache, normalize arg
+    Expr post = ExprFunctor::VisitExpr(arg);
+
+    if (!IsLeafExpr(arg)) {
+      ICHECK(!block_stack_.empty()) << "Cannot normalize non-leaf without a scope";
+      Var var = this->Emit(post, "");
+      // NOTE: current frame addr can change due to underlying vector
+      // re-allocation, redo lookup
+      CurrentFrame()->normalize_binding_map[arg] = var;
+      return var;
+    } else {
+      return post;
+    }
+  }
 
   RELAX_EXPR_NORMALIZER_LEAF(RuntimeDepShapeNode);
   RELAX_EXPR_NORMALIZER_LEAF(ExternFuncNode);
   RELAX_EXPR_NORMALIZER_LEAF(GlobalVarNode);
   RELAX_EXPR_NORMALIZER_LEAF(OpNode);
   RELAX_EXPR_NORMALIZER_LEAF(ShapeExprNode);
+  RELAX_EXPR_NORMALIZER_LEAF(tir::PrimFuncNode);
 
-  // TODO(@altanh): CopyOnWrite
-
-  Expr VisitExpr(const Expr& expr) {
-    // TODO(relax-team): generalize prim_func support
-    if (expr->IsInstance<tir::PrimFuncNode>()) {
-      return expr;
+  template <typename T>
+  Expr VisitVar_(const typename T::ContainerType* var) {
+    bool shape_unchanged = true;
+    Expr new_shape;
+    if (var->shape_) {
+      new_shape = this->VisitExpr(Downcast<Expr>(var->shape_.value()));
+      shape_unchanged &= new_shape.same_as(var->shape_);
     }
-    Optional<Expr> post = expr_memo_.Get(expr);
-    if (post) {
-      ICHECK(post.as<VarNode>()) << "memoized expressions should map to variables";
-      return post.value();
+
+    if (shape_unchanged) {
+      return GetRef<Var>(var);
+    } else {
+      Var new_var = T(var->vid, NullOpt, var->checked_type_, var->span);
+      UpdateShape(new_var, new_shape);
+      return new_var;
+    }
+  }
+
+  Expr VisitExpr_(const VarNode* var) final { return VisitVar_<Var>(var); }
+
+  Expr VisitExpr_(const DataflowVarNode* var) final { return VisitVar_<DataflowVar>(var); }
+
+  Expr VisitExpr(const Expr& expr) final {
+    // lookup normalize map
+    if (!block_stack_.empty()) {
+      BlockFrame* cur_frame = CurrentFrame();
+      auto it = cur_frame->normalize_binding_map.find(expr);
+      if (it != cur_frame->normalize_binding_map.end()) {
+        return it->second;
+      }
     }
     return ExprFunctor::VisitExpr(expr);
   }
 
-  Expr VisitExpr_(const DataflowVarNode* var) final {
-    bool shape_unchanged = true;
-    Expr new_shape;
-    if (var->shape_) {
-      new_shape = this->VisitExpr(Downcast<Expr>(var->shape_.value()));
-      shape_unchanged &= new_shape.same_as(var->shape_);
+  // Helper function to get the shape of a Tuple based on its fields
+  Optional<Expr> GetTupleShape(const Tuple& tuple) {
+    Array<Expr> tuple_shape;
+    for (Expr field : tuple->fields) {
+      if (field->shape_) {
+        tuple_shape.push_back(Downcast<Expr>(field->shape_.value()));
+      } else {
+        break;
+      }
     }
-
-    if (shape_unchanged) {
-      return GetRef<Var>(var);
-    } else {
-      Var new_var = DataflowVar(var->vid, NullOpt, var->checked_type_, var->span);
-      UpdateShape(new_var, new_shape);
-      return new_var;
+    if (tuple_shape.size() == tuple->fields.size()) {
+      return Tuple(tuple_shape);
     }
-  }
-
-  Expr VisitExpr_(const VarNode* var) final {
-    bool shape_unchanged = true;
-    Expr new_shape;
-    if (var->shape_) {
-      new_shape = this->VisitExpr(Downcast<Expr>(var->shape_.value()));
-      shape_unchanged &= new_shape.same_as(var->shape_);
-    }
-
-    if (shape_unchanged) {
-      return GetRef<Var>(var);
-    } else {
-      Var new_var = Var(var->vid, NullOpt, var->checked_type_, var->span);
-      UpdateShape(new_var, new_shape);
-      return new_var;
-    }
+    return NullOpt;
   }
 
   Expr VisitExpr_(const TupleNode* op) final {
     bool unchanged = true;
     Array<Expr> new_fields;
     for (const Expr& field : op->fields) {
-      Expr new_field = this->Bind(field);
+      Expr new_field = this->NormalizeArgument(field);
       new_fields.push_back(new_field);
       unchanged &= new_field.same_as(field);
     }
@@ -117,9 +523,6 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
 
     // Tuple's checked_type must not be null
     if (!tuple->checked_type_.defined()) {
-      if (tuple->fields.size() == 0) {
-        UpdateType(tuple, VoidType());
-      }
       Array<Type> tuple_type;
       for (Expr field : tuple->fields) {
         ICHECK(field->checked_type_.defined())
@@ -132,10 +535,11 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     // NOTE: Tuple's shape can be null
     // When a tuple consists of all DynTensorType elements or nested tuple of DynTensorTypes,
     // it has a shape.
-    if (!tuple->shape_) {
+    if (!tuple->shape_.defined()) {
       UpdateShape(tuple, GetTupleShape(tuple));
     }
 
+    // TODO(relax-team): revisit after struct info.
     // recurse into its shape in case its shape also need to be normalized
     if (tuple->shape_ && tuple->shape_.value()->IsInstance<TupleNode>()) {
       this->VisitExpr(Downcast<Expr>(tuple->shape_.value()));
@@ -152,22 +556,20 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     } else {
       func = Function(op->params, new_body, op->ret_type, op->ret_shape, op->attrs);
     }
-
     // NOTE: the shape_ of Function is left as null for now
     return func;
   }
 
   Expr VisitExpr_(const CallNode* op) final {
-    Expr new_op = this->Bind(op->op);
+    Expr new_op = this->NormalizeArgument(op->op);
     bool unchanged = new_op.same_as(op->op);
 
     Array<Expr> new_args;
-    if (!op->args.empty()) {
-      for (const Expr& arg : op->args) {
-        Expr new_arg = this->Bind(arg);
-        new_args.push_back(new_arg);
-        unchanged &= new_arg.same_as(arg);
-      }
+
+    for (Expr arg : op->args) {
+      Expr new_arg = this->NormalizeArgument(arg);
+      new_args.push_back(new_arg);
+      unchanged &= new_arg.same_as(arg);
     }
 
     Call call;
@@ -186,14 +588,13 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     // type in cases of Call for ExternFunc.
     if (!call->checked_type_.defined()) {
       // type inference
-      auto inferred_type = InferType(call, this->builder_->diag_ctx_, this->builder_->context_mod_);
+      auto inferred_type = InferType(call, this->diag_ctx_, this->context_mod_);
       UpdateType(call, inferred_type);
     }
 
     if (!call->shape_) {
       // shape inference
-      auto inferred_shape =
-          InferShape(call, this->builder_->diag_ctx_, this->builder_->context_mod_);
+      auto inferred_shape = InferShape(call, this->diag_ctx_, this->context_mod_);
       if (inferred_shape) {
         UpdateShape(call, inferred_shape.value());
       }
@@ -206,17 +607,17 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   Expr VisitExpr_(const SeqExprNode* op) final {
     bool unchanged = true;
     Array<BindingBlock> new_blocks;
-    for (const BindingBlock& block : op->blocks) {
+    for (BindingBlock block : op->blocks) {
       BindingBlock new_block = this->VisitBindingBlock(block);
       new_blocks.push_back(new_block);
       unchanged &= new_block.same_as(block);
     }
 
-    builder_->BeginBindingBlock();
+    this->BeginBindingBlock();
     // the body may not be a leaf expression, so check for that
-    Expr new_body = this->Bind(op->body);
+    Expr new_body = this->NormalizeArgument(op->body);
     unchanged &= new_body.same_as(op->body);
-    BindingBlock prologue = builder_->EndBlock();
+    BindingBlock prologue = this->EndBlock();
 
     if (!prologue->bindings.empty()) {
       new_blocks.push_back(prologue);
@@ -275,7 +676,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   }
 
   Expr VisitExpr_(const IfNode* op) final {
-    Expr new_cond = this->Bind(op->cond);
+    Expr new_cond = this->NormalizeArgument(op->cond);
     Expr new_true = this->VisitWithNewScope(op->true_branch);
     Expr new_false = this->VisitWithNewScope(op->false_branch);
 
@@ -295,8 +696,8 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
 
     if (!op->shape_.defined()) {
       if (new_true->shape_ && new_false->shape_ &&
-          builder_->CanProveShapeEqual(Downcast<Expr>(new_true->shape_.value()),
-                                       Downcast<Expr>(new_false->shape_.value()))) {
+          this->ShapeUnchanged(Downcast<Expr>(new_true->shape_.value()),
+                               Downcast<Expr>(new_false->shape_.value()))) {
         UpdateShape(if_node, new_true->shape_);
       } else {
         UpdateShape(if_node, RuntimeDepShape());
@@ -307,12 +708,10 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   }
 
   Expr VisitExpr_(const TupleGetItemNode* op) final {
-    Expr new_tuple = this->Bind(op->tuple);
-    TupleGetItem node;
-    if (new_tuple.same_as(op->tuple)) {
-      node = GetRef<TupleGetItem>(op);
-    }
-    node = TupleGetItem(new_tuple, op->index);
+    Expr new_tuple = this->NormalizeArgument(op->tuple);
+
+    TupleGetItem node = new_tuple.same_as(op->tuple) ? GetRef<TupleGetItem>(op)
+                                                     : TupleGetItem(new_tuple, op->index);
 
     // only do shape/type inference if the TupleGetItem does not have shape/type
     if (node->shape_ && node->checked_type_.defined()) {
@@ -364,28 +763,19 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
 
   BindingBlock VisitBindingBlock(const BindingBlock& block) {
     if (block.as<DataflowBlockNode>()) {
-      builder_->BeginDataflowBlock();
+      this->BeginDataflowBlock();
     } else {
-      builder_->BeginBindingBlock();
+      this->BeginBindingBlock();
     }
 
     bool unchanged = true;
     for (const Binding& binding : block->bindings) {
       Binding new_binding = this->VisitBinding(binding);
       unchanged &= new_binding.same_as(binding);
-      if (new_binding.as<VarBindingNode>()) {
-        VarBinding var_binding = Downcast<VarBinding>(new_binding);
-        if (builder_->CurrentBlockIsDataFlow() && !var_binding->var.as<DataflowVarNode>()) {
-          builder_->EmitOutput(var_binding);
-        } else {
-          builder_->Emit(var_binding);
-        }
-      } else {
-        ICHECK(new_binding.as<MatchShapeNode>());
-        builder_->EmitMatchShape(Downcast<MatchShape>(new_binding));
-      }
+
+      this->EmitNormalized(new_binding);
     }
-    BindingBlock new_block = builder_->EndBlock();
+    BindingBlock new_block = this->EndBlock();
     unchanged &= new_block->bindings.size() == block->bindings.size();
     if (unchanged) {
       return block;
@@ -393,46 +783,8 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     return new_block;
   }
 
-  void ResetMemo() { expr_memo_.Reset(); }
-
  private:
-  /*!
-   * \brief Memoization map for expressions using Id for equality of variables.
-   */
-  class ExprMemo {
-   public:
-    Optional<Expr> Get(const Expr& expr) {
-      if (const VarNode* var = expr.as<VarNode>()) {
-        auto it = var_memo_.find(var->vid);
-        if (it != var_memo_.end()) {
-          return it->second;
-        }
-      } else {
-        auto it = expr_memo_.find(expr);
-        if (it != expr_memo_.end()) {
-          return it->second;
-        }
-      }
-      return NullOpt;
-    }
-
-    void Set(const Expr& pre, const Expr& post) {
-      if (const VarNode* var = pre.as<VarNode>()) {
-        var_memo_[var->vid] = post;
-      } else {
-        expr_memo_[pre] = post;
-      }
-    }
-
-    void Reset() {
-      var_memo_ = std::unordered_map<Id, Expr, ObjectPtrHash, ObjectPtrEqual>();
-      expr_memo_ = std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual>();
-    }
-
-   private:
-    std::unordered_map<Id, Expr, ObjectPtrHash, ObjectPtrEqual> var_memo_;
-    std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual> expr_memo_;
-  };
+  bool ShapeUnchanged(const Expr& lhs, const Expr& rhs) { return CanProveShapeEqual(lhs, rhs); }
 
   // Helper function to check if a ShapeExpr is constant shape or tuple of constant shape
   bool IsConstantShapes(const Expr& shape) const {
@@ -509,7 +861,7 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
       if (var->shape_) {
         return Downcast<Expr>(var->shape_.value());
       }
-      Optional<Expr> val = builder_->LookupBinding(GetRef<Var>(var));
+      Optional<Expr> val = this->LookupBinding(GetRef<Var>(var));
       if (const auto* func_node = val.value().as<FunctionNode>()) {
         Function func = GetRef<Function>(func_node);
         if (func->ret_type.as<DynTensorTypeNode>()) {
@@ -626,26 +978,13 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     }
   }
 
-  // Helper function to get the shape of a Tuple based on its fields
-  Optional<Expr> GetTupleShape(const Tuple& tuple) {
-    Array<Expr> tuple_shape;
-    for (Expr field : tuple->fields) {
-      if (field->shape_) {
-        tuple_shape.push_back(Downcast<Expr>(field->shape_.value()));
-      } else {
-        break;
-      }
-    }
-    if (tuple_shape.size() == tuple->fields.size()) {
-      return Tuple(tuple_shape);
-    }
-    return NullOpt;
-  }
-
   Expr VisitWithNewScope(const Expr& expr) {
-    builder_->BeginBindingBlock();
-    Expr post = this->VisitExpr(expr);
-    BindingBlock prologue = builder_->EndBlock();
+    // SeqExpr do not need to prepare for normalization.
+    if (expr.as<SeqExprNode>()) return this->VisitExpr(expr);
+
+    this->BeginBindingBlock();
+    Expr post = this->NormalizeArgument(expr);
+    BindingBlock prologue = this->EndBlock();
     // "New scopes" (function bodies, if/else clauses) must be wrapped in seq exprs.
     // Don't wrap if it's already a seq and there are no bindings to add
     if (post.as<SeqExprNode>() && prologue->bindings.empty()) {
@@ -655,9 +994,11 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     if (!prologue->bindings.empty()) {
       bindings.push_back(prologue);
     }
-    auto seq = SeqExpr(bindings, post);
-    // visit in case post is not a leaf and we need to bind it too
-    return this->VisitExpr(seq);
+
+    SeqExpr seq(bindings, post);
+    UpdateShape(seq, post->shape_);
+    UpdateType(seq, post->checked_type_);
+    return seq;
   }
 
   Array<BindingBlock> NormalizeBlocks(const Array<BindingBlock>& blocks) {
@@ -695,21 +1036,6 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
     return changed ? ret : blocks;
   }
 
-  Expr Bind(const Expr& expr) {
-    Expr post = this->VisitExpr(expr);
-    if (!IsLeafExpr(post)) {
-      post = builder_->Emit(post);
-      expr_memo_.Set(expr, post);
-    }
-    return post;
-  }
-
-  /*! \brief BlockBuilder used for emitting intermediate variables. */
-  BlockBuilderNode* builder_;
-
-  /*! \brief Memoization table for mapping expressions to their ANF variables. */
-  ExprMemo expr_memo_;
-
   /*! \brief Operator to shape inference map. */
   tvm::OpAttrMap<FInferShape> op_map_infer_shape_ = Op::GetAttrMap<FInferShape>("FInferShape");
 
@@ -717,245 +1043,16 @@ class BlockBuilderNode::ExprNormalizer : public ExprFunctor<Expr(const Expr&)> {
   tvm::OpAttrMap<FInferType> op_map_infer_type_ = Op::GetAttrMap<FInferType>("FInferType");
 };
 
-// ================
-// BlockBuilderNode
-
-TVM_REGISTER_NODE_TYPE(BlockBuilderNode);
-
-BlockBuilderNode::BlockBuilderNode() {
-  name_table_ = std::make_unique<NameTable>();
-  normalizer_ = std::make_unique<ExprNormalizer>(this);
-}
-
-BlockBuilderNode::~BlockBuilderNode() {
-  if (!block_stack_.empty()) {
-    LOG(WARNING) << "BlockBuilder destroyed with remaining blocks!";
-  }
-}
-
-void BlockBuilderNode::BeginDataflowBlock() { this->block_stack_.push({{}, true}); }
-
-void BlockBuilderNode::BeginBindingBlock() { this->block_stack_.push({{}, false}); }
-
-BindingBlock BlockBuilderNode::EndBlock() {
-  BlockFrame* cur_frame = CurrentFrame();
-  BindingBlock ret = cur_frame->is_dataflow ? DataflowBlock(cur_frame->bindings)
-                                            : BindingBlock(cur_frame->bindings);
-  block_stack_.pop();
-  return ret;
-}
-
-Var BlockBuilderNode::Emit(const Expr& expr, std::string name_hint) {
-  return Emit(expr, CurrentFrame()->is_dataflow, name_hint);
-}
-
-Var BlockBuilderNode::Emit(const Expr& expr, bool is_dataflow, std::string name_hint) {
-  BlockFrame* cur_frame = CurrentFrame();
-  Expr normalized = Normalize(expr);
-
-  if (name_hint.empty()) {
-    name_hint = is_dataflow ? "lv" : "gv";
-  }
-  Id vid = Id(name_table_->GetUniqueName(name_hint));
-  Var var = is_dataflow ? DataflowVar(vid, NullOpt, NullOpt) : Var(vid, NullOpt, NullOpt);
-  UpdateType(var, normalized->checked_type_);
-  UpdateShape(var, normalized->shape_);
-
-  cur_frame->bindings.push_back(VarBinding(var, expr));
-  binding_table_[var->vid] = expr;
-
-  return var;
-}
-
-Var BlockBuilderNode::Emit(const VarBinding& binding) {
-  BlockFrame* cur_frame = CurrentFrame();
-  if (cur_frame->is_dataflow) {
-    ICHECK(binding->var.as<DataflowVarNode>())
-        << "Emit can only be used for local bindings in a dataflow block, use EmitOutput for "
-           "output bindings instead";
-  }
-  cur_frame->bindings.push_back(binding);
-  binding_table_[binding->var->vid] = binding->value;
-  return binding->var;
-}
-
-Var BlockBuilderNode::EmitMatchShape(const Expr& value, const Array<PrimExpr>& pattern,
-                                     std::string name_hint) {
-  BlockFrame* cur_frame = CurrentFrame();
-
-  if (name_hint.empty()) {
-    name_hint = cur_frame->is_dataflow ? "lv" : "gv";
-  }
-  Id vid = Id(name_table_->GetUniqueName(name_hint));
-  Var var =
-      cur_frame->is_dataflow ? DataflowVar(vid, NullOpt, NullOpt) : Var(vid, NullOpt, NullOpt);
-
-  if (value->checked_type().as<ShapeTypeNode>()) {
-    UpdateType(var, ShapeType());
-  } else if (const DynTensorTypeNode* tty = value->checked_type().as<DynTensorTypeNode>()) {
-    ShapeExpr shape = ShapeExpr(pattern);
-    UpdateShape(var, shape);
-    DataType dtype = tty->dtype;
-    UpdateType(var, DynTensorType(pattern.size(), dtype));
-  } else {
-    this->diag_ctx_.EmitFatal(
-        Diagnostic::Error(value->span)
-        << "The value passed to EmitMatchShape must be of DynTensorType or ShapeType.");
-  }
-
-  MatchShape match_shape = MatchShape(value, pattern, var);
-  cur_frame->bindings.push_back(match_shape);
-  binding_table_[var->vid] = value;
-  return var;
-}
-
-Var BlockBuilderNode::EmitMatchShape(const MatchShape& binding) {
-  BlockFrame* cur_frame = CurrentFrame();
-  if (binding->var.defined()) {
-    ICHECK(cur_frame->is_dataflow || !binding->var.as<DataflowVarNode>())
-        << "cannot emit dataflow vars outside a dataflow block: " << binding->var->name_hint();
-    binding_table_[binding->var->vid] = binding->value;
-  }
-  cur_frame->bindings.push_back(binding);
-  return binding->var;
-}
-
-Var BlockBuilderNode::EmitOutput(const Expr& output, std::string name_hint) {
-  BlockFrame* cur_frame = CurrentFrame();
-
-  ICHECK(cur_frame->is_dataflow) << "EmitOutput has to be called inside dataflow block.";
-
-  return Emit(output, false, name_hint);
-}
-
-Var BlockBuilderNode::EmitOutput(const VarBinding& binding) {
-  BlockFrame* cur_frame = CurrentFrame();
-
-  ICHECK(cur_frame->is_dataflow) << "EmitOutput has to be called inside dataflow block.";
-  ICHECK(!binding->var.as<DataflowVarNode>()) << "EmitOutput can only emit Var bindings.";
-
-  cur_frame->bindings.push_back(binding);
-  binding_table_[binding->var->vid] = binding->value;
-  return binding->var;
-}
-
-Optional<Expr> BlockBuilderNode::LookupBinding(const Var& var) {
-  auto it = binding_table_.find(var->vid);
-  if (it == binding_table_.end()) return NullOpt;
-  return it->second;
-}
-
-bool BlockBuilderNode::CanProveShapeEqual(const Expr& lhs, const Expr& rhs) {
-  if (lhs == rhs) {
-    return true;
-  }
-  if (lhs->IsInstance<RuntimeDepShapeNode>() && rhs->IsInstance<RuntimeDepShapeNode>()) {
-    return true;
-  } else if (lhs->IsInstance<ShapeExprNode>() && rhs->IsInstance<ShapeExprNode>()) {
-    const auto* lhs_shape = lhs.as<ShapeExprNode>();
-    const auto* rhs_shape = rhs.as<ShapeExprNode>();
-    size_t lhs_ndim = lhs_shape->values.size();
-    size_t rhs_ndim = rhs_shape->values.size();
-    if (lhs_ndim != rhs_ndim) {
-      return false;
-    }
-    arith::Analyzer analyzer;
-    for (size_t i = 0; i < lhs_ndim; ++i) {
-      PrimExpr lhs_dim = lhs_shape->values[i];
-      PrimExpr rhs_dim = rhs_shape->values[i];
-      if (lhs_dim.dtype() != rhs_dim.dtype() || !analyzer.CanProveEqual(lhs_dim, rhs_dim)) {
-        return false;
-      }
-    }
-    return true;
-  } else if (lhs->IsInstance<TupleNode>() && rhs->IsInstance<TupleNode>()) {
-    const auto* lhs_tuple = lhs.as<TupleNode>();
-    const auto* rhs_tuple = rhs.as<TupleNode>();
-    if (lhs_tuple->fields.size() != rhs_tuple->fields.size()) {
-      return false;
-    }
-    for (size_t i = 0; i < lhs_tuple->fields.size(); ++i) {
-      if (!CanProveShapeEqual(lhs_tuple->fields[i], rhs_tuple->fields[i])) {
-        return false;
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
-void BlockBuilderNode::ResetMemo() { normalizer_->ResetMemo(); }
-
-// TODO(@altanh, @yuchen): need an internal Emit_ that doesn't call normalize
-Expr BlockBuilderNode::Normalize(const Expr& expr) {
-  Expr normalized = normalizer_->VisitExpr(expr);
-
-  if (!normalized->IsInstance<OpNode>()) {
-    ICHECK(normalized->checked_type_.defined())
-        << "The checked_type_ of an Expr except OpNode after "
-           "normalization must not be nullptr. However, this Expr does not have checked_type_: "
-        << normalized;
-  }
-
-  return normalized;
-}
-
-BlockBuilderNode::BlockFrame* BlockBuilderNode::CurrentFrame() {
-  ICHECK(!block_stack_.empty()) << "no block is being built";
-  return &block_stack_.top();
-}
-
-NameTable* BlockBuilderNode::name_table() { return name_table_.get(); }
-
-GlobalVar BlockBuilderNode::AddFunction(const BaseFunc& func, const String& func_name_hint) {
-  auto it = func_map_.find(func);
-  if (it == func_map_.end()) {
-    context_mod_.CopyOnWrite();
-    String func_name = name_table_->GetUniqueName(func_name_hint);
-    while (context_mod_->ContainGlobalVar(func_name)) {
-      func_name = name_table_->GetUniqueName(func_name_hint);
-    }
-    GlobalVar gvar = GlobalVar(func_name);
-    if (const tir::PrimFuncNode* prim_func = func.as<tir::PrimFuncNode>()) {
-      tir::PrimFunc fn = GetRef<tir::PrimFunc>(prim_func);
-      ICHECK(fn->checked_type_.defined())
-          << "The function to be added does not have checked_type_.";
-      gvar->checked_type_ = fn->checked_type_;
-      context_mod_->Add(gvar, fn);
-    } else {
-      ICHECK(func->checked_type_.defined())
-          << "The function to be added does not have checked_type_.";
-      gvar->checked_type_ = func->checked_type_;
-      context_mod_->Add(gvar, func);
-    }
-    func_map_.emplace(func, gvar);
-    return gvar;
-  } else {
-    return it->second;
-  }
-}
-
-void BlockBuilderNode::UpdateFunction(const GlobalVar& gv, BaseFunc updated_function) {
-  context_mod_.CopyOnWrite();
-  context_mod_->Update(gv, updated_function);
-  func_map_[updated_function] = gv;
-}
-
-IRModule BlockBuilderNode::GetContextIRModule() const { return context_mod_; }
-
 BlockBuilder BlockBuilder::Create(Optional<IRModule> mod) {
-  ObjectPtr<BlockBuilderNode> n = make_object<BlockBuilderNode>();
-  if (mod) {
-    n->context_mod_ = mod.value();
-  }
-  BlockBuilder block_builder(n);
-  for (const auto& kv : n->context_mod_->functions) {
-    const GlobalVar& gv = kv.first;
-    const BaseFunc& func = kv.second;
-    block_builder->func_map_.emplace(func, gv);
-  }
-  return block_builder;
+  ObjectPtr<BlockBuilderNode> n =
+      make_object<BlockBuilderImplWithNormalize>(mod.value_or(IRModule()));
+  return BlockBuilder(n);
 }
+
+//---------------------------------------
+// User facing function registration.
+//---------------------------------------
+TVM_REGISTER_OBJECT_TYPE(BlockBuilderNode);
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderCreate").set_body_typed([](Optional<IRModule> mod) {
   return BlockBuilder::Create(mod);

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -494,7 +494,7 @@ class BlockBuilderImplWithNormalize : public BlockBuilderImpl,
   Optional<Expr> GetTupleShape(const Tuple& tuple) {
     Array<Expr> tuple_shape;
     for (Expr field : tuple->fields) {
-      if (field->shape_) {
+      if (field->shape_.defined()) {
         tuple_shape.push_back(Downcast<Expr>(field->shape_.value()));
       } else {
         break;

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -398,7 +398,14 @@ class BlockBuilderImpl : public BlockBuilderNode {
 #define RELAX_EXPR_NORMALIZER_LEAF(OP) \
   Expr VisitExpr_(const OP* op) final { return GetRef<Expr>(op); }
 
-// Invariance: If an Expr have a shape_ field, it must have already been normalized.
+// Invariance assumption: If an Expr's shape_ is not null
+// then the Expr must have already been normalized.
+//
+// This would be the case if all the shape of leaf expr are set,
+// and normalizer is the primary location of setting shape.
+//
+// TODO(relax-team): check this assumption in wellform check
+// and report to pass writer.
 class BlockBuilderImplWithNormalize : public BlockBuilderImpl,
                                       private ExprFunctor<Expr(const Expr&)> {
  public:

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -413,7 +413,7 @@ class BlockBuilderImplWithNormalize : public BlockBuilderImpl,
 
   Expr Normalize(const Expr& expr) final {
     Expr normalized = this->VisitExpr(expr);
-    // Invariance:
+    // Invariant:
     // After Normalize: an Expr always have checked_type (with the exception of Op).
     if (!normalized->IsInstance<OpNode>()) {
       ICHECK(normalized->checked_type_.defined())

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -294,7 +294,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
     /*!
      * \brief Binding map used by normalizer.
      *
-     * \note The normalizer only caches resue in the current scope
+     * \note The normalizer only caches reuse in the current scope
      *       and will not cache bindings from parent scope.
      */
     std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> normalize_binding_map;

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -696,8 +696,8 @@ class BlockBuilderImplWithNormalize : public BlockBuilderImpl,
 
     if (!op->shape_.defined()) {
       if (new_true->shape_ && new_false->shape_ &&
-          this->ShapeUnchanged(Downcast<Expr>(new_true->shape_.value()),
-                               Downcast<Expr>(new_false->shape_.value()))) {
+          this->ShapeStructEqual(Downcast<Expr>(new_true->shape_.value()),
+                                 Downcast<Expr>(new_false->shape_.value()))) {
         UpdateShape(if_node, new_true->shape_);
       } else {
         UpdateShape(if_node, RuntimeDepShape());
@@ -784,7 +784,7 @@ class BlockBuilderImplWithNormalize : public BlockBuilderImpl,
   }
 
  private:
-  bool ShapeUnchanged(const Expr& lhs, const Expr& rhs) { return CanProveShapeEqual(lhs, rhs); }
+  bool ShapeStructEqual(const Expr& lhs, const Expr& rhs) { return CanProveShapeEqual(lhs, rhs); }
 
   // Helper function to check if a ShapeExpr is constant shape or tuple of constant shape
   bool IsConstantShapes(const Expr& shape) const {

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -54,9 +54,7 @@ void FunctionFrameNode::ExitWithScope() {
   // Step 1: Create the function.
   CHECK(output.defined()) << "ValueError: A Relax function must have a return value. Please use "
                              "`return` to return an Expr";
-  // Normalizing a second time could result in false hits to the memo
-  // TODO(relax-team): We should fix the memoization not to require this
-  this->block_builder->ResetMemo();
+
   Expr body = this->block_builder->Normalize(tvm::relax::SeqExpr(binding_blocks, output.value()));
   Expr func_shape = ret_shape.value_or(tvm::relax::RuntimeDepShape());
   if (func_shape->IsInstance<tvm::relax::RuntimeDepShapeNode>()) {

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -626,7 +626,7 @@ def test_no_func_params_fail():
 
     with pytest.raises(RuntimeError):
         with bb.function("func"):
-            gv0 = bb.emit(rx.Call(ExternFunc("test.blockbuilder.nop"), None))
+            gv0 = bb.emit(rx.Call(ExternFunc("test.blockbuilder.nop"), []))
             bb.emit_func_output(gv0)
 
 


### PR DESCRIPTION
This PR refactors BlockBuilder code into three logical categories for better readability and code robustness
- Global context management
- Scope management
- Normalize

To make the implementation cleaner, we use virtual classing and hide the internal data structures behind the cc file.

We also break the logic of block builder into two parts,
- BlockBuilderImpl focuses on context and scope management.
- BlockBuilderImplWithNormalize subclass focuses on normalization.

The subclassing helps to highlight the coupling nature of normalize and scope management, but still keeps the logic reasonably separately in two locations.

Other changes:
- rename memo to normalize_binding_map and make it scope specific.
- rename func_map to ctx_func_dedup_map and make it lazy initialize.
- some code reuse
- rename Bind to NormalizeArgument