### PR TITLE
[REFACTOR] StructInfo M3: MatchShape=>MatchCast

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -160,15 +160,6 @@ class BlockBuilderNode : public Object {
   virtual Var Emit(Expr expr, String name_hint = "") = 0;
 
   /*!
-   * \brief Emit a MatchShape.
-   * \param value The value of the MatchShape to be emitted.
-   * \param pattern The pattern of the MatchShape to be emitted.
-   * \param name_hint Name hint for the bound variable.
-   * \return The variable bound to the MatchShape.
-   */
-  virtual Var EmitMatchShape(Expr value, Array<PrimExpr> pattern, String name_hint = "") = 0;
-
-  /*!
    * \brief Emit a MatchCast.
    * \param value The input value.
    * \param struct_info The struct info to be matched.

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -169,6 +169,15 @@ class BlockBuilderNode : public Object {
   virtual Var EmitMatchShape(Expr value, Array<PrimExpr> pattern, String name_hint = "") = 0;
 
   /*!
+   * \brief Emit a MatchCast.
+   * \param value The input value.
+   * \param struct_info The struct info to be matched.
+   * \param name_hint Name hint for the bound variable.
+   * \return The variable bound to the MatchCast.
+   */
+  virtual Var EmitMatchCast(Expr value, StructInfo struct_info, String name_hint = "") = 0;
+
+  /*!
    * \brief Generate an output for the current dataflow block.
    * \param output The output variable of the block.
    * \param name_hint Name hint for the bound variable.

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -214,6 +214,7 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
   // specific leaf level visitor functions
   virtual void VisitBinding_(const VarBindingNode* binding);
   virtual void VisitBinding_(const MatchShapeNode* binding);
+  virtual void VisitBinding_(const MatchCastNode* binding);
   // second level dispatching based on binding value type.
   // these dispatching functions get called from first-level dispatch on VarBinding
   virtual void VisitBinding_(const VarBindingNode* binding, const ConstantNode* val);
@@ -339,6 +340,7 @@ class ExprMutator : public ExprMutatorBase {
   // specific leaf level visitor functions
   virtual void VisitBinding_(const VarBindingNode* binding);
   virtual void VisitBinding_(const MatchShapeNode* binding);
+  virtual void VisitBinding_(const MatchCastNode* binding);
   // second level dispatching based on binding value type.
   // these dispatching functions get called from first-level dispatch on VarBinding
   virtual void VisitBinding_(const VarBindingNode* binding, const ConstantNode* val);

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -29,9 +29,8 @@
 #include <tvm/node/functor.h>
 #include <tvm/relax/block_builder.h>
 #include <tvm/relax/expr.h>
-#include <tvm/relay/adt.h>
-#include <tvm/relay/expr.h>
-#include <tvm/relay/function.h>
+#include <tvm/relax/struct_info.h>
+#include <tvm/relax/struct_info_functor.h>
 #include <tvm/relay/op.h>
 #include <tvm/tir/function.h>
 
@@ -244,6 +243,23 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
    * \note VisitExpr_(const VarNode*) will only visit the usage site of an Var
    */
   virtual void VisitVarDef(const Var& var);
+
+  /*!
+   * \brief Visit struct_info may recursively contain Expr/PrimExpr.
+   *
+   * By default, this function recurse into struct info such as
+   * TensorStructInfo and ShapeStructInfo and call VisitExpr/VisitPrimExpr
+   * accordingly. It does not recurse into FunctionStructInfo as it does
+   * not contain Expr defined in the current scope.
+   *
+   * Pass writers can overload this function to change to other behaviors.
+   * For example, if we are not interested in Expr in StructInfo, we can
+   * override this function by a no-op.
+   *
+   * \param struct_info Input struct info field.
+   */
+  virtual void VisitExprDepStructInfoField(const StructInfo& struct_info);
+
   // specific leaf level visitor functions
   virtual void VisitVarDef_(const VarNode* var);
   virtual void VisitVarDef_(const DataflowVarNode* var);
@@ -258,6 +274,30 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
       tvm::NodeFunctor<void(const ObjectRef& n, ExprVisitor* self, const VarBindingNode* binding)>;
   // initialize the vtable.
   static VisitBindingVTable InitVisitBindingVTable();
+  /*!
+   * \brief Private internal struct info field visitor.
+   *
+   *  Support default visiting of struct info field and recursive into
+   *  their Expr fields.
+   *
+   *  We use component instead of sub-classing so there can be other
+   *  joint inheritance between ExprVisitor and StructInfoVisitor.
+   */
+  class DefaultStructInfoFieldVisitor : public StructInfoVisitor {
+   public:
+    explicit DefaultStructInfoFieldVisitor(ExprVisitor* parent);
+
+    // Override defaults in struct info visitor.
+    void VisitStructInfoExprField(const Expr& expr) final;
+    void VisitStructInfoExprField(const PrimExpr& expr) final;
+    void VisitStructInfo_(const FuncStructInfoNode* op) final;
+
+   private:
+    ExprVisitor* parent_;
+  };
+  // This visitor is not visible to child classes and only
+  // used to supportd default visiting behavior.
+  DefaultStructInfoFieldVisitor default_struct_info_field_visitor_{this};
 };
 
 void PostOrderVisit(const Expr& node, std::function<void(const Expr&)> fvisit);
@@ -309,6 +349,64 @@ class ExprMutatorBase : public ExprFunctor<Expr(const Expr&)> {
    * Can be overloaded to transform the shape expressions.
    */
   virtual PrimExpr VisitPrimExpr(const PrimExpr& expr);
+
+  /*!
+   * \brief Visit struct_info that may recursively contain Expr/PrimExpr.
+   *
+   * By default, this function recurse into struct info such as
+   * TensorStructInfo and ShapeStructInfo and call VisitExpr/VisitPrimExpr
+   * accordingly. It does not recurse into FunctionStructInfo as it does
+   * not contain Expr defined in the current scope.
+   *
+   * Pass writers can overload this function to change to other behaviors.
+   * For example, if in Expr in StructInfo won't change, we can
+   * override this function by an identity function.
+   *
+   * \param struct_info Input struct info field.
+   * \return The updated struct info.
+   */
+  virtual StructInfo VisitExprDepStructInfoField(const StructInfo& struct_info);
+
+ protected:
+  /*!
+   * \brief Check whether VisitExprDepStructInfoField change struct_info.
+   * \return Whether struct info changed.
+   * \note This function is used by mutator implementations to check if
+   *       previous Expr update will trigger a change in struct_info.
+   *       If change is detected, the implementation can generate a fresh
+   *       node without struct_info, and trigger normalizer to re-derive.
+   */
+  bool VisitAndCheckStructInfoFieldUnchanged(const ObjectRef& struct_info) {
+    if (const StructInfoNode* sinfo = struct_info.as<StructInfoNode>()) {
+      return this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo)).same_as(struct_info);
+    } else {
+      return true;
+    }
+  }
+
+ private:
+  /*!
+   * \brief Private internal struct info field visitor to support
+   *  Default visiting of struct info field and recursive into their Expr fields.
+   *
+   *  We use component instead of sub-classing so there can be other
+   *  joint inheritance between ExprMutator and StructInfoMutator.
+   */
+  class DefaultStructInfoFieldMutator : public StructInfoMutator {
+   public:
+    explicit DefaultStructInfoFieldMutator(ExprMutatorBase* parent);
+
+    // Override defaults in struct info visitor.
+    Expr VisitStructInfoExprField(const Expr& expr) final;
+    PrimExpr VisitStructInfoExprField(const PrimExpr& expr) final;
+    StructInfo VisitStructInfo_(const FuncStructInfoNode* op) final;
+
+   private:
+    ExprMutatorBase* parent_;
+  };
+  // This visitor is not visible to child classes and only
+  // used to supportd default visiting behavior.
+  DefaultStructInfoFieldMutator default_struct_info_field_mutator_{this};
 };
 
 /*!
@@ -324,7 +422,6 @@ class ExprMutator : public ExprMutatorBase {
 
   ExprMutator(Optional<IRModule> mod = NullOpt) { builder_ = BlockBuilder::Create(mod); }
   Expr VisitExpr(const Expr& expr) override;
-  Expr VisitExpr_(const TupleNode* op) override;
   Expr VisitExpr_(const VarNode* op) override;
   Expr VisitExpr_(const DataflowVarNode* op) override;
   Expr VisitExpr_(const FunctionNode* op) override;

--- a/include/tvm/relax/ir_functor.h
+++ b/include/tvm/relax/ir_functor.h
@@ -78,6 +78,7 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
   virtual R VisitNode_(const relax::DataflowVarNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::ShapeExprNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::MatchShapeNode* op, Args... args) IR_FUNCTOR_DEFAULT;
+  virtual R VisitNode_(const relax::MatchCastNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::VarBindingNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::BindingBlockNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::DataflowBlockNode* op, Args... args) IR_FUNCTOR_DEFAULT;
@@ -104,6 +105,7 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
     RELAX_IR_FUNCTOR_DISPATCH(relax::DataflowVarNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::ShapeExprNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::MatchShapeNode);
+    RELAX_IR_FUNCTOR_DISPATCH(relax::MatchCastNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::VarBindingNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::BindingBlockNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::DataflowBlockNode);

--- a/include/tvm/relax/ir_functor.h
+++ b/include/tvm/relax/ir_functor.h
@@ -77,7 +77,6 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
   virtual R VisitNode_(const relax::VarNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::DataflowVarNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::ShapeExprNode* op, Args... args) IR_FUNCTOR_DEFAULT;
-  virtual R VisitNode_(const relax::MatchShapeNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::MatchCastNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::VarBindingNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::BindingBlockNode* op, Args... args) IR_FUNCTOR_DEFAULT;
@@ -104,7 +103,6 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
     RELAX_IR_FUNCTOR_DISPATCH(relax::VarNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::DataflowVarNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::ShapeExprNode);
-    RELAX_IR_FUNCTOR_DISPATCH(relax::MatchShapeNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::MatchCastNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::VarBindingNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::BindingBlockNode);

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -111,15 +111,13 @@ TVM_DLL void DataflowBlockOutput(const Array<tvm::relax::Var>& vars);
 TVM_DLL tvm::relax::Var Emit(const tvm::relax::Expr& value);
 
 /*!
- * \brief Emit a match_shape binding to the last binding block frame.
- * \param value The value of the MatchShape to be emitted.
- * \param pattern The pattern of the MatchShape to be emitted.
- * \param emit_var A boolean indicating if the MatchShape contains the emitted variable.
- * \return The emitted var if `emit_var` is true. Otherwise, return `NullOpt`.
+ * \brief Emit a match_cast binding to the last binding block frame.
+ * \param value The value of the MatchCast to be emitted.
+ * \param struct_info The struct info of the MatchCast to be emitted.
+ * \return The left side var of the emitted binding.
  */
-TVM_DLL Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value,   //
-                                                 const Array<PrimExpr>& pattern,  //
-                                                 bool emit_var);
+TVM_DLL tvm::relax::Var EmitMatchCast(const tvm::relax::Expr& value,
+                                      const tvm::relax::StructInfo& struct_info);
 
 ///////////////////////////// Type Deduce //////////////////////////////
 

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -28,6 +28,7 @@ from . import expr_functor
 from . import struct_info
 
 # Expr
