### PR TITLE
[BlockBuilder][Refactor] Normalize nested `SeqExpr`s

### DIFF
--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -1020,8 +1020,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
       for (const Binding& binding : block->bindings) {
         auto match_shape = binding.as<MatchShapeNode>();
         auto var_binding = binding.as<VarBindingNode>();
-        const Expr& value =
-            match_shape ? binding.as<MatchShapeNode>()->value : binding.as<VarBindingNode>()->value;
+        const Expr& value = match_shape ? match_shape->value : var_binding->value;
         // if we encounter a nested seq, we have to flatten it:
         //   1. Append the binding block we've accumulated so far
         //   2. Reset the current block

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -1015,7 +1015,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
     Array<BindingBlock> ret;
     bool changed = false;
     for (const BindingBlock& block : blocks) {
-      bool is_dataflow = block.as<DataflowBlockNode>();
+      bool is_dataflow = block->IsInstance<DataflowBlockNode>();
       Array<Binding> current;
       for (const Binding& binding : block->bindings) {
         auto match_shape = binding.as<MatchShapeNode>();

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -1024,13 +1024,16 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
         // if we encounter a nested seq, we have to flatten it:
         //   1. Append the binding block we've accumulated so far
         //   2. Reset the current block
-        //   3. Flatten (recursively) the inner blocks and append those
+        //   3. Append the inner blocks
         //   4. Add a binding of the current var to the seq expr's body to the current block
         // then continue
         if (auto seq = value.as<SeqExprNode>()) {
           changed = true;
           ret.push_back(is_dataflow ? DataflowBlock(current) : BindingBlock(current));
           current = {};
+          // We do not need to flatten recursively because the normalizer will have normalized
+          // and thus flattened the inner SeqExprs already
+          for (const BindingBlock& block : seq->blocks) {
             if (is_dataflow && !block->IsInstance<DataflowBlockNode>()) {
               LOG(WARNING) << "Malformed AST: Seq expr nested inside a dataflow block contains a "
                               "non-dataflow block! "

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -1008,10 +1008,55 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
     return seq;
   }
 
+  Array<BindingBlock> FlattenBlocks(const Array<BindingBlock>& blocks) {
+    // If there is a binding that is a seq expr, split the current block,
+    // add the nested blocks prior to the seq expr, and bind the seq expr body
+    // to the var
+    Array<BindingBlock> ret;
+    bool changed = false;
+    for (const BindingBlock& block : blocks) {
+      bool is_dataflow = block.as<DataflowBlockNode>();
+      Array<Binding> current;
+      for (const Binding& binding : block->bindings) {
+        auto match_shape = binding.as<MatchShapeNode>();
+        auto var_binding = binding.as<VarBindingNode>();
+        const Expr& value =
+            match_shape ? binding.as<MatchShapeNode>()->value : binding.as<VarBindingNode>()->value;
+        // if we encounter a nested seq, we have to flatten it:
+        //   1. Append the binding block we've accumulated so far
+        //   2. Reset the current block
+        //   3. Flatten (recursively) the inner blocks and append those
+        //   4. Add a binding of the current var to the seq expr's body to the current block
+        // then continue
+        if (auto seq = value.as<SeqExprNode>()) {
+          changed = true;
+          ret.push_back(is_dataflow ? DataflowBlock(current) : BindingBlock(current));
+          current = {};
+          auto flattened_blocks = FlattenBlocks(seq->blocks);
+          for (const BindingBlock& block : flattened_blocks) {
+            ret.push_back(block);
+          }
+          current.push_back(
+              match_shape
+                  ? Downcast<Binding>(MatchShape(seq->body, match_shape->pattern, match_shape->var))
+                  : Downcast<Binding>(VarBinding(var_binding->var, seq->body)));
+        } else {
+          current.push_back(binding);
+        }
+      }
+      ret.push_back(is_dataflow ? DataflowBlock(current) : BindingBlock(current));
+    }
+    return changed ? ret : blocks;
+  }
+
   Array<BindingBlock> NormalizeBlocks(const Array<BindingBlock>& blocks) {
     bool changed = false;
     Array<BindingBlock> ret;
-    for (const BindingBlock& block : blocks) {
+    auto flattened = FlattenBlocks(blocks);
+    if (!flattened.same_as(blocks)) {
+      changed = true;
+    }
+    for (const BindingBlock& block : flattened) {
       if (block->bindings.empty()) {
         // Case 1. Skip empty blocks
         changed = true;
@@ -1033,10 +1078,8 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
         ret.pop_back();
         ret.push_back(merged);
         changed = true;
-      } else if (false) {
-        // Case 3. TODO(@Hzfengsy): normalize nested SeqExprs and BindingBlocks
       } else {
-        // Case 4. Add to the result
+        // Case 3. Add to the result
         ret.push_back(block);
       }
     }

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -1031,8 +1031,11 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
           changed = true;
           ret.push_back(is_dataflow ? DataflowBlock(current) : BindingBlock(current));
           current = {};
-          auto flattened_blocks = FlattenBlocks(seq->blocks);
-          for (const BindingBlock& block : flattened_blocks) {
+            if (is_dataflow && !block->IsInstance<DataflowBlockNode>()) {
+              LOG(WARNING) << "Malformed AST: Seq expr nested inside a dataflow block contains a "
+                              "non-dataflow block! "
+                           << seq;
+            }
             ret.push_back(block);
           }
           current.push_back(

--- a/tests/python/relax/test_transform_normalize.py
+++ b/tests/python/relax/test_transform_normalize.py
@@ -366,5 +366,170 @@ def test_normalize_combine_nearby_blocks():
     assert_structural_equal(after_mod["main"], expected)
 
 
+def test_normalize_nested_seq():
+    x = relax.Var("x", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    y = relax.Var("y", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    z = relax.Var("z", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    seq = relax.SeqExpr(
+        [
+            relax.BindingBlock(
+                [
+                    relax.VarBinding(x, relax.const(1)),
+                    relax.VarBinding(
+                        y,
+                        relax.SeqExpr(
+                            [relax.BindingBlock([relax.VarBinding(z, relax.const(2))])],
+                            z,
+                        ),
+                    ),
+                ]
+            )
+        ],
+        y,
+    )
+
+    f = relax.Function(
+        [],
+        seq,
+        ret_type=relax.DynTensorType(ndim=0, dtype="int32"),
+        ret_shape=relax.RuntimeDepShape(),
+    )
+    after_mod = relax.transform.Normalize()(tvm.IRModule.from_expr(f))
+
+    @R.function
+    def expected():
+        x = relax.const(1)
+        z = relax.const(2)
+        y = z
+        return y
+
+    assert_structural_equal(after_mod["main"], expected)
+
+
+def test_normalize_nested_seq_dataflow():
+    x = relax.Var("x", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    y = relax.Var("y", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    z = relax.Var("z", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    q = relax.Var("u", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    w = relax.DataflowVar("w", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    u = relax.Var("u", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    seq = relax.SeqExpr(
+        [
+            relax.BindingBlock(
+                [
+                    relax.VarBinding(x, relax.const(1)),
+                    relax.VarBinding(
+                        y,
+                        relax.SeqExpr(
+                            [
+                                relax.BindingBlock([relax.VarBinding(q, relax.const(2))]),
+                                relax.DataflowBlock(
+                                    [
+                                        relax.VarBinding(w, q),
+                                        relax.VarBinding(u, w),
+                                    ]
+                                ),
+                                relax.BindingBlock([relax.VarBinding(z, u)]),
+                            ],
+                            z,
+                        ),
+                    ),
+                ]
+            )
+        ],
+        y,
+    )
+
+    f = relax.Function(
+        [],
+        seq,
+        ret_type=relax.DynTensorType(ndim=0, dtype="int32"),
+        ret_shape=relax.RuntimeDepShape(),
+    )
+    after_mod = relax.transform.Normalize()(tvm.IRModule.from_expr(f))
+
+    @R.function
+    def expected():
+        x = relax.const(1)
+        q = relax.const(2)
+        with R.dataflow():
+            w = q
+            u = w
+            R.output(u)
+        z = u
+        y = z
+        return y
+
+    assert_structural_equal(after_mod["main"], expected)
+
+
+def test_normalize_deeply_nested_seq():
+    x = relax.Var("x", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    y = relax.Var("y", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    z = relax.Var("z", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    u = relax.Var("u", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    v = relax.Var("v", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    w = relax.Var("w", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    seq = relax.SeqExpr(
+        [
+            relax.BindingBlock(
+                [
+                    relax.VarBinding(x, relax.const(1)),
+                    relax.VarBinding(
+                        y,
+                        relax.SeqExpr(
+                            [
+                                relax.BindingBlock(
+                                    [
+                                        relax.VarBinding(
+                                            z,
+                                            relax.SeqExpr(
+                                                [
+                                                    relax.BindingBlock(
+                                                        [
+                                                            relax.VarBinding(u, relax.const(2)),
+                                                            relax.MatchShape(u, [], None),
+                                                            relax.VarBinding(v, u),
+                                                            relax.MatchShape(v, [], w),
+                                                        ]
+                                                    )
+                                                ],
+                                                w,
+                                            ),
+                                        )
+                                    ]
+                                )
+                            ],
+                            z,
+                        ),
+                    ),
+                ]
+            )
+        ],
+        y,
+    )
+
+    f = relax.Function(
+        [],
+        seq,
+        ret_type=relax.DynTensorType(ndim=0, dtype="int32"),
+        ret_shape=relax.RuntimeDepShape(),
+    )
+    after_mod = relax.transform.Normalize()(tvm.IRModule.from_expr(f))
+
+    @R.function
+    def expected():
+        x = relax.const(1)
+        u = relax.const(2)
+        R.match_shape(u, ())
+        v = u
+        w = R.match_shape(v, ())
+        z = w
+        y = z
+        return y
+
+    assert_structural_equal(after_mod["main"], expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_transform_normalize.py
+++ b/tests/python/relax/test_transform_normalize.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 import tvm
 import tvm.testing
@@ -529,6 +529,38 @@ def test_normalize_deeply_nested_seq():
         return y
 
     assert_structural_equal(after_mod["main"], expected)
+
+
+@pytest.mark.xfail()
+def test_nesting_non_dataflow_in_dataflow_error():
+    x = relax.DataflowVar("x", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    y = relax.Var("y", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    z = relax.Var("z", [], relax.DynTensorType(ndim=0, dtype="int32"))
+    seq = relax.SeqExpr(
+        [
+            relax.DataflowBlock(
+                [
+                    relax.VarBinding(x, relax.const(1)),
+                    relax.VarBinding(
+                        y,
+                        relax.SeqExpr(
+                            [relax.BindingBlock([relax.VarBinding(z, relax.const(2))])],
+                            z,
+                        ),
+                    ),
+                ]
+            )
+        ],
+        y,
+    )
+    f = relax.Function(
+        [],
+        seq,
+        ret_type=relax.DynTensorType(ndim=0, dtype="int32"),
+        ret_shape=relax.RuntimeDepShape(),
+    )
+    relax.transform.Normalize()(tvm.IRModule.from_expr(f))
+    # should fail due to a normal binding block being inside a dataflowblock
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As a follow-up to #298, this PR handles the case of a `SeqExpr` nested inside another. Namely, if there is a `SeqExpr` on the right-hand side of a binding, this PR ensures that the normalizer will flatten the outer `SeqExpr` into a single `SeqExpr` that contains the bindings in the correct order. The parser will not produce such constructs on its own, but it is possible that a pass might place one `SeqExpr` inside another, so this will ensure that the normalizer will be able to handle these cases if they arise.