### PR TITLE
[Debugging][Arch] Expose `shape_` fields for `TupleGetItem` and `If` nodes, fix AST printer accordingly

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -161,6 +161,7 @@ class IfNode : public ExprNode {
     v->Visit("true_branch", &true_branch);
     v->Visit("false_branch", &false_branch);
     v->Visit("span", &span);
+    v->Visit("shape_", &shape_);
     v->Visit("_checked_type_", &checked_type_);
   }
 
@@ -273,6 +274,7 @@ class TupleGetItemNode : public ExprNode {
     v->Visit("tuple_value", &tuple);
     v->Visit("index", &index);
     v->Visit("span", &span);
+    v->Visit("shape_", &shape_);
     v->Visit("_checked_type_", &checked_type_);
   }
 

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -208,16 +208,13 @@ class ASTPrinter(ExprFunctor):
         )
 
     def visit_if_(self, op: relax.If) -> str:
-        # if is copied from Relay's AST, so it cannot have a Shape
-        # TODO(@relax-team): We should eventually assign a shape_ to If
-        fields = {
-            "cond": self.visit_expr(op.cond),
-            "true_branch": self.visit_expr(op.true_branch),
-            "false_branch": self.visit_expr(op.false_branch),
-        }
-        if op._checked_type_ and self.include_type_annotations:
-            fields["checked_type_"] = self.visit_type_(op.checked_type)
-        return self.build_ast_node("If", **fields)
+        return self.build_expr(
+            op,
+            "If",
+            cond=self.visit_expr(op.cond),
+            true_branch=self.visit_expr(op.true_branch),
+            false_branch=self.visit_expr(op.false_branch),
+        )
 
     def visit_op_(self, op: tvm.ir.Op) -> str:
         # TODO: List other attributes?
@@ -230,15 +227,12 @@ class ASTPrinter(ExprFunctor):
         return self.build_ast_node("PrimExpr", value=f"`{str(prim_expr)}`")
 
     def visit_tuple_getitem_(self, op: relax.TupleGetItem) -> str:
-        # TupleGetItem is copied from Relay's AST, so it cannot have a Shape
-        # TODO(@relax-team): We should eventually assign a shape_ to TupleGetItem
-        fields = {
-            "tuple_value": self.visit_expr(op.tuple_value),
-            "index": str(op.index),
-        }
-        if op._checked_type_ and self.include_type_annotations:
-            fields["checked_type_"] = self.visit_type_(op.checked_type)
-        return self.build_ast_node("TupleGetItem", **fields)
+        return self.build_expr(
+            op,
+            "TupleGetItem",
+            tuple_value=self.visit_expr(op.tuple_value),
+            index=str(op.index),
+        )
 
     def visit_type_(self, type_node: relax.Type) -> str:
         """

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -407,7 +407,7 @@ def test_call_tir():
         {
             "op": 'Op(name="relax.call_tir")',
             "args": """[
-                ExternFunc(global_symbol="test.op.identity"), 
+                ExternFunc(global_symbol="test.op.identity"),
                 Tuple(fields=[
                     Var(name_hint="x")]),
                     ShapeExpr(values=[PrimExpr(value=`m: int64`),


### PR DESCRIPTION
As noted in #288, `shape_` in `TupleGetItem` and `If` was not accessible from Python due to an omission in their `VisitAttrs` methods. This PR corrects that omission and updates the AST printer to handle those nodes accordingly. 

This PR also corrects a flaw in the tests, which is that they depended on the keys being printed in a given order. Even though the current implementation happens to use specific orders for the keys (and Python since 3.7 has guaranteed that `dict`s will be in insertion order), there is no reason for the tests to assume a specific order that they should be printed. That is, the tests should not break if we happen to reorder the printing of fields.