### PR TITLE
[Analysis] Optionally check structure info in well-formedness check

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -200,8 +200,8 @@ TVM_DLL StructInfo EraseToWellDefined(const StructInfo& info, Map<tir::Var, Prim
  *
  * For a given pair of lhs_struct_info, rhs_struct_info. We adopt
  * the following terminology:
- * - LSet = {value | value mactches lhs_struct_info}
- * - RSet = {value | value mactches rhs_struct_info}
+ * - LSet = {value | value matches lhs_struct_info}
+ * - RSet = {value | value matches rhs_struct_info}
  *
  * See the definition of each level below.
  */
@@ -283,11 +283,14 @@ TVM_DLL StructInfo StructInfoLCA(const StructInfo& lhs, const StructInfo& rhs,
  * \brief Check if the IRModule is well formed.
  *
  * \param m the IRModule to check.
- * \param diag_ctx the diagnostic context.
+ * \param check_struct_info A boolean flag indicating if the property "every Expr
+ * must have defined structure info" will be checked.
  * \return true if the IRModule is well formed, false if not.
+ * \note By default the structure info is always checked. It is only in test cases
+ * where `check_struct_info` might be false, so that other well-formed requirements
+ * will be well tested and will not be blocked by not having structure info.
  */
-TVM_DLL bool WellFormed(const IRModule& m,
-                        Optional<DiagnosticContext> diag_ctx = Optional<DiagnosticContext>());
+TVM_DLL bool WellFormed(IRModule m, bool check_struct_info = true);
 
 /*!
  * \brief Annotate Op Pattern Kind for PrimFunc, which is used in relax FuseOps.
@@ -346,7 +349,7 @@ TVM_DLL tvm::Array<Var> FreeVars(const Expr& expr);
 TVM_DLL tvm::Array<Var> AllVars(const Expr& expr);
 
 /*!
- * \brief Get all glabal variables used in calls in expression expr.
+ * \brief Get all global variables used in calls in expression expr.
  *
  * \param expr the expression.
  *
@@ -355,7 +358,7 @@ TVM_DLL tvm::Array<Var> AllVars(const Expr& expr);
 TVM_DLL tvm::Array<GlobalVar> CalledGlobalVars(const Expr& expr);
 
 /*!
- * \brief Get all glabal variables from expression expr.
+ * \brief Get all global variables from expression expr.
  *
  * AllVars is a superset of BoundVars and FreeVars.
  * The union of BoundVars and FreeVars is Allvars.
@@ -402,7 +405,7 @@ TVM_DLL Map<String, Array<Binding>> NameToBinding(const Function& fn);
  * \brief Get the use-def chain of variables inside a dataflow block.
  *
  * \param dfb The dataflow block to be analyzed.
- * \return A map mapping variable definitoins to a set of uses.
+ * \return A map mapping variable definitions to a set of uses.
  */
 TVM_DLL Map<Var, Array<Var>> DataflowBlockUseDef(const DataflowBlock& dfb);
 
@@ -410,7 +413,7 @@ TVM_DLL Map<Var, Array<Var>> DataflowBlockUseDef(const DataflowBlock& dfb);
  * \brief Get the use-def chain of variables inside a function.
  *
  * \param fn The function to be analyzed.
- * \return A map from variable definitoins to a set of uses and variables needed by return value.
+ * \return A map from variable definitions to a set of uses and variables needed by return value.
  */
 std::pair<Map<Var, Array<Var>>, Array<Var>> FunctionUseDef(const Function& fn);
 

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -197,7 +197,7 @@ def post_order_visit(expr, fvisit):
     return _ffi_api.post_order_visit(expr, fvisit)  # type: ignore
 
 
-def well_formed(mod: tvm.IRModule) -> bool:
+def well_formed(mod: tvm.IRModule, check_struct_info: bool = True) -> bool:
     """Check if the IRModule is well formed.
 
     Parameters
@@ -205,12 +205,22 @@ def well_formed(mod: tvm.IRModule) -> bool:
     mod : tvm.IRModule
         The input IRModule.
 
+    check_struct_info : bool
+        A boolean flag indicating if the property "every Expr must
+        have defined structure info" will be checked.
+
     Returns
     -------
     ret: bool
         True if the IRModule is well formed, False if not.
+
+    Note
+    ----
+    By default the structure info is always checked. It is only in test cases
+    where `check_struct_info` might be false, so that other well-formed requirements
+    will be well tested and will not be blocked by not having structure info.
     """
-    return _ffi_api.well_formed(mod)  # type: ignore
+    return _ffi_api.well_formed(mod, check_struct_info)  # type: ignore
 
 
 def get_var2val(func: Function) -> Dict[Var, Expr]:

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -44,7 +44,7 @@ def test_var():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
     # Error: Var gv0 is defined more than once
     gv0 = rx.Var("gv0", R.Tensor([m, n], "float32"))
@@ -54,7 +54,7 @@ def test_var():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
 
 def test_dataflow_var():
@@ -66,7 +66,7 @@ def test_dataflow_var():
     blocks = [rx.DataflowBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
     # Error: DataflowVar gv0 is defined more than once
     lv0 = rx.DataflowVar("lv0", R.Tensor([m, n], "float32"))
@@ -76,7 +76,7 @@ def test_dataflow_var():
     blocks = [rx.DataflowBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
     # Error: DataflowVar lv0 is defined outside DataflowBlock
     lv0 = rx.DataflowVar("lv0", R.Tensor([m, n], "float32"))
@@ -85,7 +85,7 @@ def test_dataflow_var():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
     # Error: DataflowVar lv0 is used outside DataflowBlock
     lv0 = rx.DataflowVar("lv0", R.Tensor([m, n], "float32"))
@@ -95,7 +95,7 @@ def test_dataflow_var():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
 
 def test_global_var():
@@ -110,7 +110,7 @@ def test_global_var():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
 
 def test_symbolic_var():
@@ -122,7 +122,7 @@ def test_symbolic_var():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
 
 def test_symbolic_var_invalid_type():
@@ -137,7 +137,7 @@ def test_symbolic_var_invalid_type():
         blocks = [rx.BindingBlock(bindings)]
         func = build_function(blocks, [y])
         mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-        assert not rx.analysis.well_formed(mod)
+        assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
 
 def test_seq_expr():
@@ -154,7 +154,7 @@ def test_seq_expr():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
 
 def test_if():
@@ -186,7 +186,7 @@ def test_if():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=True)
 
 
 def test_if_non_seq_body():
@@ -204,7 +204,7 @@ def test_if_non_seq_body():
     ]
     func = build_function(blocks)
     mod = tvm.IRModule.from_expr(func)
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
     # on the other hand, if they're wrapped in a seq node, it's fine
     seq = rx.SeqExpr([], x)
@@ -223,7 +223,7 @@ def test_if_non_seq_body():
     new_mod = tvm.IRModule.from_expr(new_func)
     # apply normalization to fill in checked_type_
     normalized = rx.transform.Normalize()(new_mod)
-    assert rx.analysis.well_formed(normalized)
+    assert rx.analysis.well_formed(normalized, check_struct_info=True)
 
 
 def test_if_complex_condition():
@@ -243,7 +243,7 @@ def test_if_complex_condition():
     ]
     func = build_function(blocks)
     mod = tvm.IRModule.from_expr(func)
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
     cond_var = rx.Var("q", R.Tensor([], "bool"))
     new_if = rx.If(cond_var, rx.SeqExpr([], x), rx.SeqExpr([], x))
@@ -262,7 +262,7 @@ def test_if_complex_condition():
     mod = tvm.IRModule.from_expr(func)
     # apply normalization to fill in checked_type_
     normalized = rx.transform.Normalize()(mod)
-    assert rx.analysis.well_formed(normalized)
+    assert rx.analysis.well_formed(normalized, check_struct_info=True)
 
 
 def test_tuple_get_item_nested():
@@ -279,7 +279,7 @@ def test_tuple_get_item_nested():
     )
     f = f.with_attr("global_symbol", "f")
     mod = tvm.IRModule.from_expr(f)
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
     # okay with an intermediate binding
     first_idx = rx.TupleGetItem(nested_tup, 0)
