### PR TITLE
[UX][TVMScript] Enable relax arithmetic operators

### DIFF
--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -79,14 +79,14 @@ class StructInfo(Node):
         return _ffi_api.StructInfoIsBaseOf(self, derived)  # type: ignore
 
 
-# will be registered afterwards
+# will be registered afterwards in python/tvm/relax/op/init.py
 _op_ffi_api = None
 
 
 def _binary_op_helper(lhs: "ExprWithOp", rhs: "ExprWithOp", op: Callable) -> "ExprWithOp":
-    if not isinstance(lhs, relay.Expr):
+    if not isinstance(lhs, Expr):  # type: ignore
         raise ValueError("lhs must be Expr")
-    if isinstance(rhs, relay.Expr):
+    if isinstance(rhs, Expr):  # type: ignore
         return op(lhs, rhs)
     elif isinstance(rhs, Number):
         raise TypeError(f"Please convert {rhs} with `const` first")
@@ -170,6 +170,7 @@ class ExprWithOp(Expr):
         return _binary_rhs_helper(other)
 
     def __mod__(self, other: Expr) -> "ExprWithOp":
+        # TODO(siyuan): Support it after mod operator is supported in relax
         raise ValueError("relax.mod is not supported yet.")
 
     def __rmod__(self, other: Expr) -> "ExprWithOp":

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -17,22 +17,24 @@
 # pylint: disable=invalid-name, unused-import, super-init-not-called
 # pylint: disable=redefined-builtin
 """The expression nodes of Relax."""
-from typing import Any, List, Optional, Union
 import typing
-import numpy as _np  # type: ignore
+from numbers import Number
+from typing import Any, Callable, Dict, List, Optional, Union
 
+import numpy as _np  # type: ignore
 import tvm
 import tvm._ffi
-from tvm.runtime import ndarray as _nd
 import tvm.relax
-
+from tvm import DataType
 from tvm._ffi import base as _base
+from tvm.runtime import ndarray as _nd
+
 from .. import relay
 from ..ir import BaseFunc, Node, SourceName, Span
 from ..relay import Id
 from ..runtime import String
 from ..tir import PrimExpr
-from . import _ffi_api, ty
+from . import _ffi_api
 
 # It is a workaround for mypy: https://github.com/python/mypy/issues/7866#issuecomment-549454370
 # This feature is not supported until python 3.10:
@@ -77,8 +79,142 @@ class StructInfo(Node):
         return _ffi_api.StructInfoIsBaseOf(self, derived)  # type: ignore
 
 
