### PR TITLE
[IR][ASTPrinter] Tweaks to AST printer's handling of struct info

### DIFF
--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -223,7 +223,7 @@ class ASTPrinter(ExprFunctor):
         Recurse down types and print their ASTs too
         """
         if isinstance(type_node, relax.ShapeType):
-            return self.build_ast_node("ShapeType")
+            return self.build_ast_node("ShapeType", ndim=str(type_node.ndim))
         if isinstance(type_node, relax.ObjectType):
             return self.build_ast_node("ObjectType")
         if isinstance(type_node, relax.PackedFuncType):

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -279,7 +279,7 @@ class ASTPrinter(ExprFunctor):
             )
         elif isinstance(struct_info_node, relax.FuncStructInfo):
             fields = {}
-            if struct_info_node.params:
+            if struct_info_node.params is not None:
                 fields["params"] = self.build_list(
                     map(self.visit_struct_info_, struct_info_node.params)
                 )

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -88,7 +88,7 @@ class ASTPrinter(ExprFunctor):
     def build_expr(self, node: relax.Expr, nodename: str, force_newline=False, **kwargs: str):
         """
         Renders a Relax expression as a string using `build_ast_node`.
-        Handles whether to include the checked_type_ and shape_ fields.
+        Handles whether to include the checked_type_ and struct_info fields.
         """
         fields = kwargs.copy()
         if node.struct_info_ and self.include_struct_info_annotations:
@@ -136,7 +136,7 @@ class ASTPrinter(ExprFunctor):
 
     def visit_extern_func_(self, op: relax.ExternFunc) -> str:
         # ExternFunc does not inherit from relax.Expr either,
-        # so it doesn't have checked_type_ or shape_ fields and we don't use build_expr
+        # so it doesn't have checked_type_ or struct_info fields and we don't use build_expr
         return self.build_ast_node("ExternFunc", global_symbol=wrap_quotes(op.global_symbol))
 
     def visit_global_var_(self, op: relax.GlobalVar) -> str:
@@ -203,7 +203,7 @@ class ASTPrinter(ExprFunctor):
     def visit_op_(self, op: tvm.ir.Op) -> str:
         # TODO: List other attributes?
         # op is not actually a Relax expr and does not have checked_type_
-        # or shape_ fields, so we don't use build_expr here
+        # or struct_info fields, so we don't use build_expr here
         return self.build_ast_node("Op", name=wrap_quotes(op.name))
 
     def visit_prim_expr_(self, prim_expr: PrimExpr) -> str:

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -274,7 +274,7 @@ class ASTPrinter(ExprFunctor):
             return self.build_ast_node("TensorStructInfo", **fields)
         elif isinstance(struct_info_node, relax.TupleStructInfo):
             return self.build_ast_node(
-                "TupleType",
+                "TupleStructInfo",
                 fields=self.build_list(map(self.visit_struct_info_, struct_info_node.fields)),
             )
         elif isinstance(struct_info_node, relax.FuncStructInfo):

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -262,8 +262,8 @@ def test_shape_expr():
 
 def test_types():
     printer = ASTPrinter()
-    shape_type = rx.ShapeType()
-    assert strip_whitespace(printer.visit_type_(shape_type)) == "ShapeType()"
+    assert strip_whitespace(printer.visit_type_(rx.ShapeType())) == "ShapeType(ndim=-1)"
+    assert strip_whitespace(printer.visit_type_(rx.ShapeType(ndim=1))) == "ShapeType(ndim=1)"
     object_type = rx.ObjectType()
     assert strip_whitespace(printer.visit_type_(object_type)) == "ObjectType()"
     packed_type = rx.PackedFuncType()
@@ -272,9 +272,11 @@ def test_types():
     assert strip_whitespace(printer.visit_type_(tensor_type)) == "DynTensorType(ndim=2,dtype=int32)"
     unit_type = rx.TupleType([])
     assert strip_whitespace(printer.visit_type_(unit_type)) == "TupleType(fields=[])"
-    tuple_type = rx.TupleType([shape_type, object_type])
+    tuple_type = rx.TupleType([rx.ShapeType(), object_type])
     assert_fields(
-        "TupleType", {"fields": "[ShapeType(), ObjectType()]"}, printer.visit_type_(tuple_type)
+        "TupleType",
+        {"fields": "[ShapeType(ndim=-1),ObjectType()]"},
+        strip_whitespace(printer.visit_type_(tuple_type)),
     )
 
     func_type = rx.FuncType([tensor_type], unit_type)
@@ -457,7 +459,7 @@ def test_print_struct_info_annotation_non_var():
                     ndim=1,
                     values=[PrimExpr(value=`2i64`)]
                 ),
-                checked_type_=ShapeType()
+                checked_type_=ShapeType(ndim=1)
             )
         )
         """
@@ -481,7 +483,7 @@ def test_print_type_annotation_non_var():
 
     call_str = strip_whitespace(dump_ast(call))
     # we expect the shape_of call to have a checked_type_ of ShapeType
-    type_str = "checked_type_=ShapeType()"
+    type_str = "checked_type_=ShapeType(ndim=-1)"
     assert type_str in call_str
 
 

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -41,7 +41,7 @@ def strip_whitespace(text: str) -> str:
 
 def normalize(func: rx.Function) -> rx.Function:
     """
-    Normalize the expr to fill in the checked_type_ and shape_ fields everywhere
+    Normalize the expr to fill in the checked_type_ and struct_info fields everywhere
     """
     # using a default mutator to use the BlockBuilder's normalizer,
     # which oddly differs from the Normalize pass
@@ -439,7 +439,7 @@ def test_operators():
     assert print_attrs_str in bar_str
 
 
-def test_print_shape_annotation_non_var():
+def test_print_struct_info_annotation_non_var():
     @R.function
     def f() -> R.Tensor:
         return R.const([1, 2])


### PR DESCRIPTION
Many thanks to @Hzfengsy and @tqchen for pushing through the transition to StructInfo. This PR makes a few tweaks to the AST printer as a result of these changes. In particular, it adds unit tests for printing StructInfo, eliminates outdated comments, prints `ndim` for ShapeType, corrects a typo (`TupleType` instead of `TupleStructInfo`), and also distinguishes between the case of omitting the `params` in `FuncStructInfo` (as would happen with opaque `FuncStructInfo`) and having zero params.