@@ -301,7 +301,7 @@ def test_tuple_get_item_nested():
     mod = tvm.IRModule.from_expr(new_f)
     # normalize in order to fill in checked type
     normalized = rx.transform.Normalize()(mod)
-    assert rx.analysis.well_formed(normalized)
+    assert rx.analysis.well_formed(normalized, check_struct_info=True)
 
 
 def test_complex_seq_body():
@@ -314,7 +314,7 @@ def test_complex_seq_body():
         R.Tensor(ndim=0, dtype="int32"),
     ).with_attr("global_symbol", "foo")
     mod = tvm.IRModule.from_expr(func)
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
     # but if the result is bound, then it's okay
     z = rx.Var("z", R.Tensor([], "int32"))
@@ -338,7 +338,7 @@ def test_complex_seq_body():
     new_mod = tvm.IRModule.from_expr(new_func)
     # normalize in order to fill in checked type
     normalized = rx.transform.Normalize()(new_mod)
-    assert rx.analysis.well_formed(normalized)
+    assert rx.analysis.well_formed(normalized, check_struct_info=True)
 
 
 def test_ANF():
@@ -349,7 +349,7 @@ def test_ANF():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
     # Error: Call Node in Tuple
     gv0 = rx.Var("gv0", R.Tensor([m, n], "float32"))
@@ -357,7 +357,7 @@ def test_ANF():
     blocks = [rx.BindingBlock(bindings)]
     func = build_function(blocks)
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
 
 def test_global_var_vs_gsymbol():
@@ -371,7 +371,7 @@ def test_global_var_vs_gsymbol():
         R.Tensor(ndim=2, dtype="float32"),
     ).with_attr("global_symbol", "main1")
     mod = tvm.IRModule({rx.GlobalVar("main"): func})
-    assert not rx.analysis.well_formed(mod)
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With the introduction of structure info in #314, the well-formedness check will report malformed whenever an Expr doesn’t have defined structure info.

However, when writing tests for well-formedness check and normalizer, usually we will manually construct the Exprs, which means their structure info are not defined most of the time. As a consequence, the well-formedness check will always complain “the Expr xxx doesn’t have structure info populated.” Therefore, when the checker fails to complain about the original reason of malformed, which means the checker is not working, the tests will still pass and we won’t be able to realize there is something wrong with the checker.

Thus, in this PR we add an optional flag to the well-formedness check. In well-formedness tests, we will turn off the structure info check so that the original reason of being malformed will be revealed correctly.

---

This PR also cleans up the DiagnosticContext parameter in the `WellFormed` API - the `diag_ctx` has been unused since the merge of #99.

---

cc @tqchen @SiriusNEO @slyubomirsky @YuchenJin 