+# will be registered afterwards
+_op_ffi_api = None
+
+
+def _binary_op_helper(lhs: "ExprWithOp", rhs: "ExprWithOp", op: Callable) -> "ExprWithOp":
+    if not isinstance(lhs, relay.Expr):
+        raise ValueError("lhs must be Expr")
+    if isinstance(rhs, relay.Expr):
+        return op(lhs, rhs)
+    elif isinstance(rhs, Number):
+        raise TypeError(f"Please convert {rhs} with `const` first")
+    else:
+        raise TypeError(f"type {type(rhs)} not supported")
+
+
+def _binary_rhs_helper(rhs: "ExprWithOp") -> "ExprWithOp":
+    if isinstance(rhs, Number):
+        raise TypeError(f"Please convert {rhs} with `const` first")
+    raise TypeError(f"type {type(rhs)} not supported")
+
+
+class ExprWithOp(Expr):
+    """Basetype of all relax expressions that defines op overloading."""
+
+    def astype(self, dtype: Union[str, DataType]) -> "ExprWithOp":
+        """Cast the content type of the current data to dtype.
+
+        Parameters
+        ----------
+        dtype : str
+            The target data type.
+
+        Note
+        ----
+        This function only works for TensorType Exprs.
+
+        Returns
+        -------
+        result : ExprWithOp
+            The result expression.
+        """
+        return _op_ffi_api.astype(self, dtype)  # type: ignore
+
+    def __neg__(self) -> "ExprWithOp":
+        raise ValueError("relax.negative is not supported yet.")
+
+    def __lt__(self, other: Expr) -> "ExprWithOp":
+        return _binary_op_helper(self, other, _op_ffi_api.less)  # type: ignore
+
+    def __gt__(self, other: Expr) -> "ExprWithOp":
+        return _binary_op_helper(self, other, _op_ffi_api.greater)  # type: ignore
+
+    def __ge__(self, other: Expr) -> "ExprWithOp":
+        return _binary_op_helper(self, other, _op_ffi_api.greater_equal)  # type: ignore
+
+    def __le__(self, other: Expr) -> "ExprWithOp":
+        return _binary_op_helper(self, other, _op_ffi_api.less_equal)  # type: ignore
+
+    # NOTE: Cannot override __eq__ and __ne__, which will influence object equal
+
+    def __add__(self, other: Expr) -> "ExprWithOp":
+        return _binary_op_helper(self, other, _op_ffi_api.add)  # type: ignore
+
+    def __radd__(self, other: Expr) -> "ExprWithOp":
+        return self.__add__(other)
+
+    def __sub__(self, other: Expr) -> "ExprWithOp":
+        return _binary_op_helper(self, other, _op_ffi_api.subtract)  # type: ignore
+
+    def __rsub__(self, other: Expr) -> "ExprWithOp":
+        return _binary_rhs_helper(other)
+
+    def __mul__(self, other: Expr) -> "ExprWithOp":
+        return _binary_op_helper(self, other, _op_ffi_api.multiply)  # type: ignore
+
+    def __rmul__(self, other: Expr) -> "ExprWithOp":
+        return self.__mul__(other)
+
+    def __truediv__(self, other: Expr) -> "ExprWithOp":
+        return _binary_op_helper(self, other, _op_ffi_api.divide)  # type: ignore
+
+    def __rtruediv__(self, other: Expr) -> "ExprWithOp":
+        return _binary_rhs_helper(other)
+
+    def __floordiv__(self, other: Expr) -> "ExprWithOp":
+        return _binary_op_helper(self, other, _op_ffi_api.floor_divide)  # type: ignore
+
+    def __rfloordiv__(self, other: Expr) -> "ExprWithOp":
+        return _binary_rhs_helper(other)
+
+    def __mod__(self, other: Expr) -> "ExprWithOp":
+        raise ValueError("relax.mod is not supported yet.")
+
+    def __rmod__(self, other: Expr) -> "ExprWithOp":
+        return _binary_rhs_helper(other)
+
+    def __call__(self, *args: List[Expr], attrs: Optional[Dict[str, Any]] = None) -> "ExprWithOp":
+        """Call the variable (if it represents a function).
+
+        Parameters
+        ----------
+        args: List[Expr]
+            The arguments to the call.
+
+        attr: Optional[Dict[str, object]]
+            The additional attributes to the call.
+
+        Returns
+        -------
+        call: ExprWithOp
+            A call taking the variable as a function.
+        """
+        return Call(self, args, attrs=attrs)
+
+    def __getitem__(self, index: int) -> "ExprWithOp":
+        """Get the i-th element of the tuple or Expr with TupleType.
+
+        Parameters
+        ----------
+        index: int
+            The index of the element to be retrieved.
+
+        Note
+        ----
+        This function will be overridden by Tuple and ShapeExpr
+
+        Returns
+        -------
+        result: ExprWithOp
+            The result expression.
+        """
+        return TupleGetItem(self, index)
+
+
 @tvm._ffi.register_object("relax.expr.Call")
-class Call(Expr):
+class Call(ExprWithOp):
     """Function call node in Relax.
 
     Call node corresponds the operator application node
@@ -119,7 +255,7 @@ class Call(Expr):
 
 
 @tvm._ffi.register_object("relax.expr.If")
-class If(Expr):
+class If(ExprWithOp):
     """A conditional expression in Relax.
 
     Parameters
@@ -141,7 +277,7 @@ class If(Expr):
 
 
 @tvm._ffi.register_object("relax.expr.Tuple")
-class Tuple(Expr):
+class Tuple(ExprWithOp):
     """Tuple expression that groups several fields together.
 
     Parameters
@@ -166,7 +302,7 @@ class Tuple(Expr):
 
 
 @tvm._ffi.register_object("relax.expr.TupleGetItem")
-class TupleGetItem(Expr):
+class TupleGetItem(ExprWithOp):
     """Get index-th item from a tuple.
 
     Parameters
@@ -185,7 +321,7 @@ class TupleGetItem(Expr):
 
 
 @tvm._ffi.register_object("relax.expr.ShapeExpr")
