### PR TITLE
[Bugfix] Handle function name properly in Relax TVMScript printer

### DIFF
--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -258,8 +258,8 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   size_t local_func_counter_ = 0;
   /*! \brief meta data context. */
   TextMetaDataContext* meta_;
-  /*! \brief the current relax function name. */
-  String relax_func_name_ = "foo";
+  /*! \brief default relax function name in printer. */
+  constexpr const static char* relax_default_func_name_ = "main";
   /*!
    * \brief A bool flag to indicate if we print symbolic shape as str, usually for global
    * function.

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -25,15 +25,18 @@
  * If it's malformed, messages will be logged as Warning.
  * This pass will check:
  *    1. GlobalVars are defined before use.
- *    2. Vars are defined before use.
- *    3. Vars are defined exactly once.
- *    4. Symbolic Vars are defined before use.
- *    5. DataflowVars cannot be defined inside BindingBlock.
- *    6. Vars defined in IfNode, except the return Var, are invisible
+ *    2. When a Function has a corresponding GlobalVar and a `global_symbol`
+ *       attribute, the name of the GlobalVar must equal the value of the
+ *       `global_symbol` attribute value.
+ *    3. Vars are defined before use.
+ *    4. Vars are defined exactly once.
+ *    5. Symbolic Vars are defined before use.
+ *    6. DataflowVars cannot be defined inside BindingBlock.
+ *    7. Vars defined in IfNode, except the return Var, are invisible
  *       out of the If body.(May change for new AST designs)
- *    6. SeqExpr only serves as function body, or in the true and
+ *    8. SeqExpr only serves as function body, or in the true and
  *       false branches in IfNode.
- *    7. The IR is in ANF:
+ *    9. The IR is in ANF:
  *       (a) Expressions cannot contain nested complex expressions.
  *           Here are the expressions that may be nested inside other expressions:
  *           Var, DataflowVar, GlobalVar, Constant, ShapeExpr, RuntimeDepShape,
@@ -48,7 +51,7 @@
  *           * The cond field of If nodes
  *           * The op or args fields of Call nodes
  *           * Inside the fields of Tuple nodes
- *    8. Expr always has checked_type_ (with the exception of Op).
+ *    10. Expr always has checked_type_ (with the exception of Op).
  */
 #include <tvm/relax/analysis.h>
 #include <tvm/relax/expr.h>

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -86,6 +86,8 @@ class WellFormedChecker : public relax::ExprVisitor,
 
   void RegisterGlobalVar(GlobalVar var) { global_var_set_.insert(var); }
 
