### PR TITLE
[Fix][Printer] Fix PrintFinal dispatch for Relax dedicated Expr

### DIFF
--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -599,9 +599,18 @@ class TextPrinter {
                (node->IsInstance<tir::PrimFuncNode>() || node->IsInstance<PrimExprNode>() ||
                 node->IsInstance<tir::StmtNode>())) {
       doc << tir_text_printer_.Print(node);
-    } else if (node.defined() &&
-               (node->IsInstance<relax::VarNode>() || node->IsInstance<relax::FunctionNode>() ||
-                node->IsInstance<relax::ShapeExprNode>())) {
+    } else if (node.defined() && (node->IsInstance<relax::VarNode>() ||           //
+                                  node->IsInstance<relax::FunctionNode>() ||      //
+                                  node->IsInstance<relax::ShapeExprNode>() ||     //
+                                  node->IsInstance<relax::TupleNode>() ||         //
+                                  node->IsInstance<relax::TupleGetItemNode>() ||  //
+                                  node->IsInstance<relax::CallNode>() ||          //
+                                  node->IsInstance<relax::IfNode>() ||            //
+                                  node->IsInstance<relax::ConstantNode>() ||      //
+                                  node->IsInstance<relax::BindingNode>() ||       //
+                                  node->IsInstance<relax::BindingBlockNode>() ||  //
+                                  node->IsInstance<relax::SeqExprNode>() ||       //
+                                  node->IsInstance<relax::ExternFuncNode>())) {
       doc << relax_text_printer_.Print(node);
     } else {
       doc << relay_text_printer_.PrintFinal(node);


### PR DESCRIPTION
PR #306 introduces dedicated Relax Exprs, making Relax sub-class Expr independent of Relay Expr. This PR is a fix on the text printer accordingly.

Prior to this PR, TextPrinter::PrintFinal only dispatch VarNode, FunctionNode and ShapeExprNode to Relax printer, leaving all other kinds of Exprs to Relay text printer. This is fine at the time before PR #306, when we were reusing Exprs from Relay. But since #306 this becomes an issue, because Relax Exprs are not properly dispatched to Relax printer. As a result, when we print a CallNode or TupleNode on Python side, or structural-equality check finds mismatch on Tuples, the PrettyPrint as well as PrintFinal cannot dispatch the Expr, and will result in error like
```
  Check failed: (can_dispatch(n)) is false: NodeFunctor calls un-registered function on type relax.expr.Tuple
```
which is not supposed and is also the least informative.

So this PR fixes the issue by adding our Relax Exprs to the dispatch rule. There are corresponding unit tests to make sure the printer issue is not likely to happen again.

---

cc @Hzfengsy @YuchenJin @tqchen 