-class ShapeExpr(Expr):
+class ShapeExpr(ExprWithOp):
     """A shape expression which allows users to construct a shape containing PrimExpr."""
 
     values: List[PrimExpr]
@@ -213,13 +349,13 @@ def make_shape(shape: Union[List[Any], typing.Tuple[Any, ...]]) -> ShapeExpr:
 
 
 @tvm._ffi.register_object("relax.expr.Constant")
-class Constant(Expr):
+class Constant(ExprWithOp):
     def __init__(self, data: tvm.nd.NDArray, span: Span = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.Constant, data, span)  # type: ignore
 
 
 @tvm._ffi.register_object("relax.expr.Var")
-class Var(Expr):
+class Var(ExprWithOp):
     """The variable class for all Relax bindings."""
 
     vid: Id
@@ -251,25 +387,6 @@ class Var(Expr):
         """Get name hint of the current var."""
         name = str(self.vid.name_hint)
         return name
-
-    def __call__(self, *args: Any, attrs=None) -> Call:
-        if self._checked_type_ and isinstance(self._checked_type_, ty.FuncType):
-            return Call(self, args, attrs=attrs)
-        else:
-            raise TypeError(
-                f"Only vars with function type can be called, but got type: {self._checked_type_}"
-            )
-
-    def __getitem__(self, key):
-        if not isinstance(key, int):
-            raise TypeError("TupleGetItem only supports integer index")
-        var_type = self._checked_type_
-        if var_type and isinstance(var_type, ty.TupleType):
-            return TupleGetItem(self, key)
-        else:
-            raise TypeError(
-                f"Only vars with TupleType is subscriptable, but got type: {self._checked_type_}"
-            )
 
 
 @tvm._ffi.register_object("relax.expr.DataflowVar")
@@ -375,7 +492,7 @@ class DataflowBlock(BindingBlock):
 
 
 @tvm._ffi.register_object("relax.expr.SeqExpr")
-class SeqExpr(Expr):
+class SeqExpr(ExprWithOp):
     """A sequence of binding blocks followed by an expression."""
 
     blocks: List[BindingBlock]

--- a/python/tvm/relax/op/__init__.py
+++ b/python/tvm/relax/op/__init__.py
@@ -35,3 +35,14 @@ from . import builtin
 from . import image
 from . import memory
 from . import nn
+
+
+def _register_op_make():
+    # pylint: disable=import-outside-toplevel
+    from . import _ffi_api
+    from .. import expr
+
+    expr._op_ffi_api = _ffi_api  # type: ignore
+
+
+_register_op_make()

--- a/tests/python/relax/test_op.py
+++ b/tests/python/relax/test_op.py
@@ -16,7 +16,6 @@
 # under the License.
 import tvm
 import tvm.testing
-from tvm import relay
 from tvm import relax as rx
 from tvm.script import relax as R
 from tvm.script import tir as T
@@ -53,7 +52,7 @@ def test_implicit_op():
         assert isinstance(expr, rx.Call)
         if not op_name.startswith("relax."):
             op_name = "relax." + op_name
-        op = relay.op.get(op_name)
+        op = tvm.ir.Op.get(op_name)
         assert expr.op == op
 
     # Comparison operators

--- a/tests/python/relax/test_op.py
+++ b/tests/python/relax/test_op.py
@@ -14,14 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import pytest
 import tvm
+import tvm.testing
+from tvm import relay
 from tvm import relax as rx
 from tvm.script import relax as R
 from tvm.script import tir as T
 
 
-@tvm.register_func("test.op.identity")
+@tvm.register_func("test.op.identity", override=True)
 def identity_packed(a):
     return tvm.nd.array(a.asnumpy())
 
@@ -43,5 +44,55 @@ def test_call_tir() -> None:
     v1 = rx.call_tir(identity_tir, [v0], [54, 96], "float32")
 
 
