### PR TITLE
[TVMScript] Simple fix jupyter error reporting

### DIFF
--- a/python/tvm/error.py
+++ b/python/tvm/error.py
@@ -25,7 +25,9 @@ copy the examples and raise errors with the same message convention.
 
     Please also refer to :ref:`error-handling-guide`.
 """
-from tvm._ffi.base import register_error, TVMError
+from typing import List
+
+from tvm._ffi.base import TVMError, register_error
 
 
 @register_error
@@ -134,3 +136,7 @@ class DiagnosticError(TVMError):
 
     See the configured diagnostic renderer for detailed error information.
     """
+
+    def _render_traceback_(self) -> List[str]:
+        """Custom traceback for IPython/Jupyter Notebook"""
+        return None

--- a/src/ir/diagnostic.cc
+++ b/src/ir/diagnostic.cc
@@ -314,7 +314,7 @@ DiagnosticRenderer TerminalRenderer(std::ostream& out) {
   });
 }
 
-TVM_REGISTER_GLOBAL(DEFAULT_RENDERER).set_body_typed([]() { return TerminalRenderer(std::cout); });
+TVM_REGISTER_GLOBAL(DEFAULT_RENDERER).set_body_typed([]() { return TerminalRenderer(std::cerr); });
 
 TVM_REGISTER_GLOBAL("diagnostics.GetRenderer").set_body_typed([]() { return GetRenderer(); });
 


### PR DESCRIPTION
This PR hides traceback for DiagnosticError in IPython/Jupyter Notebook

Before:
```
error: Consequential assignments like 'a = b = c' are not supported.
 --> /tmp/ipykernel_751000/417432354.py:3:5
   |  
 3 |      gv0 = gv1 = R.call_tir("extern_func", x, (128, 128), dtype="float32")
   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
---------------------------------------------------------------------------
DiagnosticError                           Traceback (most recent call last)
Input In [2], in <cell line: 1>()
      1 @R.function
----> 2 def foo(x: R.Tensor((128, 128), "float32")) -> R.Tensor(None, "float32", ndim=2):
      3     gv0 = gv1 = R.call_tir("extern_func", x, (128, 128), dtype="float32")
      4     return gv0

File ~/relax/python/tvm/script/parser/relax/entry.py:48, in function(f)
     46 if utils.is_defined_in_class(inspect.stack(), f):
     47     return f
---> 48 return parse(f, utils.inspect_function_capture(f))

...
```

After:
```
error: Consequential assignments like 'a = b = c' are not supported.
 --> /tmp/ipykernel_744691/417432354.py:3:5
   |  
 3 |      gv0 = gv1 = R.call_tir("extern_func", x, (128, 128), dtype="float32")
   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```


cc @tqchen 