+
 from .expr import (
     Expr,
     Span,

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -38,7 +38,7 @@ from .expr import (
     Var,
     DataflowVar,
     Binding,
-    MatchShape,
+    MatchCast,
     VarBinding,
     BindingBlock,
     DataflowBlock,

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -35,6 +35,7 @@ from .expr import (
     BaseFunc,
     Binding,
 )
+from .struct_info import StructInfo
 from .op.base import call_tir
 from . import _ffi_api
 
@@ -557,6 +558,24 @@ class BlockBuilder(Object):
             A newly created variable that gets bound to the call code.
         """
         return _ffi_api.BlockBuilderEmitMatchShape(self, value, pattern)  # type: ignore
+
+    def match_cast(self, value: Expr, struct_info: StructInfo) -> Var:
+        """Emit a MatchCast.
+
+        Parameters
+        ----------
+        value : tvm.relax.Expr
+            The value of the MatchShape to be emitted.
+
+        struct_info : StructInfo
+            The struct info to be matched.
+
+        Returns
+        -------
+        ret : tvm.relax.Var
+            A newly created variable that get bounds to be the casted result.
+        """
+        return _ffi_api.BlockBuilderEmitMatchCast(self, value, struct_info)  # type: ignore
 
     def emit_output(self, output: Union[Expr, Tuple, List[Expr]]) -> None:
         """Emit output for the current dataflow block or function.

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -29,7 +29,6 @@ from .expr import (
     Var,
     ShapeExpr,
     GlobalVar,
-    PrimExpr,
     BindingBlock,
     Tuple,
     BaseFunc,

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -541,31 +541,13 @@ class BlockBuilder(Object):
         """
         return self.emit(self.call_te(func, *args, **kwargs))
 
-    def match_shape(self, value: Expr, pattern: List[PrimExpr]) -> Var:
-        """Emit a MatchShape.
-
-        Parameters
-        ----------
-        value : tvm.relax.Expr
-            The value of the MatchShape to be emitted.
-
-        pattern : List[PrimExpr]
-            The pattern of the MatchShape to be emitted.
-
-        Returns
-        -------
-        ret : tvm.relax.Var
-            A newly created variable that gets bound to the call code.
-        """
-        return _ffi_api.BlockBuilderEmitMatchShape(self, value, pattern)  # type: ignore
-
     def match_cast(self, value: Expr, struct_info: StructInfo) -> Var:
         """Emit a MatchCast.
 
         Parameters
         ----------
         value : tvm.relax.Expr
-            The value of the MatchShape to be emitted.
+            The value of the MatchCast to be emitted.
 
         struct_info : StructInfo
             The struct info to be matched.

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -308,20 +308,6 @@ class Binding(Node):
     ...
 
 
-@tvm._ffi.register_object("relax.expr.MatchShape")
-class MatchShape(Binding):
-    """Symbolic shape match, binds the variable of the lhs with the rhs."""
-
-    value: Expr
-    pattern: List[PrimExpr]
-    var: Var
-
-    def __init__(self, value: Expr, pattern: List[PrimExpr], var: Var, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(
-            _ffi_api.MatchShape, value, pattern, var, span  # type: ignore
-        )
-
-
 @tvm._ffi.register_object("relax.expr.MatchCast")
 class MatchCast(Binding):
     """Runtime-match the value to the struct info.
@@ -335,24 +321,22 @@ class MatchCast(Binding):
     var: Var
         The return variable that the match cast bind to.
 
-    struct_info: tvm.relax.StructInfo
-        The struct info to match cast to.
-
     value: Expr
         The input value expression.
+
+    struct_info: tvm.relax.StructInfo
+        The struct info to match cast to.
     """
 
     var: Var
     struct_info: "tvm.relax.StructInfo"
     value: Expr
 
-    def __init__(self,
-                 var: Var,
-                 struct_info: "tvm.relax.StructInfo",
-                 value: Expr,
-                 span: Span = None) -> None:
+    def __init__(
+        self, var: Var, value: Expr, struct_info: "tvm.relax.StructInfo", span: Span = None
+    ) -> None:
         self.__init_handle_by_constructor__(
-            _ffi_api.MatchCast, var, struct_info, value, span  # type: ignore
+            _ffi_api.MatchCast, var, value, struct_info, span  # type: ignore
         )
 
 

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -322,6 +322,40 @@ class MatchShape(Binding):
         )
 
 
+@tvm._ffi.register_object("relax.expr.MatchCast")
+class MatchCast(Binding):
+    """Runtime-match the value to the struct info.
+
+    This operation does runtime check, populates the un-defined symbolic shape vars
+    and vars in struct_info in the first occurrence, and insert equality assertions in
+    other cases.
+
+    Parameters
+    ----------
+    var: Var
+        The return variable that the match cast bind to.
+
+    struct_info: tvm.relax.StructInfo
+        The struct info to match cast to.
+
+    value: Expr
+        The input value expression.
+    """
+
+    var: Var
+    struct_info: "tvm.relax.StructInfo"
+    value: Expr
+
+    def __init__(self,
+                 var: Var,
+                 struct_info: "tvm.relax.StructInfo",
+                 value: Expr,
+                 span: Span = None) -> None:
+        self.__init_handle_by_constructor__(
+            _ffi_api.MatchCast, var, struct_info, value, span  # type: ignore
+        )
+
+
 @tvm._ffi.register_object("relax.expr.VarBinding")
 class VarBinding(Binding):
     """Variable binding, bind he variable of the lhs with the rhs."""

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -29,7 +29,7 @@ from .expr import Constant, Var, DataflowVar
 from .expr import ShapeExpr
 from .expr import GlobalVar, SeqExpr, Tuple
 from .expr import Call, If, TupleGetItem
-from .expr import Binding, MatchShape, VarBinding
+from .expr import Binding, MatchCast, VarBinding
 from .expr import BindingBlock, DataflowBlock
 from .struct_info import StructInfo
 from ..relay import Id
@@ -190,7 +190,7 @@ class ExprFunctor:
     def visit_var_binding_(self, binding: VarBinding):
         raise NotImplementedError()
 
-    def visit_match_shape_(self, binding: MatchShape):
+    def visit_match_cast_(self, binding: MatchCast):
         raise NotImplementedError()
 
     def visit_binding_block_(self, block: BindingBlock):
@@ -206,8 +206,8 @@ class ExprFunctor:
         raise NotImplementedError()
 
     def visit_binding(self, binding: Binding):
-        if isinstance(binding, MatchShape):
-            self.visit_match_shape_(binding)
+        if isinstance(binding, MatchCast):
+            self.visit_match_cast_(binding)
         elif isinstance(binding, VarBinding):
             self.visit_var_binding_(binding)
         else:
@@ -259,7 +259,7 @@ class _PyExprVisitor(Object):
         f_visit_tuple_getitem_: Callable = None,
         f_visit_binding: Callable = None,
         f_visit_var_binding_: Callable = None,
-        f_visit_match_shape_: Callable = None,
+        f_visit_match_cast_: Callable = None,
         f_visit_binding_block: Callable = None,
         f_visit_binding_block_: Callable = None,
         f_visit_dataflow_block_: Callable = None,
@@ -289,7 +289,7 @@ class _PyExprVisitor(Object):
             f_visit_tuple_getitem_,
             f_visit_binding,
             f_visit_var_binding_,
-            f_visit_match_shape_,
+            f_visit_match_cast_,
             f_visit_binding_block,
             f_visit_binding_block_,
             f_visit_dataflow_block_,
@@ -378,7 +378,7 @@ class PyExprVisitor:
             "visit_tuple_getitem_",
             "visit_binding",
             "visit_var_binding_",
-            "visit_match_shape_",
+            "visit_match_cast_",
             "visit_binding_block",
             "visit_binding_block_",
             "visit_dataflow_block_",
@@ -623,15 +623,15 @@ class PyExprVisitor:
         # Using self._outer() to ref _PyExprVisitor
         return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)  # type: ignore
 
-    def visit_match_shape_(self, binding: MatchShape) -> None:
-        """Visit MatchShape.
-        Users can customized this function to overwrite VisitBinding_(const MatchShapeNode* binding)
+    def visit_match_cast_(self, binding: MatchCast) -> None:
+        """Visit MatchCast.
+        Users can customized this function to overwrite VisitBinding_(const MatchCastNode* binding)
         on the C++ side.
 
         Parameters
         ----------
-        binding : MatchShape
-            The MatchShape to be visited.
+        binding : MatchCast
+            The MatchCast to be visited.
         """
         # Using self._outer() to ref _PyExprVisitor
         return _ffi_api.ExprVisitorVisitBinding(self._outer(), binding)  # type: ignore
@@ -743,7 +743,7 @@ class _PyExprMutator(Object):
         f_visit_tuple_getitem_: Callable = None,
         f_visit_binding: Callable = None,
         f_visit_var_binding_: Callable = None,
-        f_visit_match_shape_: Callable = None,
+        f_visit_match_cast_: Callable = None,
         f_visit_binding_block: Callable = None,
         f_visit_binding_block_: Callable = None,
         f_visit_dataflow_block_: Callable = None,
@@ -774,7 +774,7 @@ class _PyExprMutator(Object):
             f_visit_tuple_getitem_,
             f_visit_binding,
             f_visit_var_binding_,
-            f_visit_match_shape_,
+            f_visit_match_cast_,
             f_visit_binding_block,
             f_visit_binding_block_,
             f_visit_dataflow_block_,
@@ -879,7 +879,7 @@ class PyExprMutator:
             "visit_tuple_getitem_",
             "visit_binding",
             "visit_var_binding_",
-            "visit_match_shape_",
+            "visit_match_cast_",
             "visit_binding_block",
             "visit_binding_block_",
             "visit_dataflow_block_",
@@ -1208,15 +1208,15 @@ class PyExprMutator:
         # Using self._outer() to ref _PyExprMutator
         return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)  # type: ignore
 
-    def visit_match_shape_(self, binding: MatchShape) -> None:
-        """Visit MatchShape.
-        Users can customized this function to overwrite VisitBinding_(const MatchShapeNode* binding)
+    def visit_match_cast_(self, binding: MatchCast) -> None:
+        """Visit MatchCast.
+        Users can customized this function to overwrite VisitBinding_(const MatchCastNode* binding)
         on the C++ side.
 
         Parameters
         ----------
-        binding : MatchShape
-            The MatchShape to be visited.
+        binding : MatchCast
+            The MatchCast to be visited.
         """
         # Using self._outer() to ref _PyExprMutator
         return _ffi_api.ExprMutatorVisitBinding(self._outer(), binding)  # type: ignore

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -312,24 +312,22 @@ class ASTPrinter(ExprFunctor):
         """
         Distinguish between binding types
         """
-        if isinstance(binding, relax.MatchShape):
-            return self.visit_match_shape_(binding)
+        if isinstance(binding, relax.MatchCast):
+            return self.visit_match_cast_(binding)
         if isinstance(binding, relax.VarBinding):
             return self.visit_var_binding_(binding)
         raise ValueError(f"Invalid binding type in {binding}: {type(binding)}")
 
-    def visit_match_shape_(self, match_shape: relax.MatchShape) -> str:
+    def visit_match_cast_(self, match_cast: relax.MatchCast) -> str:
         """
         Handle match shape
         """
         fields = {
-            "value": self.visit_expr(match_shape.value),
-            "pattern": self.build_list(map(self.visit_prim_expr_, match_shape.pattern)),
+            "var": self.visit_expr(match_cast.var),
+            "value": self.visit_expr(match_cast.value),
+            "struct_info": self.visit_struct_info_(match_cast.struct_info),
         }
-        # not always defined
-        if match_shape.var:
-            fields["var"] = self.visit_expr(match_shape.var)
-        return self.build_ast_node("MatchShape", **fields)
+        return self.build_ast_node("MatchCast", **fields)
 
     def visit_var_binding_(self, var_binding: relax.VarBinding) -> str:
         """

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -281,25 +281,6 @@ def emit(value: Expr) -> Var:
     return _ffi_api.Emit(value)  # pylint: disable=no-member # type: ignore
 
 
-def emit_match_shape(value: Expr, pattern: List[PrimExpr], emit_var: bool) -> Optional[Var]:
-    """Emit a match_shape binding to the last binding block frame.
-    Parameters
-    ----------
-    value: Expr
-        The value of the MatchShape to be emitted.
-    pattern: List[PrimExpr]
-        The pattern of the MatchShape to be emitted.
-    emit_var: bool
-        A boolean indicating if the MatchShape contains the emitted variable.
-
-    Returns
-    -------
-    var: Optional[Var]
-        The emitted var if `emit_var` is True. Otherwise, return `None`.
-    """
-    return _ffi_api.EmitMatchShape(value, pattern, emit_var)  # type: ignore
-
-
 def emit_match_cast(value: Expr, struct_info: StructInfo) -> Var:
     """Emit a match_cast binding to the last binding block frame.
     Parameters
@@ -425,7 +406,6 @@ __all__ = [
     "dataflow",
     "emit",
     "emit_match_cast",
-    "emit_match_shape",
     "ewise_fma",
     "func_attr",
     "func_name",

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -300,6 +300,23 @@ def emit_match_shape(value: Expr, pattern: List[PrimExpr], emit_var: bool) -> Op
     return _ffi_api.EmitMatchShape(value, pattern, emit_var)  # type: ignore
 
 
+def emit_match_cast(value: Expr, struct_info: StructInfo) -> Var:
+    """Emit a match_cast binding to the last binding block frame.
+    Parameters
+    ----------
+    value: Expr
+        The value of the MatchCast to be emitted.
+    struct_info: StructInfo
+        The struct_info of the MatchCast to be emitted.
+
+    Returns
+    -------
+    var: Var
+        The left side var of the emitted binding.
+    """
+    return _ffi_api.EmitMatchCast(value, struct_info)  # type: ignore
+
+
 ############################# Type Deduce ##############################
 
 
@@ -407,6 +424,7 @@ __all__ = [
     "const",
     "dataflow",
     "emit",
+    "emit_match_cast",
     "emit_match_shape",
     "ewise_fma",
     "func_attr",

--- a/python/tvm/script/parser/relax/__init__.py
+++ b/python/tvm/script/parser/relax/__init__.py
@@ -18,7 +18,7 @@
 from ...ir_builder.relax import *  # pylint: disable=redefined-builtin
 from ...ir_builder.relax import ir as _relax
 from . import parser as _parser
-from .entry import Callable, Shape, Tensor, Tuple, function, match_cast, match_shape
+from .entry import Callable, Shape, Tensor, Tuple, function, match_cast
 
 __all__ = _relax.__all__ + [
     "Callable",
@@ -27,5 +27,4 @@ __all__ = _relax.__all__ + [
     "Tuple",
     "function",
     "match_cast",
-    "match_shape",
 ]

--- a/python/tvm/script/parser/relax/__init__.py
+++ b/python/tvm/script/parser/relax/__init__.py
@@ -18,6 +18,14 @@
 from ...ir_builder.relax import *  # pylint: disable=redefined-builtin
 from ...ir_builder.relax import ir as _relax
 from . import parser as _parser
-from .entry import Callable, Shape, Tensor, Tuple, function, match_shape
+from .entry import Callable, Shape, Tensor, Tuple, function, match_cast, match_shape
 
-__all__ = _relax.__all__ + ["Callable", "Shape", "Tensor", "Tuple", "function", "match_shape"]
+__all__ = _relax.__all__ + [
+    "Callable",
+    "Shape",
+    "Tensor",
+    "Tuple",
+    "function",
+    "match_cast",
+    "match_shape",
+]

--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -193,3 +193,21 @@ def match_shape(value: Expr, pattern: List[PrimExpr]):
     if pattern is None:
         raise ValueError("pattern of match_shape cannot be None")
     return MatchShapePair(value, pattern)
+
+
+############################ R.match_cast #############################
+class MatchCastPair:
+    value: Expr
+    struct_info: StructInfo
+
+    def __init__(self, value: Expr, struct_info: StructInfo) -> None:
+        self.value = value
+        self.struct_info = struct_info
+
+
+def match_cast(value: Expr, struct_info: StructInfo):
+    if value is None:
+        raise ValueError("value of match_cast cannot be None")
+    if struct_info is None:
+        raise ValueError("struct_info of match_cast cannot be None")
+    return MatchCastPair(value, struct_info)

--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -177,23 +177,6 @@ class ShapeProxy:
 
 Shape = ShapeProxy()
 
-############################ R.match_shape #############################
-class MatchShapePair:
-    value: Expr
-    pattern: List[PrimExpr]
-
-    def __init__(self, value: Expr, pattern: List[PrimExpr]) -> None:
-        self.value = value
-        self.pattern = pattern
-
-
-def match_shape(value: Expr, pattern: List[PrimExpr]):
-    if value is None:
-        raise ValueError("value of match_shape cannot be None")
-    if pattern is None:
-        raise ValueError("pattern of match_shape cannot be None")
-    return MatchShapePair(value, pattern)
-
 
 ############################ R.match_cast #############################
 class MatchCastPair:

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -29,7 +29,7 @@ from ...ir_builder import ir as I
 from ...ir_builder import relax as R
 from ...ir_builder.base import IRBuilder
 from .._core import Parser, dispatch, doc
-from .entry import MatchShapePair, MatchCastPair
+from .entry import MatchCastPair
 
 
 def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:
@@ -66,12 +66,6 @@ def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -
         value = R.const(value)
     if isinstance(value, relax.Expr):
         var = R.emit(value)
-        # It's an internal check, so directly use assert here.
-        assert var is not None
-        IRBuilder.name(var_name, var)
-        return var
-    elif isinstance(value, MatchShapePair):
-        var = R.emit_match_shape(value.value, value.pattern, emit_var=True)
         # It's an internal check, so directly use assert here.
         assert var is not None
         IRBuilder.name(var_name, var)
@@ -154,9 +148,7 @@ def post_token_switch(self: Parser, node: doc.Expr) -> None:
 @dispatch.register(token="relax", type_name="Expr")
 def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
     value = self.eval_expr(node.value)
-    if isinstance(value, MatchShapePair):
-        R.emit_match_shape(value.value, value.pattern, emit_var=False)
-    elif value is not None:
+    if value is not None:
         self.report_error(node, f"Unsupported Expr stmt type {value}.")
 
 

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -29,7 +29,7 @@ from ...ir_builder import ir as I
 from ...ir_builder import relax as R
 from ...ir_builder.base import IRBuilder
 from .._core import Parser, dispatch, doc
-from .entry import MatchShapePair
+from .entry import MatchShapePair, MatchCastPair
 
 
 def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:
@@ -74,6 +74,10 @@ def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -
         var = R.emit_match_shape(value.value, value.pattern, emit_var=True)
         # It's an internal check, so directly use assert here.
         assert var is not None
+        IRBuilder.name(var_name, var)
+        return var
+    elif isinstance(value, MatchCastPair):
+        var = R.emit_match_cast(value.value, value.struct_info)
         IRBuilder.name(var_name, var)
         return var
     else:

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -278,6 +278,19 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::MatchShapeNode* op) {
   return doc;
 }
 
+Doc RelaxScriptPrinter::VisitNode_(const relax::MatchCastNode* op) {
+  Doc doc;
+  doc << Print(op->var);
+  if (const auto& sinfo = MatchStructInfo<StructInfo>(op->var)) {
+    doc << ": " << Print(sinfo);
+  }
+  doc << " = ";
+  doc << "R.match_cast(";
+  doc << Print(op->value) << ", " << Print(op->struct_info);
+  doc << ")";
+  return doc;
+}
+
 Doc RelaxScriptPrinter::VisitNode_(const relax::VarBindingNode* op) {
   // TODO(@altanh): think deeper about normal form (need to be strict about block exprs)
   if (const relax::IfNode* ite = op->value.as<relax::IfNode>()) {

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -262,22 +262,6 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::ShapeExprNode* op) {
   return doc;
 }
 
-Doc RelaxScriptPrinter::VisitNode_(const relax::MatchShapeNode* op) {
-  Doc doc;
-  if (op->var.defined()) {
-    doc << Print(op->var);
-    if (const auto& sinfo = MatchStructInfo<StructInfo>(op->var)) {
-      doc << ": " << Print(sinfo);
-    }
-    doc << " = ";
-  }
-  doc << "R.match_shape(";
-  // TODO(@altanh): maybe op->pattern should just be a ShapeExpr?
-  doc << Print(op->value) << ", " << Print(relax::ShapeExpr(op->pattern));
-  doc << ")";
-  return doc;
-}
-
 Doc RelaxScriptPrinter::VisitNode_(const relax::MatchCastNode* op) {
   Doc doc;
   doc << Print(op->var);
@@ -331,16 +315,7 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::DataflowBlockNode* op) {
   std::vector<Doc> return_vars;
   for (const relax::Binding& binding : op->bindings) {
     body << Print(binding) << Doc::NewLine();
-    Var var;
-    if (const auto* var_binding = binding.as<VarBindingNode>()) {
-      var = var_binding->var;
-    } else if (const auto* shape_binding = binding.as<MatchShapeNode>()) {
-      var = shape_binding->var;
-    } else if (const auto* match_cast = binding.as<MatchCastNode>()) {
-      var = match_cast->var;
-    } else {
-      LOG(FATAL) << "Unsupported binding type: " << binding->GetTypeKey();
-    }
+    Var var = binding->var;
     if (var.defined() && !var.as<relax::DataflowVarNode>()) {
       return_vars.push_back(Print(var));
     }

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -332,10 +332,14 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::DataflowBlockNode* op) {
   for (const relax::Binding& binding : op->bindings) {
     body << Print(binding) << Doc::NewLine();
     Var var;
-    if (const relax::VarBindingNode* var_binding = binding.as<relax::VarBindingNode>()) {
+    if (const auto* var_binding = binding.as<VarBindingNode>()) {
       var = var_binding->var;
-    } else if (const relax::MatchShapeNode* shape_binding = binding.as<relax::MatchShapeNode>()) {
+    } else if (const auto* shape_binding = binding.as<MatchShapeNode>()) {
       var = shape_binding->var;
+    } else if (const auto* match_cast = binding.as<MatchCastNode>()) {
+      var = match_cast->var;
+    } else {
+      LOG(FATAL) << "Unsupported binding type: " << binding->GetTypeKey();
     }
     if (var.defined() && !var.as<relax::DataflowVarNode>()) {
       return_vars.push_back(Print(var));

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -279,7 +279,6 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   Doc VisitNode_(const relax::VarNode* op) override;
   Doc VisitNode_(const relax::DataflowVarNode* op) override;
   Doc VisitNode_(const relax::ShapeExprNode* op) override;
-  Doc VisitNode_(const relax::MatchShapeNode* op) override;
   Doc VisitNode_(const relax::MatchCastNode* op) override;
   Doc VisitNode_(const relax::VarBindingNode* op) override;
   Doc VisitNode_(const relax::BindingBlockNode* op) override;

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -280,6 +280,7 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   Doc VisitNode_(const relax::DataflowVarNode* op) override;
   Doc VisitNode_(const relax::ShapeExprNode* op) override;
   Doc VisitNode_(const relax::MatchShapeNode* op) override;
+  Doc VisitNode_(const relax::MatchCastNode* op) override;
   Doc VisitNode_(const relax::VarBindingNode* op) override;
   Doc VisitNode_(const relax::BindingBlockNode* op) override;
   Doc VisitNode_(const relax::DataflowBlockNode* op) override;

--- a/src/relax/analysis/analysis.cc
+++ b/src/relax/analysis/analysis.cc
@@ -141,6 +141,11 @@ class VarVisitor : protected ExprVisitor {
     ExprVisitor::VisitBinding_(binding);
   }
 
+  void VisitBinding_(const MatchCastNode* binding) final {
+    MarkBounded(binding->var);
+    ExprVisitor::VisitBinding_(binding);
+  }
+
  private:
   InsertionSet<Var> vars_;
   InsertionSet<Var> bound_vars_;

--- a/src/relax/analysis/analysis.cc
+++ b/src/relax/analysis/analysis.cc
@@ -134,13 +134,6 @@ class VarVisitor : protected ExprVisitor {
     VisitVarDef(binding->var);
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) final {
-    if (binding->var.defined()) {
-      MarkBounded(binding->var);
-    }
-    ExprVisitor::VisitBinding_(binding);
-  }
-
   void VisitBinding_(const MatchCastNode* binding) final {
     MarkBounded(binding->var);
     ExprVisitor::VisitBinding_(binding);

--- a/src/relax/analysis/var2value.cc
+++ b/src/relax/analysis/var2value.cc
@@ -70,11 +70,6 @@ class Name2BindingAnalysis : public relax::ExprVisitor {
     name2bindings_[vname].push_back(GetRef<VarBinding>(binding));
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) override {
-    const auto& vname = binding->var->name_hint();
-    name2bindings_[vname].push_back(GetRef<MatchShape>(binding));
-  }
-
   void VisitBinding_(const MatchCastNode* binding) override {
     const auto& vname = binding->var->name_hint();
     name2bindings_[vname].push_back(GetRef<MatchCast>(binding));

--- a/src/relax/analysis/var2value.cc
+++ b/src/relax/analysis/var2value.cc
@@ -74,6 +74,11 @@ class Name2BindingAnalysis : public relax::ExprVisitor {
     const auto& vname = binding->var->name_hint();
     name2bindings_[vname].push_back(GetRef<MatchShape>(binding));
   }
+
+  void VisitBinding_(const MatchCastNode* binding) override {
+    const auto& vname = binding->var->name_hint();
+    name2bindings_[vname].push_back(GetRef<MatchCast>(binding));
+  }
 };
 
 Map<String, Array<Binding>> NameToBinding(const Function& fn) {

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -316,15 +316,6 @@ class WellFormedChecker : public relax::ExprVisitor,
     dataflow_var_set_.clear();
   }
 
-  void VisitBinding_(const MatchCastNode* binding) final {
-    this->VisitExpr(binding->value);
-    // define the vars
-    WithMode(VisitMode::kMatchVarDef, [&]() { this->VisitStructInfo(binding->struct_info); });
-
-    this->VisitStructInfo(binding->struct_info);
-    this->VisitVarDef(binding->var);
-  }
-
   void VisitVarDef_(const DataflowVarNode* var) final {
     if (!is_dataflow_) {
       Malformed(Diagnostic::Error(var)

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -316,6 +316,7 @@ class WellFormedChecker : public relax::ExprVisitor,
     }
   }
 
+
   void VisitBindingBlock_(const DataflowBlockNode* block) final {
     is_dataflow_ = true;
     for (Binding binding : block->bindings) {
@@ -323,6 +324,15 @@ class WellFormedChecker : public relax::ExprVisitor,
     }
     is_dataflow_ = false;
     dataflow_var_set_.clear();
+  }
+
+  void VisitBinding_(const MatchCastNode* binding) final {
+    this->VisitExpr(binding->value);
+    // define the vars
+    WithMode(VisitMode::kMatchVarDef, [&]() { this->VisitStructInfo(binding->struct_info); });
+
+    this->VisitStructInfo(binding->struct_info);
+    this->VisitVarDef(binding->var);
   }
 
   void VisitVarDef_(const DataflowVarNode* var) final {

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -298,24 +298,14 @@ class WellFormedChecker : public relax::ExprVisitor,
     this->VisitVarDef(binding->var);
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) final {
+  void VisitBinding_(const MatchCastNode* binding) final {
     this->VisitExpr(binding->value);
     // define the vars
-    WithMode(VisitMode::kMatchVarDef, [&]() {
-      for (PrimExpr expr : binding->pattern) {
-        this->VisitStructInfoExprField(expr);
-      }
-    });
+    WithMode(VisitMode::kMatchVarDef, [&]() { this->VisitStructInfo(binding->struct_info); });
 
-    for (PrimExpr expr : binding->pattern) {
-      this->VisitStructInfoExprField(expr);
-    }
-
-    if (binding->var.defined()) {
-      this->VisitVarDef(binding->var);
-    }
+    this->VisitStructInfo(binding->struct_info);
+    this->VisitVarDef(binding->var);
   }
-
 
   void VisitBindingBlock_(const DataflowBlockNode* block) final {
     is_dataflow_ = true;

--- a/src/relax/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relax/backend/contrib/codegen_json/codegen_json.h
@@ -252,11 +252,6 @@ class JSONSerializer
     return VisitExpr(binding->value);
   }
 
-  std::vector<JSONGraphNodeEntry> VisitBinding_(const MatchShapeNode* binding) {
-    LOG(FATAL) << "JSON runtime currently doesn't shape expr\n";
-    return {};
-  }
-
   std::vector<JSONGraphNodeEntry> VisitBinding_(const MatchCastNode* binding) {
     LOG(FATAL) << "JSON runtime currently doesn't match cast\n";
     return {};
@@ -267,7 +262,7 @@ class JSONSerializer
     if (const auto* node = binding.as<VarBindingNode>()) {
       auto from_b = VisitBinding_(node);
       nodes.insert(nodes.end(), from_b.begin(), from_b.end());
-    } else if (const auto* node = binding.as<MatchShapeNode>()) {
+    } else if (const auto* node = binding.as<MatchCastNode>()) {
       auto from_b = VisitBinding_(node);
       nodes.insert(nodes.end(), from_b.begin(), from_b.end());
     } else {

--- a/src/relax/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relax/backend/contrib/codegen_json/codegen_json.h
@@ -257,6 +257,11 @@ class JSONSerializer
     return {};
   }
 
+  std::vector<JSONGraphNodeEntry> VisitBinding_(const MatchCastNode* binding) {
+    LOG(FATAL) << "JSON runtime currently doesn't match cast\n";
+    return {};
+  }
+
   std::vector<JSONGraphNodeEntry> VisitBinding(const Binding& binding) {
     std::vector<JSONGraphNodeEntry> nodes;
     if (const auto* node = binding.as<VarBindingNode>()) {

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -105,14 +105,6 @@ class VMShapeLowerMutator : public ExprMutator {
     return builder_->GetContextIRModule();
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) override {
-    Expr value = ExprMutator::VisitExpr(binding->value);
-
-    // TODO(@yuchen): match_shape overloaded semantic: value is ShapeType
-    Var shape = builder_->Emit(Call(ExternFunc("vm.builtin.shape_of"), {value}), "sh");
-    StoreShape(shape, binding->pattern);
-  }
-
   void VisitBinding_(const MatchCastNode* binding) override {
     // TODO(@tqchen): match_cast support for general struct info
     Expr value = ExprMutator::VisitExpr(binding->value);

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -217,6 +217,21 @@ class BlockBuilderImpl : public BlockBuilderNode {
     return var;
   }
 
+
+  Var EmitMatchCast(Expr value, StructInfo struct_info, String name_hint) final {
+    value = this->Normalize(value);
+
+    BlockFrame* cur_frame = CurrentBlockFrame();
+    Var var = CreateVar(cur_frame->is_dataflow, name_hint);
+    UpdateStructInfo(var, struct_info);
+
+    MatchCast match_cast(var, value, struct_info);
+    cur_frame->bindings.push_back(match_cast);
+    // NOTE match shape do not follow simple binding rule
+    // as a result should not appear in binding table.
+    return var;
+  }
+
   Var EmitOutput(Expr output, String name_hint) final {
     BlockFrame* cur_frame = CurrentBlockFrame();
 
@@ -915,6 +930,11 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderNormalize")
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmit").set_body_typed([](BlockBuilder builder, Expr expr) {
   return builder->Emit(expr);
 });
+
+TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitMatchCast")
+    .set_body_typed([](BlockBuilder builder, Expr value, StructInfo struct_info) {
+      return builder->EmitMatchCast(value, struct_info);
+    });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitMatchShape")
     .set_body_typed([](BlockBuilder builder, Expr value, Array<PrimExpr> pattern) {

--- a/src/relax/ir/emit_te.cc
+++ b/src/relax/ir/emit_te.cc
@@ -63,7 +63,7 @@ te::Tensor TETensor(Expr value, std::string name) {
   auto* shape_expr = tensor_sinfo->shape.as<ShapeExprNode>();
   CHECK(shape_expr)
       << "ValueError: Expression does not have an known symbolic shape, please consider use "
-         "match_shape "
+         "match_cast "
       << "to constrain the shape before passing into te_tensor";
   n->shape = shape_expr->values;
   n->dtype = tensor_sinfo->dtype;

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -340,6 +340,23 @@ TVM_REGISTER_GLOBAL("relax.MatchShape")
       return MatchShape(value, pattern, var, span);
     });
 
+TVM_REGISTER_NODE_TYPE(MatchCastNode);
+
+MatchCast::MatchCast(Var var, Expr value, StructInfo struct_info, Span span) {
+  ObjectPtr<MatchCastNode> n = make_object<MatchCastNode>();
+  ICHECK(var.defined()) << "MatchCast requires var to be defined";
+  n->var = std::move(var);
+  n->value = std::move(value);
+  n->struct_info = std::move(struct_info);
+  n->span = span;
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_GLOBAL("relax.MatchCast")
+    .set_body_typed([](Var var, Expr value, StructInfo struct_info, Span span) {
+      return MatchCast(var, value, struct_info, span);
+    });
+
 TVM_REGISTER_NODE_TYPE(VarBindingNode);
 
 VarBinding::VarBinding(Var var, Expr value, Span span) {

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -322,24 +322,6 @@ TVM_REGISTER_GLOBAL("relax.Constant").set_body_typed([](runtime::NDArray data, S
   return Constant(data, span);
 });
 
-TVM_REGISTER_NODE_TYPE(BindingNode);
-
-TVM_REGISTER_NODE_TYPE(MatchShapeNode);
-
-MatchShape::MatchShape(Expr value, Array<PrimExpr> pattern, Var var, Span span) {
-  ObjectPtr<MatchShapeNode> n = make_object<MatchShapeNode>();
-  n->value = std::move(value);
-  n->pattern = std::move(pattern);
-  n->var = std::move(var);
-  n->span = span;
-  data_ = std::move(n);
-}
-
-TVM_REGISTER_GLOBAL("relax.MatchShape")
-    .set_body_typed([](Expr value, Array<PrimExpr> pattern, Var var, Span span) {
-      return MatchShape(value, pattern, var, span);
-    });
-
 TVM_REGISTER_NODE_TYPE(MatchCastNode);
 
 MatchCast::MatchCast(Var var, Expr value, StructInfo struct_info, Span span) {

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -83,24 +83,65 @@ namespace relax {
 // ==================
 // ExprVisitor
 
+void ExprVisitor::VisitExprDepStructInfoField(const StructInfo& struct_info) {
+  // recurse into struct info in case they depend on value
+  // under the current scope.
+  default_struct_info_field_visitor_.VisitStructInfo(struct_info);
+}
+
+ExprVisitor::DefaultStructInfoFieldVisitor::DefaultStructInfoFieldVisitor(ExprVisitor* parent)
+    : parent_(parent) {}
+
+void ExprVisitor::DefaultStructInfoFieldVisitor::VisitStructInfoExprField(const Expr& expr) {
+  parent_->VisitExpr(expr);
+}
+
+void ExprVisitor::DefaultStructInfoFieldVisitor::VisitStructInfoExprField(const PrimExpr& expr) {
+  parent_->VisitPrimExpr(expr);
+}
+
+void ExprVisitor::DefaultStructInfoFieldVisitor::VisitStructInfo_(const FuncStructInfoNode* op) {
+  // Do not recurse into function struct info
+  // as they won't contain ref to values in current scope.
+}
+
 void ExprVisitor::VisitExpr(const Expr& expr) { ExprFunctor::VisitExpr(expr); }
 
-void ExprVisitor::VisitExpr_(const ConstantNode* op) { this->VisitSpan(op->span); }
+void ExprVisitor::VisitExpr_(const ConstantNode* op) {
+  this->VisitSpan(op->span);
+  // Constant's StructInfo does not depend on Expr.
+}
 
-void ExprVisitor::VisitExpr_(const GlobalVarNode* op) { this->VisitSpan(op->span); }
+void ExprVisitor::VisitExpr_(const GlobalVarNode* op) {
+  this->VisitSpan(op->span);
+  // FuncStructInfo is not value-dep
+}
 
 void ExprVisitor::VisitExpr_(const TupleNode* op) {
   this->VisitSpan(op->span);
   for (Expr field : op->fields) {
     this->VisitExpr(field);
   }
+  if (auto* sinfo = op->struct_info_.as<StructInfoNode>()) {
+    this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+  }
 }
 
 // Visit the use-site of a defined Var
-void ExprVisitor::VisitExpr_(const VarNode* op) { this->VisitSpan(op->span); }
+void ExprVisitor::VisitExpr_(const VarNode* op) {
+  this->VisitSpan(op->span);
+  if (auto* sinfo = op->struct_info_.as<StructInfoNode>()) {
+    this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+  }
+}
 
 // Visit the use-site of a defined DataflowVar
-void ExprVisitor::VisitExpr_(const DataflowVarNode* op) { this->VisitSpan(op->span); }
+void ExprVisitor::VisitExpr_(const DataflowVarNode* op) {
+  this->VisitSpan(op->span);
+  if (auto* sinfo = op->struct_info_.as<StructInfoNode>()) {
+    this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+  }
+}
 
 void ExprVisitor::VisitExpr_(const FunctionNode* op) {
   this->VisitSpan(op->span);
@@ -109,6 +150,7 @@ void ExprVisitor::VisitExpr_(const FunctionNode* op) {
   }
 
   this->VisitExpr(op->body);
+  // FuncStructInfo does not depend on Expr.
 }
 
 void ExprVisitor::VisitExpr_(const CallNode* op) {
@@ -122,6 +164,10 @@ void ExprVisitor::VisitExpr_(const CallNode* op) {
   for (Expr arg : op->args) {
     this->VisitExpr(arg);
   }
+
+  if (auto* sinfo = op->struct_info_.as<StructInfoNode>()) {
+    this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+  }
 }
 
 void ExprVisitor::VisitExpr_(const IfNode* op) {
@@ -129,6 +175,10 @@ void ExprVisitor::VisitExpr_(const IfNode* op) {
   this->VisitExpr(op->cond);
   this->VisitExpr(op->true_branch);
   this->VisitExpr(op->false_branch);
+
+  if (auto* sinfo = op->struct_info_.as<StructInfoNode>()) {
+    this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+  }
 }
 
 void ExprVisitor::VisitExpr_(const OpNode* op) {}
@@ -136,6 +186,10 @@ void ExprVisitor::VisitExpr_(const OpNode* op) {}
 void ExprVisitor::VisitExpr_(const TupleGetItemNode* op) {
   this->VisitSpan(op->span);
   this->VisitExpr(op->tuple);
+
+  if (auto* sinfo = op->struct_info_.as<StructInfoNode>()) {
+    this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+  }
 }
 
 void ExprVisitor::VisitExpr_(const ShapeExprNode* op) {
@@ -143,9 +197,16 @@ void ExprVisitor::VisitExpr_(const ShapeExprNode* op) {
     this->VisitPrimExpr(val);
   }
   this->VisitSpan(op->span);
+
+  if (auto* sinfo = op->struct_info_.as<StructInfoNode>()) {
+    this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+  }
 }
 
-void ExprVisitor::VisitExpr_(const ExternFuncNode* op) { this->VisitSpan(op->span); }
+void ExprVisitor::VisitExpr_(const ExternFuncNode* op) {
+  this->VisitSpan(op->span);
+  // FuncStructInfo does not depend on Expr.
+}
 
 void ExprVisitor::VisitExpr_(const SeqExprNode* op) {
   this->VisitSpan(op->span);
@@ -153,6 +214,10 @@ void ExprVisitor::VisitExpr_(const SeqExprNode* op) {
     this->VisitBindingBlock(block);
   }
   this->VisitExpr(op->body);
+
+  if (auto* sinfo = op->struct_info_.as<StructInfoNode>()) {
+    this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+  }
 }
 
 void ExprVisitor::VisitType(const Type& t) {}
@@ -252,11 +317,43 @@ TVM_REGISTER_GLOBAL("relax.analysis.post_order_visit").set_body_typed([](Expr ex
 // ==================
 // ExprMutatorBase
 
+StructInfo ExprMutatorBase::VisitExprDepStructInfoField(const StructInfo& struct_info) {
+  // recurse into struct info in case they depend on value
+  // under the current scope.
+  return default_struct_info_field_mutator_.VisitStructInfo(struct_info);
+}
+
+ExprMutatorBase::DefaultStructInfoFieldMutator::DefaultStructInfoFieldMutator(
+    ExprMutatorBase* parent)
+    : parent_(parent) {}
+
+Expr ExprMutatorBase::DefaultStructInfoFieldMutator::VisitStructInfoExprField(const Expr& expr) {
+  return parent_->VisitExpr(expr);
+}
+
+PrimExpr ExprMutatorBase::DefaultStructInfoFieldMutator::VisitStructInfoExprField(
+    const PrimExpr& expr) {
+  return parent_->VisitPrimExpr(expr);
+}
+
+StructInfo ExprMutatorBase::DefaultStructInfoFieldMutator::VisitStructInfo_(
+    const FuncStructInfoNode* op) {
+  // Do not recurse into function struct info
+  // as they won't contain ref to values in current scope.
+  return GetRef<StructInfo>(op);
+}
+
 Expr ExprMutatorBase::VisitExpr(const Expr& expr) { return ExprFunctor::VisitExpr(expr); }
 
-Expr ExprMutatorBase::VisitExpr_(const ConstantNode* op) { return GetRef<Expr>(op); }
+Expr ExprMutatorBase::VisitExpr_(const ConstantNode* op) {
+  // Constant' struct info won't be affected by Expr/PrimExpr change.
+  return GetRef<Expr>(op);
+}
 
-Expr ExprMutatorBase::VisitExpr_(const GlobalVarNode* op) { return GetRef<Expr>(op); }
+Expr ExprMutatorBase::VisitExpr_(const GlobalVarNode* op) {
+  // FuncStructInfo won't be affected by Expr/PrimExpr change.
+  return GetRef<Expr>(op);
+}
 
 Expr ExprMutatorBase::VisitExpr_(const TupleNode* op) {
   bool unchanged = true;
@@ -268,20 +365,33 @@ Expr ExprMutatorBase::VisitExpr_(const TupleNode* op) {
   }
 
   if (unchanged) {
+    // If tuple's struct info change it means that
+    // one of its fields' struct info will change
+    // so un-changed already implies that struct info won't change
     return GetRef<Expr>(op);
   } else {
-    Expr new_tuple = Tuple(fields, op->span);
-    return new_tuple;
+    // when there is a change return a new tuple node
+    return Tuple(fields, op->span);
   }
 }
 
 // Visit the use-site of a defined Var
-Expr ExprMutatorBase::VisitExpr_(const VarNode* op) { return GetRef<Expr>(op); }
+Expr ExprMutatorBase::VisitExpr_(const VarNode* op) {
+  // struct info of var-use should remain stable
+  // or the var itself will get replaced
+  return GetRef<Expr>(op);
+}
 
 // Visit the use-site of a defined DataflowVar
-Expr ExprMutatorBase::VisitExpr_(const DataflowVarNode* op) { return GetRef<Expr>(op); }
+Expr ExprMutatorBase::VisitExpr_(const DataflowVarNode* op) {
+  // struct info of var-use should remain stable
+  // or the var itself will get replaced
+  return GetRef<Expr>(op);
+}
 
 Expr ExprMutatorBase::VisitExpr_(const FunctionNode* op) {
+  // struct info of function is not value dependent
+  // so no need to check struct_info field
   Expr body = this->VisitExpr(op->body);
 
   if (body.same_as(op->body)) {
@@ -309,11 +419,10 @@ Expr ExprMutatorBase::VisitExpr_(const CallNode* call_node) {
     unchanged &= new_arg.same_as(arg);
   }
 
-  if (unchanged) {
+  if (unchanged && VisitAndCheckStructInfoFieldUnchanged(call_node->struct_info_)) {
     return GetRef<Expr>(call_node);
   } else {
-    Expr new_call = Call(new_op, call_args, call_node->attrs, ty_args, call_node->span);
-    return new_call;
+    return Call(new_op, call_args, call_node->attrs, ty_args, call_node->span);
   }
 }
 
@@ -322,7 +431,8 @@ Expr ExprMutatorBase::VisitExpr_(const IfNode* op) {
   Expr true_b = this->VisitExpr(op->true_branch);
   Expr false_b = this->VisitExpr(op->false_branch);
   if (op->cond.same_as(guard) && op->true_branch.same_as(true_b) &&
-      op->false_branch.same_as(false_b)) {
+      op->false_branch.same_as(false_b) &&
+      VisitAndCheckStructInfoFieldUnchanged(op->struct_info_)) {
     return GetRef<Expr>(op);
   } else {
     return If(guard, true_b, false_b, op->span);
@@ -334,6 +444,8 @@ Expr ExprMutatorBase::VisitExpr_(const OpNode* op) { return GetRef<Expr>(op); }
 Expr ExprMutatorBase::VisitExpr_(const TupleGetItemNode* op) {
   auto t = this->VisitExpr(op->tuple);
   if (op->tuple.same_as(t)) {
+    // struct info can be deterministically derived by tuple and index
+    // if t does not change, then struct info won't change.
     return GetRef<Expr>(op);
   } else {
     return TupleGetItem(t, op->index, op->span);
@@ -344,13 +456,17 @@ Expr ExprMutatorBase::VisitExpr_(const ShapeExprNode* op) {
   auto values = op->values.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
 
   if (values.same_as(op->values)) {
+    // If values does not change, struct info won't change.
     return GetRef<Expr>(op);
   } else {
     return ShapeExpr(values, op->span);
   }
 }
 
-Expr ExprMutatorBase::VisitExpr_(const ExternFuncNode* op) { return GetRef<Expr>(op); }
+Expr ExprMutatorBase::VisitExpr_(const ExternFuncNode* op) {
+  // StructInfo of function remains value independent.
+  return GetRef<Expr>(op);
+}
 
 Expr ExprMutatorBase::VisitExpr_(const SeqExprNode* op) {
   bool all_blocks_unchanged = true;
@@ -365,11 +481,11 @@ Expr ExprMutatorBase::VisitExpr_(const SeqExprNode* op) {
 
   Expr body = this->VisitExpr(op->body);
 
-  if (all_blocks_unchanged && body.same_as(op->body)) {
+  if (all_blocks_unchanged && body.same_as(op->body) &&
+      VisitAndCheckStructInfoFieldUnchanged(op->struct_info_)) {
     return GetRef<Expr>(op);
-  } else {
-    return SeqExpr(blocks, body);
   }
+  return SeqExpr(blocks, body);
 }
 
 BindingBlock ExprMutatorBase::VisitBindingBlock(const BindingBlock& block) {
@@ -408,23 +524,6 @@ Expr ExprMutator::VisitExpr(const Expr& expr) {
   return builder_->Normalize(ExprFunctor::VisitExpr(expr));
 }
 
-Expr ExprMutator::VisitExpr_(const TupleNode* op) {
-  bool unchanged = true;
-  tvm::Array<Expr> fields;
-  for (Expr field : op->fields) {
-    Expr new_field = this->VisitExpr(field);
-    fields.push_back(new_field);
-    unchanged &= new_field.same_as(field);
-  }
-
-  if (unchanged) {
-    return GetRef<Expr>(op);
-  } else {
-    Expr new_tuple = Tuple(fields, op->span);
-    return new_tuple;
-  }
-}
-
 // Visit the use-site of a defined Var
 Expr ExprMutator::VisitExpr_(const VarNode* op) {
   auto it = var_remap_.find(op->vid);
@@ -458,6 +557,7 @@ Expr ExprMutator::VisitExpr_(const FunctionNode* op) {
 
   Expr body = this->VisitWithNewScope(op->body, params);
 
+  // FuncStructInfo does not depend on Expr
   if (all_params_unchanged && body.same_as(op->body)) {
     return GetRef<Expr>(op);
   } else {
@@ -470,7 +570,8 @@ Expr ExprMutator::VisitExpr_(const IfNode* op) {
   Expr true_b = this->VisitWithNewScope(op->true_branch);
   Expr false_b = this->VisitWithNewScope(op->false_branch);
   if (op->cond.same_as(guard) && op->true_branch.same_as(true_b) &&
-      op->false_branch.same_as(false_b)) {
+      op->false_branch.same_as(false_b) &&
+      VisitAndCheckStructInfoFieldUnchanged(op->struct_info_)) {
     return GetRef<Expr>(op);
   } else {
     return If(guard, true_b, false_b, op->span);
@@ -496,7 +597,8 @@ Expr ExprMutator::VisitExpr_(const SeqExprNode* op) {
     all_blocks_unchanged = false;
   }
 
-  if (all_blocks_unchanged && body.same_as(op->body)) {
+  if (all_blocks_unchanged && body.same_as(op->body) &&
+      VisitAndCheckStructInfoFieldUnchanged(op->struct_info_)) {
     return GetRef<Expr>(op);
   } else {
     return SeqExpr(blocks, body);
@@ -566,14 +668,30 @@ BindingBlock ExprMutator::VisitBindingBlock_(const DataflowBlockNode* block) {
 }
 
 Var ExprMutator::VisitVarDef_(const DataflowVarNode* var) {
-  // If an Expr have struct info, they must already be normalized,
-  // This invariant is checked at the constructor location.
-  // to simplify our overall development complexity and keep var def
-  // stable by default.
-  return GetRef<Var>(var);
+  if (auto* sinfo = var->struct_info_.as<StructInfoNode>()) {
+    StructInfo struct_info = this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+    if (struct_info.same_as(var->struct_info_)) {
+      return GetRef<DataflowVar>(var);
+    } else {
+      return DataflowVar(var->vid, struct_info, var->span);
+    }
+  } else {
+    return GetRef<DataflowVar>(var);
+  }
 }
 
-Var ExprMutator::VisitVarDef_(const VarNode* var) { return GetRef<Var>(var); }
+Var ExprMutator::VisitVarDef_(const VarNode* var) {
+  if (auto* sinfo = var->struct_info_.as<StructInfoNode>()) {
+    StructInfo struct_info = this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
+    if (struct_info.same_as(var->struct_info_)) {
+      return GetRef<Var>(var);
+    } else {
+      return Var(var->vid, struct_info, var->span);
+    }
+  } else {
+    return GetRef<Var>(var);
+  }
+}
 
 void ExprMutator::VisitBinding(const Binding& binding) {
   if (const auto* node = binding.as<VarBindingNode>()) {

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -585,14 +585,15 @@ void ExprMutator::VisitBinding_(const MatchShapeNode* binding) {
 }
 
 void ExprMutator::VisitBinding_(const MatchCastNode* binding) {
+  Var new_var = this->VisitVarDef(binding->var);
   Expr new_value = this->VisitExpr(binding->value);
+
   // re-emit old binding if nothing changes
-  if (new_value.same_as(binding->value)) {
+  if (new_var.same_as(binding->var) && new_value.same_as(binding->value)) {
     builder_->EmitNormalized(GetRef<MatchCast>(binding));
   } else {
     new_value = builder_->NormalizeArgument(new_value);
-    builder_->EmitNormalized(
-        MatchCast(binding->var, new_value, binding->struct_info, binding->span));
+    builder_->EmitNormalized(MatchCast(new_var, new_value, binding->struct_info, binding->span));
   }
 }
 

--- a/src/relax/transform/bind_params.cc
+++ b/src/relax/transform/bind_params.cc
@@ -20,10 +20,10 @@
 #include <tvm/driver/driver_api.h>
 #include <tvm/ir/function.h>
 #include <tvm/relax/attrs/memory.h>
+#include <tvm/relax/expr.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/transform.h>
 #include <tvm/relax/type.h>
-#include <tvm/relay/interpreter.h>
 #include <tvm/tir/op.h>
 
 #include <utility>

--- a/src/relax/transform/canonicalize_bindings.cc
+++ b/src/relax/transform/canonicalize_bindings.cc
@@ -68,36 +68,6 @@ class BindingCanonicalizer : public ExprMutator {
     this->builder_->EmitNormalized(VarBinding(new_var, new_value));
   }
 
-  void VisitBinding_(const MatchShapeNode* binding) override {
-    // If we have a trivial shape check (the shape_ of LHS and RHS is the same),
-    // we can canonicalize to a var binding
-    Expr new_value = this->VisitExpr(binding->value);
-
-    Var new_var;
-    // since we do not permit the checked_type to change and don't make any changes
-    // to the shape pattern, there is no reason to do any more checking like in the
-    // original mutator
-    if (binding->var.defined()) {
-      new_var = this->VisitVarDef(binding->var);
-    }
-
-    // if the LHS and RHS have the same shape_, we canonicalize to a var binding instead
-    if (new_var.defined() && StructuralEqual()(GetStructInfo(new_var), GetStructInfo(new_value))) {
-      builder_->EmitNormalized(VarBinding(new_var, new_value));
-      return;
-    }
-
-    // reemit old binding if nothing changes
-    if (new_value.same_as(binding->value)) {
-      if (!binding->var.defined() || (binding->var.defined() && new_var.same_as(binding->var))) {
-        builder_->EmitNormalized(GetRef<MatchShape>(binding));
-        return;
-      }
-    }
-
-    builder_->EmitNormalized(MatchShape(new_value, binding->pattern, new_var));
-  }
-
   void VisitBinding_(const MatchCastNode* binding) override {
     // If we have a trivial shape check (the shape_ of LHS and RHS is the same),
     // we can canonicalize to a var binding

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -289,11 +289,7 @@ class FusedTIRConstructor : public ExprVisitor {
     }
   }
 
-  void VisitBinding_(const MatchShapeNode* match_shape) final {
-    LOG(FATAL) << "MatchShape is unsupported in primitive functions";
-  }
-
-  void VisitBinding_(const MatchCastNode* match_shape) final {
+  void VisitBinding_(const MatchCastNode* match_cast) final {
     LOG(FATAL) << "MatchCast is unsupported in primitive functions";
   }
 

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -290,8 +290,11 @@ class FusedTIRConstructor : public ExprVisitor {
   }
 
   void VisitBinding_(const MatchShapeNode* match_shape) final {
-    // TODO(relax-team): support match shape in primitive functions;
     LOG(FATAL) << "MatchShape is unsupported in primitive functions";
+  }
+
+  void VisitBinding_(const MatchCastNode* match_shape) final {
+    LOG(FATAL) << "MatchCast is unsupported in primitive functions";
   }
 
   void VisitExpr_(const CallNode* call) final {

--- a/src/relax/transform/normalize.cc
+++ b/src/relax/transform/normalize.cc
@@ -132,8 +132,6 @@ class NormalizeMutator : public ExprMutatorBase {
   void VisitBinding(const Binding& binding) {
     if (const auto* node = binding.as<VarBindingNode>()) {
       VisitBinding_(node);
-    } else if (const auto* node = binding.as<MatchShapeNode>()) {
-      VisitBinding_(node);
     } else if (const auto* node = binding.as<MatchCastNode>()) {
       VisitBinding_(node);
     } else {
@@ -151,21 +149,6 @@ class NormalizeMutator : public ExprMutatorBase {
       builder_->EmitNormalized(GetRef<VarBinding>(binding));
     } else {
       builder_->EmitNormalized(VarBinding(binding->var, new_value));
-    }
-  }
-
-  void VisitBinding_(const MatchShapeNode* binding) {
-    Expr new_value = this->VisitExpr(binding->value);
-
-    if (binding->var.defined()) {
-      if (!binding->var->struct_info_.defined()) {
-        UpdateStructInfo(binding->var, GetStructInfo(new_value));
-      }
-    }
-    if (new_value.same_as(binding->value)) {
-      builder_->EmitNormalized(GetRef<MatchShape>(binding));
-    } else {
-      builder_->EmitNormalized(MatchShape(new_value, binding->pattern, binding->var));
     }
   }
 

--- a/src/relax/transform/normalize.cc
+++ b/src/relax/transform/normalize.cc
@@ -167,6 +167,17 @@ class NormalizeMutator : public ExprMutatorBase {
     }
   }
 
+  void VisitBinding_(const MatchCastNode* binding) {
+    Expr new_value = this->VisitExpr(binding->value);
+
+    if (new_value.same_as(binding->value)) {
+      builder_->EmitNormalized(GetRef<MatchCast>(binding));
+    } else {
+      builder_->EmitNormalized(
+          MatchCast(binding->var, builder_->NormalizeArgument(new_value), binding->struct_info));
+    }
+  }
+
  private:
   /*! \brief Internal block builder to emit bindings during rewriting. */
   BlockBuilder builder_;

--- a/src/relax/transform/normalize.cc
+++ b/src/relax/transform/normalize.cc
@@ -134,6 +134,8 @@ class NormalizeMutator : public ExprMutatorBase {
       VisitBinding_(node);
     } else if (const auto* node = binding.as<MatchShapeNode>()) {
       VisitBinding_(node);
+    } else if (const auto* node = binding.as<MatchCastNode>()) {
+      VisitBinding_(node);
     } else {
       LOG(FATAL) << "TypeError: Invalid type: " << binding->GetTypeKey();
     }

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -169,6 +169,10 @@ void BlockFrameNode::ExitWithScope() {
             !match_shape->var->IsInstance<tvm::relax::DataflowVarNode>()) {
           new_global_vars.Set(match_shape->var->vid, match_shape->var);
         }
+      } else if (const auto* match_cast = binding.as<tvm::relax::MatchCastNode>()) {
+        if (!match_cast->var->IsInstance<tvm::relax::DataflowVarNode>()) {
+          new_global_vars.Set(match_cast->var->vid, match_cast->var);
+        }
       } else {
         LOG(FATAL) << "ValueError: Unsupported binding type: " << binding;
       }

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -160,21 +160,8 @@ void BlockFrameNode::ExitWithScope() {
     // Step 3.2. Collect global vars' reference in bindings
     Map<tvm::relax::Id, tvm::relax::Var> new_global_vars;
     for (const tvm::relax::Binding& binding : block->bindings) {
-      if (const auto* var_binding = binding.as<tvm::relax::VarBindingNode>()) {
-        if (!var_binding->var->IsInstance<tvm::relax::DataflowVarNode>()) {
-          new_global_vars.Set(var_binding->var->vid, var_binding->var);
-        }
-      } else if (const auto* match_shape = binding.as<tvm::relax::MatchShapeNode>()) {
-        if (match_shape->var.defined() &&
-            !match_shape->var->IsInstance<tvm::relax::DataflowVarNode>()) {
-          new_global_vars.Set(match_shape->var->vid, match_shape->var);
-        }
-      } else if (const auto* match_cast = binding.as<tvm::relax::MatchCastNode>()) {
-        if (!match_cast->var->IsInstance<tvm::relax::DataflowVarNode>()) {
-          new_global_vars.Set(match_cast->var->vid, match_cast->var);
-        }
-      } else {
-        LOG(FATAL) << "ValueError: Unsupported binding type: " << binding;
+      if (!binding->var->IsInstance<tvm::relax::DataflowVarNode>()) {
+        new_global_vars.Set(binding->var->vid, binding->var);
       }
     }
 

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -204,26 +204,6 @@ tvm::relax::Var Emit(const tvm::relax::Expr& expr) {
   return var;
 }
 
-Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value,   //
-                                         const Array<PrimExpr>& pattern,  //
-                                         bool emit_var) {
-  BlockFrame block_frame = CheckBlockFrameExistAndUnended();
-  tvm::relax::BlockBuilder block_builder = GetBlockBuilder();
-
-  if (!emit_var) {
-    // If we don't intend to emit a variable, just emit the binding and return.
-    tvm::relax::MatchShape match_shape(block_builder->Normalize(value), pattern,
-                                       tvm::relax::Var{nullptr});
-    block_builder->EmitNormalized(match_shape);
-    return NullOpt;
-  } else {
-    // Otherwise, we need to emit a variable and bind it to the match shape.
-    tvm::relax::Var var = block_builder->EmitMatchShape(value, pattern);
-    block_frame->emitted_vars.push_back(var);
-    return var;
-  }
-}
-
 tvm::relax::Var EmitMatchCast(const tvm::relax::Expr& value,
                               const tvm::relax::StructInfo& struct_info) {
   BlockFrame block_frame = CheckBlockFrameExistAndUnended();
@@ -235,7 +215,6 @@ tvm::relax::Var EmitMatchCast(const tvm::relax::Expr& value,
 }
 
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.Emit").set_body_typed(Emit);
-TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchShape").set_body_typed(EmitMatchShape);
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchCast").set_body_typed(EmitMatchCast);
 
 ///////////////////////////// Type Deduce //////////////////////////////

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -224,8 +224,19 @@ Optional<tvm::relax::Var> EmitMatchShape(const tvm::relax::Expr& value,   //
   }
 }
 
+tvm::relax::Var EmitMatchCast(const tvm::relax::Expr& value,
+                              const tvm::relax::StructInfo& struct_info) {
+  BlockFrame block_frame = CheckBlockFrameExistAndUnended();
+  const tvm::relax::BlockBuilder& block_builder = GetBlockBuilder();
+
+  tvm::relax::Var var = block_builder->EmitMatchCast(value, struct_info);
+  block_frame->emitted_vars.push_back(var);
+  return var;
+}
+
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.Emit").set_body_typed(Emit);
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchShape").set_body_typed(EmitMatchShape);
+TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchCast").set_body_typed(EmitMatchCast);
 
 ///////////////////////////// Type Deduce //////////////////////////////
 

--- a/src/script/ir_builder/relax/utils.h
+++ b/src/script/ir_builder/relax/utils.h
@@ -90,12 +90,11 @@ inline tvm::relax::SeqExpr GetSeqExprForBranch(const SeqExprFrame& frame, String
         << "A non-dataflow var is expected in the last binding of '" << method << "'.";
     body = var_binding->value;
     *var_name = var_binding->var->name_hint();
-  } else if (const auto* match_shape = last_binding.as<tvm::relax::MatchShapeNode>()) {
-    CHECK(match_shape->var.defined() &&
-          !match_shape->var->IsInstance<tvm::relax::DataflowVarNode>())
+  } else if (const auto* match_cast = last_binding.as<tvm::relax::MatchCastNode>()) {
+    CHECK(!match_cast->var->IsInstance<tvm::relax::DataflowVarNode>())
         << "A non-dataflow var is expected in the last binding of '" << method << "'.";
     body = var_binding->value;
-    *var_name = match_shape->var->name_hint();
+    *var_name = match_cast->var->name_hint();
   } else {
     ICHECK(false) << "TypeError: Unsupported binding type: " << last_binding->GetTypeKey();
   }

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -267,11 +267,11 @@ class VarExample:
     def main(x: R.Tensor, y: R.Tensor) -> R.Tensor:
         z = R.add(x, y)
         # no binding here
-        R.match_shape(x, (5, 5))
+        _ = R.match_cast(x, R.Tensor((5, 5)))
         with R.dataflow():
             q = R.add(z, z)
             p = func(q)
-            r = R.match_shape(p, (5, 5))
+            r = R.match_cast(p, R.Tensor((5, 5)))
             s = r
             R.output(s)
         return s
@@ -285,7 +285,7 @@ def test_all_vars():
     assert vars[1] == VarExample["func"].body.body
 
     var_names = var_name_set(all_vars(VarExample["main"]))
-    assert var_names == {"x", "y", "z", "p", "q", "r", "s"}
+    assert var_names == {"_", "x", "y", "z", "p", "q", "r", "s"}
 
 
 def test_bound_vars():
@@ -297,11 +297,11 @@ def test_bound_vars():
 
     # all the vars are bound
     var_names = var_name_set(bound_vars(VarExample["main"]))
-    assert var_names == {"x", "y", "z", "p", "q", "r", "s"}
+    assert var_names == {"_", "x", "y", "z", "p", "q", "r", "s"}
 
     # if we consider only the body, then the function arguments are not bound
     body_names = var_name_set(bound_vars(VarExample["main"].body))
-    assert body_names == {"z", "p", "q", "r", "s"}
+    assert body_names == {"_", "z", "p", "q", "r", "s"}
 
     # only binding is in the (normalized) body
     simple_body_vars = bound_vars(VarExample["func"].body)

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -66,9 +66,9 @@ class InputModule:
     def main(x:R.Tensor((m,n), "float32"), w:R.Tensor((n,k), "float32")) -> R.Tensor:
         with R.dataflow():
             sh = R.call_packed("vm.builtin.shape_of", x)
-            x0 = R.match_shape(sh, (m, n))
+            x0 = R.match_cast(sh, R.Tensor((m, n), "float32"))
             sh1 = R.call_packed("vm.builtin.shape_of", w)
-            x1 = R.match_shape(sh1, (n, k))
+            x1 = R.match_cast(sh1, R.Tensor((n, k), "float32"))
             lv0 = R.call_tir(tir_matmul, (x, w), (m, k), dtype="float32")
             lv1 = R.call_tir(tir_relu, (lv0), (m, k), dtype="float32)
             R.output(lv1)

--- a/tests/python/relax/test_blockbuilder.py
+++ b/tests/python/relax/test_blockbuilder.py
@@ -232,7 +232,7 @@ def test_binary_shape_type_deduction():
         assert gv0.checked_type.dtype == "float16"
 
 
-def test_emit_match_shape():
+def test_emit_match_cast():
     m = tir.Var("m", dtype="int64")
     n = tir.Var("n", dtype="int64")
     x = rx.Var("tensor_value", R.Tensor("float32", ndim=-1))
@@ -242,55 +242,54 @@ def test_emit_match_shape():
     with bb.function("func", [x, y]):
         with bb.dataflow():
             # lv0: Tensor((m, n), "float32") =
-            #   match_shape(x: Tensor(_, "float32"], [m, n))
-            lv0 = bb.match_shape(x, [m, n])
+            #   match_cast(x: Tensor(_, "float32"], [m, n))
+            lv0 = bb.match_cast(x, R.Tensor([m, n], "float32"))
             assert isinstance(lv0, rx.DataflowVar)
             assert_structural_equal(lv0.struct_info, rx.TensorStructInfo([m, n], "float32"))
 
-            # lv1: Shape = match_shape(shape, [m, n])
-            lv1 = bb.match_shape(y, [m, n])
-            assert lv1.struct_info == rx.ShapeStructInfo(ndim=2)
+            # lv1: Shape = match_cast(shape, R.Shape([m, n]))
+            lv1 = bb.match_cast(y, R.Shape([m, n]))
+            assert lv1.struct_info == rx.ShapeStructInfo([m, n])
             gv0 = bb.emit_output(lv1)
 
         bb.emit_func_output(gv0)
     func = bb.get()["func"]
     block = func.body.blocks[0]
     b0, b1 = block.bindings[:2]
-    assert isinstance(b0, rx.MatchShape)
-    assert isinstance(b1, rx.MatchShape)
+    assert isinstance(b0, rx.MatchCast)
+    assert isinstance(b1, rx.MatchCast)
 
     assert b0.value == x
-    assert b0.pattern[0] == m
-    assert b0.pattern[1] == n
+    assert b0.struct_info == rx.TensorStructInfo([m, n], "float32")
     assert b0.var == lv0
 
     assert b1.value == y
-    assert b1.pattern[0] == m
-    assert b1.pattern[1] == n
+    assert b1.struct_info == rx.ShapeStructInfo([m, n])
     assert b1.var == lv1
 
 
-def test_emit_match_shape_binding_in_dataflow_block():
+def test_emit_match_cast_binding_in_dataflow_block():
     bb = rx.BlockBuilder()
 
     x = rx.Var("x", R.Tensor("float32", ndim=-1))
     m = tir.Var("m", dtype="int64")
     gv = rx.Var("gv", R.Tensor("float32", ndim=-1))
-    match_shape = rx.MatchShape(x, (m,), gv)
+    match_cast = rx.MatchCast(gv, x, R.Tensor((m,), "float32"))
 
     with bb.function("main", [x]):
         with bb.dataflow():
-            bb.emit_normalized(match_shape)
+            bb.emit_normalized(match_cast)
             bb.emit_output(gv)
         bb.emit_func_output(x)
 
     func = bb.get()["main"]
     block = func.body.blocks[0]
     b0 = block.bindings[0]
-    assert isinstance(b0, rx.MatchShape)
+    assert isinstance(b0, rx.MatchCast)
 
     assert b0.value == x
-    assert b0.pattern[0] == m
+    assert isinstance(b0.struct_info, rx.TensorStructInfo)
+    assert b0.struct_info.shape[0] == m
     assert b0.var == gv
 
 

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -22,6 +22,22 @@ from tvm import tir
 from tvm.script import relax as R
 
 
+def _check_equal(x, y, map_free_vars=False):
+    tvm.ir.assert_structural_equal(x, y, map_free_vars)
+    tvm.ir.assert_structural_equal(y, x, map_free_vars)
+
+    xhash = tvm.ir.structural_hash(x, map_free_vars)
+    yhash = tvm.ir.structural_hash(y, map_free_vars)
+
+    assert xhash == yhash
+
+
+def _check_json_roundtrip(x):
+    xret = tvm.ir.load_json(tvm.ir.save_json(x))
+    _check_equal(x, xret, map_free_vars=True)
+    return xret
+
+
 def test_var() -> None:
     v0 = rx.Var("v0")
     assert v0.name_hint == "v0"
@@ -75,6 +91,17 @@ def test_match_shape() -> None:
     assert b1.pattern[1] == n
     assert b1.var is not None
     assert b1.var.checked_type == rx.DynTensorType(2, "float32")
+
+
+def test_match_cast() -> None:
+    m = tir.Var("m", dtype="int64")
+    n = tir.Var("n", dtype="int64")
+    ivalue = rx.Var("input_value")
+    sinfo = rx.TensorStructInfo([n, m], "float32")
+    b0 = rx.MatchCast(rx.Var("v"), ivalue, sinfo)
+    assert b0.value.same_as(ivalue)
+    assert b0.struct_info == sinfo
+    _check_json_roundtrip(b0)
 
 
 def test_var_binding() -> None:

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -67,13 +67,13 @@ def test_dataflow_var() -> None:
     tvm.ir.assert_structural_equal(v1.struct_info, rx.TensorStructInfo(shape, "float16"))
 
 
-def test_match_shape() -> None:
-    # match_shape([16, 8], [m, n])
+def test_match_cast() -> None:
+    # match_cast([16, 8], [m, n])
     m = tir.Var("m", dtype="int64")
     n = tir.Var("n", dtype="int64")
     shape = rx.const([16, 8], "int32")
     var = rx.Var("v0", R.Shape())
-    b0 = rx.MatchShape(shape, [m, n], var)
+    b0 = rx.MatchCast(var, shape, R.Tensor([m, n], "int32"))
     assert b0.value == shape
     assert b0.pattern[0] == m
     assert b0.pattern[1] == n
@@ -81,11 +81,11 @@ def test_match_shape() -> None:
     assert b0.var.checked_type == rx.ShapeType()
 
     # var1: R.Tensor((m, n), "float32") =
-    #   match_shape(var0: R.Tensor("float32", ndim=-1), [m, n])
+    #   match_cast(var0: R.Tensor("float32", ndim=-1), R.Tensor((m, n), "float32"))
     value = rx.Var("value", R.Tensor("float32", ndim=-1))
 
     var = rx.Var("v1", R.Tensor([m, n], "float32"))
-    b1 = rx.MatchShape(value, [m, n], var)
+    b1 = rx.MatchCast(var, value, R.Tensor([m, n], "float32"))
     assert b1.value == value
     assert b1.pattern[0] == m
     assert b1.pattern[1] == n
@@ -113,10 +113,10 @@ def test_var_binding() -> None:
 
 
 def test_binding_block() -> None:
-    m = tir.Var("m", dtype="int32")
-    n = tir.Var("n", dtype="int32")
+    m = tir.Var("m", dtype="int64")
+    n = tir.Var("n", dtype="int64")
     shape = rx.const([16, 8], "int32")
-    b0 = rx.MatchShape(shape, [m, n], rx.Var("v0"))
+    b0 = rx.MatchCast(rx.Var("v0"), shape, R.Tensor([m, n], "int32"))
 
     v0 = rx.Var("v0")
     val = rx.const(np.random.rand(24, 56))
@@ -128,10 +128,10 @@ def test_binding_block() -> None:
 
 
 def test_dataflow_block() -> None:
-    m = tir.Var("m", dtype="int32")
-    n = tir.Var("n", dtype="int32")
+    m = tir.Var("m", dtype="int64")
+    n = tir.Var("n", dtype="int64")
     shape = rx.const([16, 8], "int32")
-    b0 = rx.MatchShape(shape, [m, n], rx.Var("v0"))
+    b0 = rx.MatchCast(rx.Var("v0"), shape, R.Tensor([m, n], "int32"))
 
     v0 = rx.Var("v0")
     val = rx.const(np.random.rand(24, 56))

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -402,7 +402,7 @@ def test_call():
     basic_check(
         call_node,
         "\n".join(["Call", "\tOp", "\tVar", "\tVar"]),
-        "\n".join(["Op", "Var", "Var", "Call"]),
+        "\n".join(["Op", "Var", "Var", "ShapeExpr", "Call"]),
     )
 
 

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -64,11 +64,11 @@ def test_ndim_annotations():
     check_roundtrip(foo)
 
 
-def test_match_shape():
+def test_match_cast():
     @R.function
     def foo(x: R.Tensor(dtype="float32")):
         n, m = T.var("int64"), T.var("int64")
-        R.match_shape(R.shape_of(x), (n, m))
+        _ = R.match_cast(R.shape_of(x), R.Shape((n, m)))
         y: R.Tensor((n, m), "float32") = R.add(x, x)
         return x
 
@@ -141,15 +141,15 @@ def test_dataflow():
     check_roundtrip(foo)
 
 
-def test_dataflow_match_shape():
+def test_dataflow_match_cast():
     @R.function
     def foo(x: R.Tensor(ndim=2)):
         n, m = T.var("int64"), T.var("int64")
         with R.dataflow():
-            x2: R.Tensor((n, m)) = R.match_shape(x, (n, m))
+            x2: R.Tensor((n, m)) = R.match_cast(x, R.Tensor((n, m)))
             y = R.add(x2, x2)
             z = R.multiply(y, x)
-            R.match_shape(R.shape_of(z), (n, m))
+            _ = R.match_cast(R.shape_of(z), R.Shape((n, m)))
             w: R.Tensor((n, m)) = R.add(z, x)
             R.output(y, w, x2)
         t: R.Tensor((n, m)) = R.multiply(y, w)

--- a/tests/python/relax/test_structual_equal_hash.py
+++ b/tests/python/relax/test_structual_equal_hash.py
@@ -53,14 +53,14 @@ def test_var_binding():
     _check_equal(block0, block1)
 
 
-def test_match_shape():
+def test_match_cast():
     x = rx.Var("x", R.Tensor([10]))
     m = tir.Var("m", dtype="int64")
 
     def generator(x):
         bb = rx.BlockBuilder()
         bb._begin_binding_block()
-        bb.match_shape(x, [m * 2])
+        bb.match_cast(x, R.Tensor([m * 2]))
         return bb._end_block()
 
     block0 = generator(x)
@@ -108,13 +108,13 @@ def test_ir_module():
     _check_equal(mod0, mod1)
 
 
-def test_match_shape_symbolic():
+def test_match_cast_symbolic():
     @tvm.script.ir_module
     class InputModule:
         @R.function
         def f(x: R.Tensor("float32", ndim=2)):
             n, m = T.var("int64"), T.var("int64")
-            x0 = R.match_shape(x, (n, m))
+            x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             return (x0, (n + 1, m))
 
     _check_save_roundtrip(InputModule)

--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -135,14 +135,14 @@ def test_casting():
     assert_structural_equal(new_mod, Expected)
 
 
-def test_match_shape():
+def test_match_cast():
     @tvm.script.ir_module
-    class TestMatchShape:
+    class TestMatchCast:
         @R.function
         def main(x: R.Tensor):
             q = x
             m, n = T.var("int64"), T.var("int64")
-            z = R.match_shape(q, (m, n))
+            z = R.match_cast(q, R.Tensor((m, n)))
             w = z
             return w
 
@@ -153,11 +153,11 @@ def test_match_shape():
             q = x
             # can't get rid of z because its shape_ is different from x's
             m, n = T.var("int64"), T.var("int64")
-            z = R.match_shape(x, (m, n))
+            z = R.match_cast(x, R.Tensor((m, n)))
             w = z
             return z
 
-    new_mod = relax.transform.CanonicalizeBindings()(TestMatchShape)
+    new_mod = relax.transform.CanonicalizeBindings()(TestMatchCast)
     assert_structural_equal(new_mod, Expected)
 
 

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -207,7 +207,7 @@ def test_fold_mixed_case():
         @R.function
         def before(c0: R.Tensor((16, 16), "float32"), x: R.Tensor("float32", ndim=2)):
             n, m = T.var("int64"), T.var("int64")
-            x0 = R.match_shape(x, (n, m))
+            x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             # this line cannot be folded because n is unknown
             lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
             # this line can be folded
@@ -226,7 +226,7 @@ def test_fold_mixed_case():
             x: R.Tensor("float32", ndim=2),
         ) -> R.Tensor:
             n, m = T.var("int64"), T.var("int64")
-            x0 = R.match_shape(x, (n, m))
+            x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             # this line cannot be folded because n is unknown
             lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
             # this line can be folded

--- a/tests/python/relax/test_transform_normalize.py
+++ b/tests/python/relax/test_transform_normalize.py
@@ -454,6 +454,7 @@ def test_normalize_deeply_nested_seq():
     u = relax.Var("u", R.Tensor([], "int32"))
     v = relax.Var("v", R.Tensor([], "int32"))
     w = relax.Var("w", R.Tensor([], "int32"))
+    _ = relax.Var("w", R.Tensor([], "int32"))
     seq = relax.SeqExpr(
         [
             relax.BindingBlock(
@@ -472,9 +473,13 @@ def test_normalize_deeply_nested_seq():
                                                     relax.BindingBlock(
                                                         [
                                                             relax.VarBinding(u, relax.const(2)),
-                                                            relax.MatchShape(u, [], None),
+                                                            relax.MatchCast(
+                                                                _, u, R.Tensor([], "int32")
+                                                            ),
                                                             relax.VarBinding(v, u),
-                                                            relax.MatchShape(v, [], w),
+                                                            relax.MatchCast(
+                                                                w, v, R.Tensor([], "int32")
+                                                            ),
                                                         ]
                                                     )
                                                 ],
@@ -504,9 +509,9 @@ def test_normalize_deeply_nested_seq():
     def expected():
         x = relax.const(1)
         u = relax.const(2)
-        R.match_shape(u, ())
+        _ = R.match_cast(u, R.Tensor((), "int32"))
         v = u
-        w = R.match_shape(v, ())
+        w = R.match_cast(v, R.Tensor((), "int32"))
         z = w
         y = z
         return y

--- a/tests/python/relax/test_tvmscript_ir_builder.py
+++ b/tests/python/relax/test_tvmscript_ir_builder.py
@@ -53,14 +53,14 @@ def test_function_simple():
     assert func.body.body.name_hint == "out"
 
 
-def test_match_shape():
+def test_match_cast():
     """
     @R.function
     def foo(x: R.Tensor(None, "float32"), y: R.Tensor(None, "float32")):
         m = T.var("int64")
         n = T.var("int64")
-        R.match_shape(x, (m,))
-        y1 = R.match_shape(x, (n,))
+        _ = R.match_cast(x, R.Tensor((m,), "float32"))
+        y1 = R.match_cast(x, R.Tensor((n,), "float32"))
         return (m, n * 2)
     """
     # create with Script IRBuilder
@@ -71,8 +71,8 @@ def test_match_shape():
             y = R.arg("y", R.tensor(ndim=-1, dtype="float32"))
             m = tir.Var("m", dtype="int64")
             n = tir.Var("n", dtype="int64")
-            R.emit_match_shape(x, (m,), emit_var=False)
-            y1 = R.emit_match_shape(y, (n,), emit_var=True)
+            _ = R.emit_match_cast(x, R.tensor((m,), "float32"))
+            y1 = R.emit_match_cast(y, R.tensor((n,), "float32"))
             IRBuilder.name("y1", y1)
             R.func_ret_value(relax.ShapeExpr([m, n * 2]))
     func = ir_builder.get()
@@ -84,8 +84,8 @@ def test_match_shape():
     n = tir.Var("n", dtype="int64")
     bb = relax.BlockBuilder()
     with bb.function("foo", (x, y)):
-        bb.emit_normalized(relax.MatchShape(x, (m,), var=None))
-        y1 = bb.match_shape(y, (n,))
+        _ = bb.match_cast(x, R.tensor((m,), "float32"))
+        y1 = bb.match_cast(y, R.tensor((n,), "float32"))
         bb.emit_func_output(relax.ShapeExpr([m, n * 2]))
     mod = bb.get()
 

--- a/tests/python/relax/test_vm.py
+++ b/tests/python/relax/test_vm.py
@@ -399,7 +399,7 @@ def test_vm_compile_stage2():
         @R.function
         def foo(x: R.Tensor(dtype="float32")) -> R.Shape:
             n, m = T.var("int64"), T.var("int64")
-            R.match_shape(x, (n, m))
+            _ = R.match_cast(x, R.Tensor((n, m), "float32"))
             return (n * 2, m * 3)
 
     mod = TestVMCompileStage2
@@ -442,7 +442,7 @@ def test_vm_compile_e2e():
         def foo(x: R.Tensor(dtype="float32")) -> R.Tensor:
             with R.dataflow():
                 n, m = T.var("int64"), T.var("int64")
-                R.match_shape(x, (n, m))
+                _ = R.match_cast(x, R.Tensor((n, m), "float32"))
                 y = R.call_tir("test.vm.tile", (x), (n, m * 2), dtype="float32")
                 R.output(y)
             return y

--- a/tests/python/relay/test_dataflow_pattern.py
+++ b/tests/python/relay/test_dataflow_pattern.py
@@ -422,13 +422,13 @@ def test_no_match_dtype():
     assert not ty_pat.match(x)
 
 
-def test_match_shape():
+def test_match_cast():
     x = relay.var("x", shape=(10, 10), dtype="float32")
     ty_pat = has_shape((10, 10))
     assert ty_pat.match(x)
 
 
-def test_no_match_shape():
+def test_no_match_cast():
     x = relay.var("x", shape=(10, 10), dtype="int32")
     ty_pat = has_shape((10, 5))
     assert not ty_pat.match(x)


### PR DESCRIPTION
This PR is M3 of https://github.com/tlc-pack/relax/issues/315

This PR introduces MatchCast  node and replaces all the occurance of MatchShape to MatchCast. We also updated the Visitor/Mutator so that Visitor can recurse into Expr within StructInfo field by default.

This PR is intentionally not meant as a perfect implementation. The MatchCast is implemented to be on par with what MatchShape can do and for now only restricts to Tensor shape matching and we refactored from most of the existing logic. It offers a first step for us to complete transition of StructInfo. We will bring followup improvements to support full MatchCast.