+def test_implicit_op():
+    m, n = tvm.tir.Var("m", "int64"), tvm.tir.Var("n", "int64")
+    x = rx.Var("x", R.Tensor([m, n], "float32"))
+    y = rx.Var("y", R.Tensor([m, n], "float32"))
+
+    def _check_call(expr, op_name: str):
+        assert isinstance(expr, rx.Call)
+        if not op_name.startswith("relax."):
+            op_name = "relax." + op_name
+        op = relay.op.get(op_name)
+        assert expr.op == op
+
+    # Comparison operators
+    _check_call(x > y, "greater")
+    _check_call(x >= y, "greater_equal")
+    _check_call(x < y, "less")
+    _check_call(x <= y, "less_equal")
+
+    # Arithmetic operators
+    _check_call(x + y, "add")
+    _check_call(x - y, "subtract")
+    _check_call(x * y, "multiply")
+    _check_call(x / y, "divide")
+    _check_call(x // y, "floor_divide")
+    # _check_call(x % y, "mod") <= relax.mod is not implemented yet
+
+    # Cast
+    _check_call(x.astype("float32"), "astype")
+
+    # Call
+    call_expr = x(y)(y)
+    assert isinstance(call_expr.op, rx.Call)
+    assert call_expr.op.op == x
+
+    # GetTupleItem
+    ## Eager get item for tuple
+    tuple_expr = rx.Tuple((x, y))
+    assert tuple_expr[0] == x
+    assert tuple_expr[1] == y
+
+    ## Eager get item for ShapeExpr
+    shape_expr = rx.ShapeExpr((1, 2))
+    assert shape_expr[0] == 1
+    assert shape_expr[1] == 2
+
+    ## Create TupleGetItem for other expr
+    assert isinstance(x[0], rx.TupleGetItem)
+    assert isinstance(x[1][0], rx.TupleGetItem)
+
+
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -186,9 +186,6 @@ def test_shadowing():
         z = bb.emit(y)
         bb.emit_func_output(z)
 
-    print(foo.script())
-    print(bb.get()["foo"])
-
     _check(foo, bb.get()["foo"])
 
 
@@ -868,9 +865,8 @@ def test_arith_operators():
         tuple_expr = ((x, x), y)
         t0 = tuple_expr[0]
         t1 = tuple_expr[1]
-        t2 = tuple_expr[0][0] # <= Will normalize to two bindings
+        t2 = tuple_expr[0][0]  # <= Will normalize to two bindings
         return a0, a1, a2, a3, a4, c0, c1, c2, c3, t0, t1, t2
-
 
     m = tir.Var("m", "int64")
     n = tir.Var("n", "int64")

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -186,6 +186,9 @@ def test_shadowing():
         z = bb.emit(y)
         bb.emit_func_output(z)
 
+    print(foo.script())
+    print(bb.get()["foo"])
+
     _check(foo, bb.get()["foo"])
 
 
@@ -846,6 +849,29 @@ def test_symbolic_shape_computing():
         def foo(x: R.Tensor(("m + 1", "m * 2"), "float32")):  # name 'm' is not defined
             z = R.add(x, x)
             return z
+
+
+def test_arith_operators():
+    @R.function
+    def foo(x: R.Tensor(("m", "n"), "float32"), y: R.Tensor(("m", "n"), "float32")):
+        a0 = x + y
+        a1 = x - y
+        a2 = x * y
+        a3 = x / y
+        a4 = x // y
+
+        c0 = x > y
+        c1 = x < y
+        c2 = x >= y
+        c3 = x <= y
+
+        tuple_expr = ((x, x), y)
+        t0 = tuple_expr[0]
+        t1 = tuple_expr[1]
+        t2 = tuple_expr[0][0]
+        return a0, a1, a2, a3, a4, c0, c1, c2, c3, t0, t1, t2
+
+    _check(foo, None)
 
 
 @pytest.mark.skip(reason="potential upstream Metadata changes.")


### PR DESCRIPTION
This PR enables arithmetic operators (e.g. `+`, `//`) for relax Expr, with sequential TupleGetItem Or Call support.

```python
@R.function
def foo(x: R.Tensor(("m", "n"), "float32"), y: R.Tensor(("m", "n"), "float32")):
    a0 = x + y
    a1 = x - y
    a2 = x * y
    a3 = x / y
    a4 = x // y

    c0 = x > y
    c1 = x < y
    c2 = x >= y
    c3 = x <= y

    tuple_expr = ((x, x), y)
    t0 = tuple_expr[0]
    t1 = tuple_expr[1]
    t2 = tuple_expr[0][0]
    return a0, a1, a2, a3, a4, c0, c1, c2, c3, t0, t1, t2
```