### PR TITLE
[TVMScript] Fix empty TupleStructInfo

### DIFF
--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -130,7 +130,11 @@ class TupleProxy:
         if len(fields) == 1 and isinstance(fields[0], (tuple, list)):
             fields = fields[0]
 
-        # TODO(siyuan): Revisit this part
+        if len(fields) == 0:
+            # Note: We cannot detect it's an expr or a struct info for empty tuple.
+            # So we return an expr by default, and use a spacial case in parser to fix it.
+            return RxTuple([])
+
         if all([isinstance(f, Expr) for f in fields]):
             return RxTuple(fields)
         else:

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -85,6 +85,11 @@ def eval_type_annotation(
     annotation = self.eval_expr(node)
     if callable(annotation):
         annotation = annotation()
+
+    if isinstance(annotation, relax.Tuple) and len(annotation.fields) == 0:
+        # Case for empty tuple
+        annotation = relax.TupleStructInfo([])
+
     if isinstance(annotation, StructInfo):
         var_table = {k: v for k, v in self.var_table.get().items() if isinstance(v, tir.Var)}
         annotation, undefined_vars = R.RewriteSymbolicShape(annotation, var_table)

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -59,7 +59,7 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::TupleNode* op) {
   size_t num_fields = op->fields.size();
 
   if (num_fields == 0) {
-    return Doc::Text("tuple()");
+    return Doc::Text("R.Tuple()");
   }
 
   Doc doc;

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -751,6 +751,21 @@ def test_erase_to_well_defined():
     _check(foo, None)
 
 
+def test_empty_tuple():
+    @R.function
+    def foo(x: R.Tuple()):
+        y: R.Tuple() = R.Tuple()
+        return y
+
+    x = relax.Var("x", relax.TupleStructInfo([]))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", (x,)):
+        y = bb.emit(relax.Tuple([]))
+        bb.emit_func_output(y)
+
+    _check(foo, bb.get()["foo"])
+
+
 @pytest.mark.skip(reason="potential upstream Metadata changes.")
 def test_meta():
     metadata = tvm.ir.load_json(


### PR DESCRIPTION
This PR fixes the empty tuple issue. 

Empty `R.Tuple` would create an Expr instead of StructInfo. This PR adds an additional check during struct info parsing.

cc @tqchen 