### PR TITLE
[Op] Use int64 IntImms as static shape-related attributes

### DIFF
--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -31,9 +31,9 @@ namespace relax {
 
 /*! \brief Attributes used in Conv2d operator */
 struct Conv2DAttrs : public tvm::AttrsNode<Conv2DAttrs> {
-  Array<PrimExpr> strides;
-  Array<PrimExpr> padding;
-  Array<PrimExpr> dilation;
+  Array<IntImm> strides;
+  Array<IntImm> padding;
+  Array<IntImm> dilation;
   int groups;
   String data_layout;
   String kernel_layout;
@@ -77,9 +77,9 @@ struct Conv2DAttrs : public tvm::AttrsNode<Conv2DAttrs> {
 /*! \brief Attributes used in max_pool2d operator */
 struct MaxPool2DAttrs : public tvm::AttrsNode<MaxPool2DAttrs> {
   Array<PrimExpr> pool_size;
-  Array<PrimExpr> strides;
-  Array<PrimExpr> padding;
-  Array<PrimExpr> dilation;
+  Array<IntImm> strides;
+  Array<IntImm> padding;
+  Array<IntImm> dilation;
   bool ceil_mode;
   String layout;
   String out_layout;

--- a/src/relax/op/nn/convolution.h
+++ b/src/relax/op/nn/convolution.h
@@ -36,13 +36,13 @@ namespace tvm {
 namespace relax {
 
 template <typename T>
-inline Expr MakeConv(Expr data, Expr weight, Array<PrimExpr> strides, Array<PrimExpr> padding,
-                     Array<PrimExpr> dilation, int groups, String data_layout, String kernel_layout,
+inline Expr MakeConv(Expr data, Expr weight, Array<IntImm> strides, Array<IntImm> padding,
+                     Array<IntImm> dilation, int groups, String data_layout, String kernel_layout,
                      String out_layout, DataType out_dtype, std::string op_name) {
   auto attrs = make_object<T>();
-  attrs->strides = std::move(strides);
-  attrs->padding = std::move(padding);
-  attrs->dilation = std::move(dilation);
+  attrs->strides = ConvertIntImmToInt64(strides);
+  attrs->padding = ConvertIntImmToInt64(padding);
+  attrs->dilation = ConvertIntImmToInt64(dilation);
   attrs->groups = groups;
   attrs->data_layout = std::move(data_layout);
   attrs->kernel_layout = std::move(kernel_layout);
@@ -53,8 +53,8 @@ inline Expr MakeConv(Expr data, Expr weight, Array<PrimExpr> strides, Array<Prim
 }
 
 /*! \brief 2D convolution */
-Expr conv2d(Expr data, Expr weight, Array<PrimExpr> strides, Array<PrimExpr> padding,
-            Array<PrimExpr> dilation, int groups, String data_layout, String kernel_layout,
+Expr conv2d(Expr data, Expr weight, Array<IntImm> strides, Array<IntImm> padding,
+            Array<IntImm> dilation, int groups, String data_layout, String kernel_layout,
             Optional<String> out_layout, DataType out_dtype);
 
 }  // namespace relax

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -28,8 +28,8 @@ namespace relax {
 /* relax.nn.max_pool2d */
 TVM_REGISTER_NODE_TYPE(MaxPool2DAttrs);
 
-Expr max_pool2d(Expr data, Array<PrimExpr> pool_size, Array<PrimExpr> strides,
-                Array<PrimExpr> padding, Array<PrimExpr> dilation, bool ceil_mode, String layout,
+Expr max_pool2d(Expr data, Array<PrimExpr> pool_size, Array<IntImm> strides, Array<IntImm> padding,
+                Array<IntImm> dilation, bool ceil_mode, String layout,
                 Optional<String> out_layout) {
   padding = GetCompletePadding2D(std::move(padding));
   if (pool_size.size() == 1) {
@@ -53,9 +53,9 @@ Expr max_pool2d(Expr data, Array<PrimExpr> pool_size, Array<PrimExpr> strides,
 
   auto attrs = make_object<MaxPool2DAttrs>();
   attrs->pool_size = std::move(pool_size);
-  attrs->strides = std::move(strides);
-  attrs->padding = std::move(padding);
-  attrs->dilation = std::move(dilation);
+  attrs->strides = ConvertIntImmToInt64(strides);
+  attrs->padding = ConvertIntImmToInt64(padding);
+  attrs->dilation = ConvertIntImmToInt64(dilation);
   attrs->ceil_mode = ceil_mode;
   attrs->layout = layout;
   attrs->out_layout = out_layout.value_or(layout);
@@ -103,8 +103,8 @@ StructInfo InferStructInfoMaxPool2D(const Call& call, const BlockBuilder& ctx) {
     numerator_h += attrs->strides[0] - 1;
     numerator_w += attrs->strides[1] - 1;
   }
-  out_NCHW_shape[2] = analyzer->Simplify(numerator_h / attrs->strides[0] + 1);
-  out_NCHW_shape[3] = analyzer->Simplify(numerator_w / attrs->strides[1] + 1);
+  out_NCHW_shape[2] = analyzer->Simplify(floordiv(numerator_h, attrs->strides[0]) + 1);
+  out_NCHW_shape[3] = analyzer->Simplify(floordiv(numerator_w, attrs->strides[1]) + 1);
 
   Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype);

--- a/src/relax/op/nn/pooling.h
+++ b/src/relax/op/nn/pooling.h
@@ -33,9 +33,8 @@ namespace tvm {
 namespace relax {
 
 /*! \brief 2D maximum pooling operator. */
-Expr max_pool2d(Expr data, Array<PrimExpr> pool_size, Array<PrimExpr> strides,
-                Array<PrimExpr> padding, Array<PrimExpr> dilation, bool ceil_mode, String layout,
-                Optional<String> out_layout);
+Expr max_pool2d(Expr data, Array<PrimExpr> pool_size, Array<IntImm> strides, Array<IntImm> padding,
+                Array<IntImm> dilation, bool ceil_mode, String layout, Optional<String> out_layout);
 
 /*! \brief 2D adaptive average pooling operator. */
 Expr adaptive_avg_pool2d(Expr data, Optional<Array<PrimExpr>> output_size, String layout,

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -176,6 +176,15 @@ inline int NormalizeAxis(const Call& call, const BlockBuilder& ctx, int ndim, in
   return NormalizeAxes(call, ctx, ndim, {axis})[0];
 }
 
+/*!
+ * \brief Convert an array of integers to int64 dtype.
+ * \param int_imms The input IntImms to be converted.
+ * \return The conversion result, where every IntImm has dtype int64
+ */
+inline Array<IntImm> ConvertIntImmToInt64(const Array<IntImm>& int_imms) {
+  return int_imms.Map([](const IntImm& i) { return Downcast<IntImm>(cast(DataType::Int(64), i)); });
+}
+
 /************ Utilities for NN operators ************/
 
 /*!
@@ -187,7 +196,7 @@ inline int NormalizeAxis(const Call& call, const BlockBuilder& ctx, int ndim, in
  * \return The completed padding.
  * \throws Throws error if the input padding length is neither 1, 2 or 4.
  */
-inline Array<PrimExpr> GetCompletePadding2D(Array<PrimExpr> padding) {
+inline Array<IntImm> GetCompletePadding2D(Array<IntImm> padding) {
   if (padding.size() == 1) {
     return {padding[0], padding[0], padding[0], padding[0]};
   } else if (padding.size() == 2) {

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -600,10 +600,12 @@ Expr split(Expr x, ObjectRef indices_or_sections, int axis) {
                                "However, the given indices "
                             << indices_or_sections << " contains some non-integer.";
     }
+    indices_or_sections = ConvertIntImmToInt64(GetRef<Array<IntImm>>(indices));
   } else if (const auto* n_section = indices_or_sections.as<IntImmNode>()) {
     CHECK_GT(n_section->value, 0) << "Split op expects the input number of sections to be a "
                                      "positive integer. However, the given number of sections is "
                                   << n_section->value;
+    indices_or_sections = IntImm(DataType::Int(64), n_section->value);
   } else {
     LOG(FATAL) << "Split op expects the input indices_or_sections to be either an Array of "
                   "PrimExpr or an integer. However, the given one is "

--- a/tests/python/relax/test_op_index.py
+++ b/tests/python/relax/test_op_index.py
@@ -530,6 +530,23 @@ def test_strided_slice_infer_struct_info_no_axis():
     )
 
 
+def test_strided_slice_begin_end_strides_int64():
+    x = relax.Var("x", R.Tensor((8, 9, 10, 10), "float32"))
+    strided_slice = relax.op.strided_slice(
+        x, axes=[0, 1, 3], begin=[1, 0, 8], end=[8, 9, 0], strides=[2, 1, -3]
+    )
+
+    assert strided_slice.attrs.begin[0].dtype == "int64"
+    assert strided_slice.attrs.begin[1].dtype == "int64"
+    assert strided_slice.attrs.begin[2].dtype == "int64"
+    assert strided_slice.attrs.end[0].dtype == "int64"
+    assert strided_slice.attrs.end[1].dtype == "int64"
+    assert strided_slice.attrs.end[2].dtype == "int64"
+    assert strided_slice.attrs.strides[0].dtype == "int64"
+    assert strided_slice.attrs.strides[1].dtype == "int64"
+    assert strided_slice.attrs.strides[2].dtype == "int64"
+
+
 def test_strided_slice_inconsistent_axes_begin_end_strides_length():
     x = relax.Var("x", R.Tensor((8, 9), "float32"))
 

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -1676,6 +1676,16 @@ def test_split_infer_struct_info_by_n_section():
     )
     _check_inference(
         bb,
+        relax.op.split(x0, 2, axis=1),
+        relax.TupleStructInfo(
+            [
+                relax.TensorStructInfo((2, 5, 4), "float32"),
+                relax.TensorStructInfo((2, 5, 4), "float32"),
+            ]
+        ),
+    )
+    _check_inference(
+        bb,
         relax.op.split(x0, 3, axis=-2),
         relax.TupleStructInfo(
             [
@@ -1930,6 +1940,16 @@ def test_split_infer_struct_info_single_output():
         relax.op.split(x5, 1, axis=1),
         relax.TupleStructInfo([relax.TensorStructInfo(s2, "float32")]),
     )
+
+
+def test_split_indices_or_sections_int64():
+    x = relax.Var("x", R.Tensor((2, 10, 4), "float32"))
+    split0 = relax.op.split(x, [3, 6], axis=1)
+    split1 = relax.op.split(x, 4, axis=1)
+
+    assert split0.attrs.indices_or_sections[0].dtype == "int64"
+    assert split0.attrs.indices_or_sections[1].dtype == "int64"
+    assert split1.attrs.indices_or_sections.dtype == "int64"
 
 
 def test_split_infer_struct_info_non_integer_indices():


### PR DESCRIPTION
This PR introduces the conversion for shape-related static integer op attributes.

Currently in Relax the default integer dtype for shape-related values is int64, while TVM FFI’s default dtype for integers is int32. This means when our TVMScript parser parsing an integer attribute of a operator, the parsed dtype will be int32, the default integer dtype of FFI.

However, for shape-related attributes we hope them to have int64 dtype. Therefore, this PR will actively converts them to int64 upon construction of op calls. To simplify the conversion, we change the type of these values from `Integer` to `IntImm`.

We add regression tests to make sure that these fields are indeed int64 after parsing.
