### PR TITLE
[REFACTOR] Refactor BlockBuilder

### DIFF
--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -33,6 +33,7 @@
 #include <tvm/relay/expr.h>
 #include <tvm/relay/function.h>
 #include <tvm/relay/op.h>
+#include <tvm/tir/function.h>
 
 #include <deque>
 #include <string>
@@ -137,6 +138,8 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     return vtable(n, this, std::forward<Args>(args)...);
   }
   // Functions that can be overriden by subclass
+  // NOTE: cross dialect calls are invoked through global var
+  // We do not expect inline PrimFunc to appear in relax IR.
   virtual R VisitExpr_(const ConstantNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const TupleNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const VarNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
@@ -369,8 +372,6 @@ class ExprMutator : public ExprMutatorBase {
   virtual Var VisitVarDef_(const DataflowVarNode* var);
 
  protected:
-  class ExprNormalizer;
-
   /*!
    * \brief Try to remit binding and bind it to a new_value
    *

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -406,7 +406,8 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
   Expr Normalize(const Expr& expr) final {
     Expr normalized = this->VisitExpr(expr);
     // Invariant:
-    // After Normalize: an Expr always have checked_type (with the exception of Op).
+    // After Normalize: an Expr always have
+    // checked_type (with the exception of Op).
     if (!normalized->IsInstance<OpNode>()) {
       ICHECK(normalized->checked_type_.defined())
           << "The checked_type_ of an Expr except OpNode after "

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -54,9 +54,7 @@ void FunctionFrameNode::ExitWithScope() {
   // Step 1: Create the function.
   CHECK(output.defined()) << "ValueError: A Relax function must have a return value. Please use "
                              "`return` to return an Expr";
-  // Normalizing a second time could result in false hits to the memo
-  // TODO(relax-team): We should fix the memoization not to require this
-  this->block_builder->ResetMemo();
+
   Expr body = this->block_builder->Normalize(tvm::relax::SeqExpr(binding_blocks, output.value()));
   Expr func_shape = ret_shape.value_or(tvm::relax::RuntimeDepShape());
   if (func_shape->IsInstance<tvm::relax::RuntimeDepShapeNode>()) {

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -626,7 +626,7 @@ def test_no_func_params_fail():
 
     with pytest.raises(RuntimeError):
         with bb.function("func"):
-            gv0 = bb.emit(rx.Call(ExternFunc("test.blockbuilder.nop"), None))
+            gv0 = bb.emit(rx.Call(ExternFunc("test.blockbuilder.nop"), []))
             bb.emit_func_output(gv0)
 
 


### PR DESCRIPTION
This PR refactors BlockBuilder code into three logical categories for better readability and code robustness
- Global context management
- Scope management
- Normalize

To make the implementation cleaner, we use virtual classing and hide the internal data structures behind the cc file.

We also break the logic of block builder into two parts,
- BlockBuilderImpl focuses on context and scope management.
- BlockBuilderImplWithNormalize subclass focuses on normalization.

The subclassing helps to highlight the coupling nature of normalize and scope management, but still keeps the logic reasonably separately in two locations.

Other changes:
- rename memo to normalize_binding_map and make it scope specific.
- rename func_map to ctx_func_dedup_map and make it lazy initialize.
- some code reuse
- rename Bind to NormalizeArgument

Co-authored-by: Ruihang Lai <ruihangl@cs.cmu.edu>
Co-authored-by: Steven S. Lyubomirsky <slyubomirsky@gmail.com>