+  void SetCurrentGlobalVar(GlobalVar var) { cur_global_var_ = var; }
+
  private:
   // Possible mode of visitor
   enum class VisitMode {
@@ -162,6 +164,13 @@ class WellFormedChecker : public relax::ExprVisitor,
   }
 
   void VisitExpr_(const FunctionNode* op) {
+    // check name in global var and gsymbol
+    Optional<String> gsymbol = op->GetAttr<String>(tvm::attr::kGlobalSymbol);
+    if (gsymbol && cur_global_var_ && gsymbol != cur_global_var_.value()->name_hint) {
+      Malformed(Diagnostic::Error(op->span)
+                << "Name in GlobalVar is not equal to name in gsymbol: "
+                << cur_global_var_.value()->name_hint << " != " << gsymbol.value());
+    }
     // save the var_set_ for local function
     auto prev_var_set = var_set_;
     auto prev_symbolic_var_set = symbolic_var_set_;
@@ -396,6 +405,7 @@ class WellFormedChecker : public relax::ExprVisitor,
   // Current visit mode.
   VisitMode mode_ = VisitMode::kDefault;
   // set of context variables.
+  Optional<GlobalVar> cur_global_var_;
   std::unordered_set<GlobalVar, ObjectPtrHash, ObjectPtrEqual> global_var_set_;
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> var_set_;
   std::unordered_set<DataflowVar, ObjectPtrHash, ObjectPtrEqual> dataflow_var_set_;
@@ -413,6 +423,7 @@ bool WellFormed(const IRModule& m, Optional<DiagnosticContext> diag_ctx) {
     // visit relax.Function
     if (auto* n = it.second.as<FunctionNode>()) {
       Function func = GetRef<Function>(n);
+      well_formed_checker.SetCurrentGlobalVar(it.first);
       well_formed_checker.VisitExpr(func);
     }
   }

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -18,6 +18,7 @@ import pytest
 import tvm
 from tvm import tir
 from tvm import relax as rx
+import tvm.script
 from tvm.script import relax as R
 
 m = tir.Var("m", "int64")
@@ -358,6 +359,20 @@ def test_ANF():
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
     assert not rx.analysis.well_formed(mod)
+
+
+def test_global_var_vs_gsymbol():
+    # Error: gsymbol "main1" not equals to the name in global var "main"
+    @tvm.script.ir_module
+    class NameDiff:
+        @R.function
+        def main(
+            x: R.Tensor((3, 3), "float32"),
+        ) -> R.Tensor:
+            R.func_attr({"global_symbol": "main1"})
+            return x
+
+    assert not rx.analysis.well_formed(NameDiff)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -18,7 +18,6 @@ import pytest
 import tvm
 from tvm import tir
 from tvm import relax as rx
-import tvm.script
 from tvm.script import relax as R
 
 m = tir.Var("m", "int64")
@@ -363,16 +362,16 @@ def test_ANF():
 
 def test_global_var_vs_gsymbol():
     # Error: gsymbol "main1" not equals to the name in global var "main"
-    @tvm.script.ir_module
-    class NameDiff:
-        @R.function
-        def main(
-            x: R.Tensor((3, 3), "float32"),
-        ) -> R.Tensor:
-            R.func_attr({"global_symbol": "main1"})
-            return x
-
-    assert not rx.analysis.well_formed(NameDiff)
+    gv0 = rx.Var("gv0", R.Tensor([m, n], "float32"))
+    bindings = [rx.VarBinding(gv0, x)]
+    blocks = [rx.DataflowBlock(bindings)]
+    func = rx.Function(
+        [x],
+        rx.SeqExpr(blocks, gv0),
+        R.Tensor(ndim=2, dtype="float32"),
+    ).with_attr("global_symbol", "main1")
+    mod = tvm.IRModule({rx.GlobalVar("main"): func})
+    assert not rx.analysis.well_formed(mod)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_function_attr.py
+++ b/tests/python/relax/test_function_attr.py
@@ -63,21 +63,20 @@ def test_func_attr_setter():
     mod = InputModule
     assert isinstance(mod, tvm.IRModule)
 
-    mod = annotate(mod, "relax_add", {"Codegen": "test-codegen", "global_symbol": "test-symbol"})
+    mod = annotate(mod, "relax_add", {"Codegen": "test-codegen"})
     _check_save_roundtrip(mod)
     annot_func = mod["relax_add"]
 
     # Test annotation
     assert annot_func.attrs
     assert annot_func.attrs["Codegen"] == "test-codegen"
-    assert annot_func.attrs["global_symbol"] == "test-symbol"
 
 
 def test_func_attr_roundtrip_and_equality():
     mod = InputModule
     assert isinstance(mod, tvm.IRModule)
-    mod1 = annotate(mod, "relax_add", {"Codegen": "test-codegen", "global_symbol": "test-symbol"})
-    mod2 = annotate(mod, "relax_add", {"Codegen": "test-codegen", "global_symbol": "test-symbol"})
+    mod1 = annotate(mod, "relax_add", {"Codegen": "test-codegen"})
+    mod2 = annotate(mod, "relax_add", {"Codegen": "test-codegen"})
     _check_save_roundtrip(mod1)
     _check_save_roundtrip(mod2)
     _check_equal(mod1, mod2)
@@ -87,7 +86,7 @@ def test_func_attr_setter_with_passes():
     mod = InputModule
     assert isinstance(mod, tvm.IRModule)
     # Annotate
-    mod = annotate(mod, "relax_add", {"Codegen": "test-codegen", "global_symbol": "test-symbol"})
+    mod = annotate(mod, "relax_add", {"Codegen": "test-codegen"})
 
     # Test with passes
     # Annotation should stay the same unless the pass needs to modify it
@@ -101,13 +100,13 @@ def test_func_attr_setter_with_passes():
 
     # Apply passes
     new_mod = seq(mod)
+    print(mod.script())
     _check_save_roundtrip(new_mod)
 
     # Test annotation
     func = new_mod["relax_add"]
     assert func.attrs
     assert func.attrs["Codegen"] == "test-codegen"
-    assert func.attrs["global_symbol"] == "test-symbol"
 
 
 def test_irmodule_attr_setter_with_passes():


### PR DESCRIPTION
This ICHECK is unnecessary and will cause some problems when building a module with `TVM_LOG_DEBUG=DEFAULT=2`:
```
x = relax.Var("x", (3, 3), relax.DynTensorType(ndim=2, dtype="float32"))

bb = relax.BlockBuilder()
with bb.function("main", [x]):
    with bb.dataflow():
        out = x
    bb.emit_func_output(out)

ex = relax.vm.build(bb.get(), tvm.target.Target("llvm"))
```
```
/src/printer/relax_script_printer.cc", line 353:
TVMError:
---------------------------------------------------------------
An error occurred during the execution of TVM.
For more information, please see: https://tvm.apache.org/docs/errors.html
---------------------------------------------------------------

  Check failed: gsymbol.value() == relax_func_name_ (main vs. foo) :
```