### PR TITLE
[FIX] Fix ShapeExpr/Tuple getitem

### DIFF
--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -335,8 +335,8 @@ class ShapeExpr(ExprWithOp):
         self.__init_handle_by_constructor__(_ffi_api.ShapeExpr, values, span)  # type: ignore
 
     def __getitem__(self, index):
-        if index >= len(self) or index < 0:
-            raise IndexError("Tuple index out of range")
+        if index >= len(self):
+            raise IndexError("ShapeExpr index out of range")
         return self.values[index]
 
     def __len__(self):

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -294,7 +294,7 @@ class Tuple(ExprWithOp):
         self.__init_handle_by_constructor__(_ffi_api.Tuple, fields, span)  # type: ignore
 
     def __getitem__(self, index: int) -> Expr:
-        if index >= len(self):
+        if index >= len(self) or index < -len(self):
             raise IndexError("Tuple index out of range")
         return self.fields[index]
 
@@ -335,7 +335,7 @@ class ShapeExpr(ExprWithOp):
         self.__init_handle_by_constructor__(_ffi_api.ShapeExpr, values, span)  # type: ignore
 
     def __getitem__(self, index):
-        if index >= len(self):
+        if index >= len(self) or index < -len(self):
             raise IndexError("ShapeExpr index out of range")
         return self.values[index]
 

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -192,6 +192,12 @@ def test_shape_expr():
     assert s[-2] == m
     assert isinstance(s.struct_info, rx.ShapeStructInfo)
 
+    with pytest.raises(IndexError, match="ShapeExpr index out of range"):
+        s[2]
+
+    with pytest.raises(IndexError, match="ShapeExpr index out of range"):
+        s[-3]
+
     shape_expr = rx.ShapeExpr([10, 20])
     assert shape_expr.values[0] == 10
     assert shape_expr.values[1] == 20

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -186,6 +186,10 @@ def test_shape_expr():
     s = rx.ShapeExpr([m, n])
     assert s.values[0] == m
     assert s.values[1] == n
+    assert s[0] == m
+    assert s[1] == n
+    assert s[-1] == m
+    assert s[-2] == n
     assert isinstance(s.struct_info, rx.ShapeStructInfo)
 
     shape_expr = rx.ShapeExpr([10, 20])

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -67,6 +67,26 @@ def test_dataflow_var() -> None:
     tvm.ir.assert_structural_equal(v1.struct_info, rx.TensorStructInfo(shape, "float16"))
 
 
+def test_tuple() -> None:
+    v0 = rx.Var("v0")
+    v1 = rx.Var("v1")
+    t = rx.Tuple((v0, v1))
+
+    assert t.fields[0] == v0
+    assert t.fields[1] == v1
+    assert t[0] == v0
+    assert t[1] == v1
+    assert t[-1] == v1
+    assert t[-2] == v0
+
+    with pytest.raises(IndexError, match="Tuple index out of range"):
+        t[2]
+
+    with pytest.raises(IndexError, match="Tuple index out of range"):
+        t[-3]
+
+
+
 def test_match_cast() -> None:
     # match_cast([16, 8], [m, n])
     m = tir.Var("m", dtype="int64")

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -188,8 +188,8 @@ def test_shape_expr():
     assert s.values[1] == n
     assert s[0] == m
     assert s[1] == n
-    assert s[-1] == m
-    assert s[-2] == n
+    assert s[-1] == n
+    assert s[-2] == m
     assert isinstance(s.struct_info, rx.ShapeStructInfo)
 
     shape_expr = rx.ShapeExpr([10, 20])

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -86,7 +86,6 @@ def test_tuple() -> None:
         t[-3]
 
 
-
 def test_match_cast() -> None:
     # match_cast([16, 8], [m, n])
     m = tir.Var("m", dtype="int64")


### PR DESCRIPTION
Currently ShapeExpr checks index should be non-negative in `__getitem__`, which is unnecessary and effects the lowering process of several Ops that receives negative index. This PR removes this check.