### PR TITLE
[TVMScript][Bugfix] Minor fix for `type_args` and constant printing

### DIFF
--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -171,7 +171,7 @@ def call_builtin(
     if isinstance(args, (list, tuple)):
         args = RxTuple(args)
 
-    if not isinstance(type_args, (list, tuple)):
+    if type_args is not None and not isinstance(type_args, (list, tuple)):
         type_args = [type_args]
 
     return _ffi_api.call_builtin(  # type: ignore

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -129,7 +129,7 @@ def call_builtin(
     func: Union[str, Expr],
     args: Union[RxTuple, List[Expr]],
     *,
-    type_args: Optional[List[Type]] = None,
+    type_args: Optional[Union[Type, List[Type]]] = None,
     int_args: Optional[List[int]] = None,
     dtype_arg: Optional[str] = None,
     str_args: Optional[List[str]] = None,
@@ -145,7 +145,7 @@ def call_builtin(
     args : Union[RxTuple, List[Expr]]
         The input arguments.
 
-    type_args: Optional[List[Type]]
+    type_args: Optional[Union[Type, List[Type]]]
         The type arguments to the call node.
 
     int_args: Optional[List[int]]
@@ -170,6 +170,9 @@ def call_builtin(
 
     if isinstance(args, (list, tuple)):
         args = RxTuple(args)
+
+    if not isinstance(type_args, (list, tuple)):
+        type_args = [type_args]
 
     return _ffi_api.call_builtin(  # type: ignore
         func, args, type_args, int_args, dtype_arg, str_args, require_ctx  # type: ignore

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -140,8 +140,9 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::CallNode* op) {
   if (!op->type_args.empty()) {
     doc << ", type_args=";
     std::vector<Doc> type_args = PrintTypeArgs(op->type_args);
+
     if (type_args.size() == 1) {
-      doc << type_args[0];
+      doc << "(" << type_args[0] << " ,)";
     } else {
       doc << "(" << Doc::Concat(type_args, Doc::Text(", ")) << ")";
     }
@@ -229,7 +230,7 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::ConstantNode* op) {
     } else if (dtype == DataType::Bool()) {
       scalar_val = ScalarLiteral(dtype, static_cast<const uint8_t*>(op->data->data)[0]);
     }
-    return doc << scalar_val;
+    return doc << "R.const(" << Doc::Concat({scalar_val, PrintDType(dtype)}) << ")";
   }
   // default fall-back, record it as meta node.
   // Don't append optional_info. Because the entry function is Print,

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -356,6 +356,7 @@ bool ReadIfCond(TVMArgValue cond) {
       break;
     }
     default:
+      result = 0;  // eliminate compilation warning: -Wsometimes-uninitialized
       LOG(FATAL) << "Unknown scalar int type: " << DLDataType2String(arr->dtype);
   }
   return result != 0;

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -356,8 +356,8 @@ bool ReadIfCond(TVMArgValue cond) {
       break;
     }
     default:
-      result = 0;  // eliminate compilation warning: -Wsometimes-uninitialized
       LOG(FATAL) << "Unknown scalar int type: " << DLDataType2String(arr->dtype);
+      throw;
   }
   return result != 0;
 }

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -450,5 +450,4 @@ def test_func_type():
 
 
 if __name__ == "__main__":
-    test_relax_base_op()
     tvm.testing.main()

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -204,7 +204,15 @@ def test_call_packed():
     check_roundtrip(foo)
 
 
-@pytest.mark.skip("Need to fix string ast expr")
+def test_relax_base_op():
+    @R.function
+    def foo(x: R.Tensor((2, 4), dtype="float32")):
+        gv = R.call_builtin("test_intrin", [x], type_args=R.Object)
+        return gv
+
+    check_roundtrip(foo)
+
+
 def test_primexpr_arithmetic():
     @R.function
     def foo(x: R.Tensor(("n", "m"), "float32")):
@@ -271,6 +279,18 @@ def test_const():
         return w
 
     check_roundtrip(my_const)
+
+
+def test_scalar_const():
+    x = relax.Var("x", relax.TensorStructInfo((8,)))
+    const_one = relax.const(1, "float32")
+
+    bb = relax.BlockBuilder()
+    with bb.function("main", [x]):
+        v0 = bb.emit(R.add(x, const_one))
+        bb.emit_func_output(v0)
+
+    check_roundtrip(bb.get())
 
 
 def test_const_meta():
@@ -430,4 +450,5 @@ def test_func_type():
 
 
 if __name__ == "__main__":
+    test_relax_base_op()
     tvm.testing.main()


### PR DESCRIPTION
Minor fixes:
1. eliminate compilation warning on my env (clang-15).
2. Print `R.const` for every ConstantNode, even if scalar to support tuple (e.g. `(x, 1)`) and possible PrimValue in the near future.
3. Always print list for `type_args`, also support direct type for `R.call_builtin`

Thanks for the bug reporting from @vinx13 

cc @vinx13 @tqchen 