### PR TITLE
[Op] Change shape-related op attributes to arguments

### DIFF
--- a/include/tvm/relax/attrs/image.h
+++ b/include/tvm/relax/attrs/image.h
@@ -31,7 +31,6 @@ namespace relax {
 
 /*! \brief Attributes used in image resize2d operator */
 struct Resize2DAttrs : public tvm::AttrsNode<Resize2DAttrs> {
-  Array<PrimExpr> size;
   Array<FloatImm> roi;
   String layout;
   String method;
@@ -43,7 +42,6 @@ struct Resize2DAttrs : public tvm::AttrsNode<Resize2DAttrs> {
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(Resize2DAttrs, "relax.attrs.Resize2DAttrs") {
-    TVM_ATTR_FIELD(size).describe("Output image size.");
     TVM_ATTR_FIELD(roi).describe(
         "Region of Interest for coordinate transformation mode 'tf_crop_and_resize'");
     TVM_ATTR_FIELD(layout).describe(

--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -76,7 +76,7 @@ struct Conv2DAttrs : public tvm::AttrsNode<Conv2DAttrs> {
 
 /*! \brief Attributes used in max_pool2d operator */
 struct MaxPool2DAttrs : public tvm::AttrsNode<MaxPool2DAttrs> {
-  Array<PrimExpr> pool_size;
+  Array<IntImm> pool_size;
   Array<IntImm> strides;
   Array<IntImm> padding;
   Array<IntImm> dilation;
@@ -113,7 +113,7 @@ struct MaxPool2DAttrs : public tvm::AttrsNode<MaxPool2DAttrs> {
 
 /*! \brief Attributes for 2d adaptive pool operator */
 struct AdaptivePool2DAttrs : public tvm::AttrsNode<AdaptivePool2DAttrs> {
-  Optional<Array<PrimExpr>> output_size;
+  Optional<Array<IntImm>> output_size;
   String layout;
   String out_layout;
 

--- a/python/tvm/relax/op/image/image.py
+++ b/python/tvm/relax/op/image/image.py
@@ -21,7 +21,7 @@ from tvm import DataType
 from tvm.ir.expr import PrimExpr
 
 from . import _ffi_api
-from ...expr import Expr
+from ...expr import Expr, ShapeExpr
 
 
 PrimExprLike = Union[int, PrimExpr]
@@ -29,7 +29,7 @@ PrimExprLike = Union[int, PrimExpr]
 
 def resize2d(
     data: Expr,
-    size: Union[PrimExprLike, Tuple[PrimExprLike]],
+    size: Union[Expr, PrimExprLike, Tuple[PrimExprLike]],
     roi: Optional[Union[float, Tuple[float]]] = None,
     layout: str = "NCHW",
     method: str = "linear",
@@ -55,9 +55,10 @@ def resize2d(
     data : relax.Expr
         The input data to the operator.
 
-    size: Union[PrimExprLike, Tuple[PrimExprLike]]
+    size: Union[Expr, PrimExprLike, Tuple[PrimExprLike]]
         The out size to which the image will be resized.
-        It is required to have length either 1 or 2.
+        If specified as a list, it is required to have length either 1 or 2.
+        If specified as an Expr, it is required to have ndim 2.
 
     roi: Optional[Union[float, Tuple[float]]]
         The region of interest for cropping the input image. Expected to be of
@@ -106,6 +107,11 @@ def resize2d(
 
     if isinstance(size, (int, PrimExpr)):
         size = (size, size)
+    if isinstance(size, tuple):
+        if len(size) == 1:
+            size = ShapeExpr([size[0], size[0]])
+        else:
+            size = ShapeExpr(size)
 
     return _ffi_api.resize2d(  # type: ignore
         data,

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -18,20 +18,17 @@
 from typing import List, Optional, Tuple, Union
 
 from tvm import DataType
-from tvm.ir.expr import PrimExpr
 
 from . import _ffi_api
 from ...expr import Expr
-
-PrimExprLike = Union[int, PrimExpr]
 
 
 def conv2d(
     data: Expr,
     weight: Expr,
-    strides: Union[PrimExprLike, Tuple[PrimExprLike]] = (1, 1),
-    padding: Union[PrimExprLike, Tuple[PrimExprLike]] = (0, 0),
-    dilation: Union[PrimExprLike, Tuple[PrimExprLike]] = (1, 1),
+    strides: Union[int, Tuple[int, int]] = (1, 1),
+    padding: Union[int, Tuple[int, ...]] = (0, 0),
+    dilation: Union[int, Tuple[int, int]] = (1, 1),
     groups: int = 1,
     data_layout: str = "NCHW",
     kernel_layout: str = "OIHW",
@@ -71,14 +68,14 @@ def conv2d(
     weight : relax.Expr
         The weight expressions.
 
-    strides : Union[PrimExprLike, Tuple[PrimExprLike]]
+    strides : Union[int, Tuple[int, int]]
         The strides of convolution. It is required to have length either 1 or 2.
 
-    padding : Union[PrimExprLike, Tuple[PrimExprLike]]
+    padding : Union[int, Tuple[int, ...]]
         The padding of convolution on both sides of inputs before convolution.
         It is required to have length either 1, 2 or 4.
 
-    dilation : Union[PrimExprLike, Tuple[PrimExprLike]]
+    dilation : Union[int, Tuple[int, int]]
         Specifies the dilation rate to be used for dilated convolution.
         It is required to have length either 1 or 2.
 
@@ -103,11 +100,11 @@ def conv2d(
     result : relax.Expr
         The computed result.
     """
-    if isinstance(strides, (int, PrimExpr)):
+    if isinstance(strides, int):
         strides = (strides, strides)
-    if isinstance(dilation, (int, PrimExpr)):
+    if isinstance(dilation, int):
         dilation = (dilation, dilation)
-    if isinstance(padding, (int, PrimExpr)):
+    if isinstance(padding, int):
         padding = (padding, padding, padding, padding)
 
     return _ffi_api.conv2d(  # type: ignore
@@ -126,10 +123,10 @@ def conv2d(
 
 def max_pool2d(
     data: Expr,
-    pool_size: Union[PrimExprLike, Tuple[PrimExprLike]] = (1, 1),
-    strides: Union[PrimExprLike, Tuple[PrimExprLike]] = (1, 1),
-    padding: Union[PrimExprLike, Tuple[PrimExprLike]] = (0, 0),
-    dilation: Union[PrimExprLike, Tuple[PrimExprLike]] = (1, 1),
+    pool_size: Union[int, Tuple[int, int]] = (1, 1),
+    strides: Union[int, Tuple[int, int]] = (1, 1),
+    padding: Union[int, Tuple[int, ...]] = (0, 0),
+    dilation: Union[int, Tuple[int, int]] = (1, 1),
     ceil_mode: bool = False,
     layout: str = "NCHW",
     out_layout: Optional[str] = None,
@@ -160,16 +157,16 @@ def max_pool2d(
     data : relax.Expr
         The input data to the operator.
 
-    pool_size : Union[PrimExprLike, Tuple[PrimExprLike]]
+    pool_size : Union[int, Tuple[int, int]]
         The size of window for pooling. It is required to have length either 1 or 2.
 
-    strides : Union[PrimExprLike, Tuple[PrimExprLike]]
+    strides : Union[int, Tuple[int, int]]
         The strides of pooling. It is required to have length either 1 or 2.
 
-    padding : Union[PrimExprLike, Tuple[PrimExprLike]]
+    padding : Union[int, Tuple[int, ...]]
         The padding for pooling. It is required to have length either 1, 2 or 4.
 
-    dilation : Union[PrimExprLike, Tuple[PrimExprLike]]
+    dilation : Union[int, Tuple[int, int]]
         The dilation of pooling. It is required to have length either 1 or 2.
 
     ceil_mode : bool
@@ -187,13 +184,13 @@ def max_pool2d(
     result : Expr
         The computed result.
     """
-    if isinstance(pool_size, (int, PrimExpr)):
+    if isinstance(pool_size, int):
         pool_size = (pool_size, pool_size)
-    if isinstance(strides, (int, PrimExpr)):
+    if isinstance(strides, int):
         strides = (strides, strides)
-    if isinstance(dilation, (int, PrimExpr)):
+    if isinstance(dilation, int):
         dilation = (dilation, dilation)
-    if isinstance(padding, (int, PrimExpr)):
+    if isinstance(padding, int):
         padding = (padding, padding, padding, padding)
 
     return _ffi_api.max_pool2d(  # type: ignore
@@ -203,7 +200,7 @@ def max_pool2d(
 
 def adaptive_avg_pool2d(
     data: Expr,
-    output_size: Optional[Union[PrimExprLike, Tuple[PrimExprLike]]] = None,
+    output_size: Optional[Union[int, Tuple[int, int]]] = None,
     layout: str = "NCHW",
     out_layout: Optional[str] = None,
 ) -> Expr:
@@ -236,7 +233,7 @@ def adaptive_avg_pool2d(
     data : relax.Expr
         The input data to the operator.
 
-    output_size : Optional[Union[PrimExprLike, Tuple[PrimExprLike]]]
+    output_size : Optional[Union[int, Tuple[int, int]]]
         Output height and width.
         If not specified, it will be the same as the input height and width.
         If specified, it is required to have length either 1 or 2.
@@ -252,7 +249,7 @@ def adaptive_avg_pool2d(
     result : relax.Expr
         The computed result.
     """
-    if isinstance(output_size, (int, PrimExpr)):
+    if isinstance(output_size, int):
         output_size = (output_size, output_size)
     return _ffi_api.adaptive_avg_pool2d(data, output_size, layout, out_layout)  # type: ignore
 

--- a/src/relax/op/image/resize.cc
+++ b/src/relax/op/image/resize.cc
@@ -32,18 +32,10 @@ namespace relax {
 /* relax.resize2d */
 TVM_REGISTER_NODE_TYPE(Resize2DAttrs);
 
-Expr resize2d(Expr data, Array<PrimExpr> size, Array<FloatImm> roi, String layout, String method,
+Expr resize2d(Expr data, Expr size, Array<FloatImm> roi, String layout, String method,
               String coordinate_transformation_mode, String rounding_method, double cubic_alpha,
               int cubic_exclude, double extrapolation_value, DataType out_dtype) {
-  if (size.size() == 1) {
-    size.push_back(size[0]);
-  }
-  CHECK_EQ(size.size(), 2) << "In Resize2D, the input size length is expected to be 2. However, "
-                              "the given size is "
-                           << size;
-
   ObjectPtr<Resize2DAttrs> attrs = make_object<Resize2DAttrs>();
-  attrs->size = std::move(size);
   attrs->roi = std::move(roi);
   attrs->layout = std::move(layout);
   attrs->method = std::move(method);
@@ -55,13 +47,38 @@ Expr resize2d(Expr data, Array<PrimExpr> size, Array<FloatImm> roi, String layou
   attrs->out_dtype = out_dtype;
 
   static const Op& op = Op::Get("relax.image.resize2d");
-  return Call(op, {std::move(data)}, Attrs(attrs), {});
+  return Call(op, {std::move(data), std::move(size)}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.image.resize2d").set_body_typed(resize2d);
 
 StructInfo InferStructInfoResize2D(const Call& call, const BlockBuilder& ctx) {
-  TensorStructInfo data_sinfo = GetUnaryInputTensorStructInfo(call, ctx);
+  if (call->args.size() != 1 && call->args.size() != 2) {
+    ctx->ReportFatal(
+        Diagnostic::Error(call)
+        << "Resize2D expects either one or two arguments, while the given number of arguments is "
+        << call->args.size());
+  }
+
+  const auto* data_sinfo = GetStructInfoAs<TensorStructInfoNode>(call->args[0]);
+  const auto* size_sinfo = GetStructInfoAs<ShapeStructInfoNode>(call->args[1]);
+  const auto* size_value = call->args[1].as<ShapeExprNode>();
+  if (data_sinfo == nullptr) {
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << "Resize2D expects the input data to be a Tensor, while the given data is "
+                     << call->args[0]->GetTypeKey());
+  }
+  if (size_sinfo == nullptr) {
+    ctx->ReportFatal(
+        Diagnostic::Error(call)
+        << "Resize2D expects the given output image size to be a Shape, while the given one is "
+        << call->args[1]->GetTypeKey());
+  }
+  if (size_sinfo->ndim != 2) {
+    ctx->ReportFatal(Diagnostic::Error(call) << "Resize2D expects the given output image size to "
+                                                "be a 2-dim shape, while the given one has ndim "
+                                             << size_sinfo->ndim);
+  }
 
   const auto* attrs = call->attrs.as<Resize2DAttrs>();
   auto [data_layout, data2NCHW] = CheckTensorLayout(call, ctx, attrs->layout,  //
@@ -71,15 +88,15 @@ StructInfo InferStructInfoResize2D(const Call& call, const BlockBuilder& ctx) {
   DataType out_dtype = attrs->out_dtype.is_void() ? data_sinfo->dtype : attrs->out_dtype;
 
   Optional<ShapeExpr> data_shape =
-      CheckNdimPerLayoutAndGetShape(call, ctx, data_sinfo, data_layout);
-  if (!data_shape.defined()) {
+      CheckNdimPerLayoutAndGetShape(call, ctx, GetRef<TensorStructInfo>(data_sinfo), data_layout);
+  if (!data_shape.defined() || size_value == nullptr) {
     return TensorStructInfo(out_dtype, data_layout.ndim());
   }
 
   Array<PrimExpr> data_NCHW_shape = data2NCHW.ForwardShape(data_shape.value()->values);
   Array<PrimExpr> out_NCHW_shape(data_NCHW_shape);
-  out_NCHW_shape.Set(2, attrs->size[0]);
-  out_NCHW_shape.Set(3, attrs->size[1]);
+  out_NCHW_shape.Set(2, size_value->values[0]);
+  out_NCHW_shape.Set(3, size_value->values[1]);
 
   Array<PrimExpr> out_shape = data2NCHW.BackwardShape(out_NCHW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype);
@@ -87,8 +104,9 @@ StructInfo InferStructInfoResize2D(const Call& call, const BlockBuilder& ctx) {
 
 TVM_REGISTER_OP("relax.image.resize2d")
     .set_attrs_type<Resize2DAttrs>()
-    .set_num_inputs(1)
+    .set_num_inputs(2)
     .add_argument("data", "Tensor", "The input tensor.")
+    .add_argument("size", "Shape", "The output image shape.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoResize2D);
 
 }  // namespace relax

--- a/src/relax/op/image/resize.h
+++ b/src/relax/op/image/resize.h
@@ -33,7 +33,7 @@ namespace tvm {
 namespace relax {
 
 /*! \brief Image resize2d operator. */
-Expr resize2d(Expr data, Array<PrimExpr> size, Array<FloatImm> roi, String layout, String method,
+Expr resize2d(Expr data, Expr size, Array<FloatImm> roi, String layout, String method,
               String coordinate_transformation_mode, String rounding_method, double cubic_alpha,
               int cubic_exclude, double extrapolation_value, DataType out_dtype);
 

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -28,7 +28,7 @@ namespace relax {
 /* relax.nn.max_pool2d */
 TVM_REGISTER_NODE_TYPE(MaxPool2DAttrs);
 
-Expr max_pool2d(Expr data, Array<PrimExpr> pool_size, Array<IntImm> strides, Array<IntImm> padding,
+Expr max_pool2d(Expr data, Array<IntImm> pool_size, Array<IntImm> strides, Array<IntImm> padding,
                 Array<IntImm> dilation, bool ceil_mode, String layout,
                 Optional<String> out_layout) {
   padding = GetCompletePadding2D(std::move(padding));
@@ -60,7 +60,7 @@ Expr max_pool2d(Expr data, Array<PrimExpr> pool_size, Array<IntImm> strides, Arr
   attrs->layout = layout;
   attrs->out_layout = out_layout.value_or(layout);
   static const Op& op = Op::Get("relax.nn.max_pool2d");
-  return Call(op, {data}, Attrs(attrs), {});
+  return Call(op, {std::move(data)}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.nn.max_pool2d").set_body_typed(max_pool2d);
@@ -119,13 +119,13 @@ TVM_REGISTER_OP("relax.nn.max_pool2d")
 /* relax.nn.adaptive_avg_pool2d */
 TVM_REGISTER_NODE_TYPE(AdaptivePool2DAttrs);
 
-Expr adaptive_avg_pool2d(Expr data, Optional<Array<PrimExpr>> output_size, String layout,
+Expr adaptive_avg_pool2d(Expr data, Optional<Array<IntImm>> output_size, String layout,
                          Optional<String> out_layout) {
   ObjectPtr<AdaptivePool2DAttrs> attrs = make_object<AdaptivePool2DAttrs>();
   attrs->layout = layout;
   attrs->out_layout = out_layout.value_or(layout);
   if (output_size.defined()) {
-    Array<PrimExpr> _output_size = output_size.value();
+    Array<IntImm> _output_size = output_size.value();
     if (_output_size.size() == 1) {
       _output_size.push_back(_output_size[0]);
     }

--- a/src/relax/op/nn/pooling.h
+++ b/src/relax/op/nn/pooling.h
@@ -33,11 +33,11 @@ namespace tvm {
 namespace relax {
 
 /*! \brief 2D maximum pooling operator. */
-Expr max_pool2d(Expr data, Array<PrimExpr> pool_size, Array<IntImm> strides, Array<IntImm> padding,
+Expr max_pool2d(Expr data, Array<IntImm> pool_size, Array<IntImm> strides, Array<IntImm> padding,
                 Array<IntImm> dilation, bool ceil_mode, String layout, Optional<String> out_layout);
 
 /*! \brief 2D adaptive average pooling operator. */
-Expr adaptive_avg_pool2d(Expr data, Optional<Array<PrimExpr>> output_size, String layout,
+Expr adaptive_avg_pool2d(Expr data, Optional<Array<IntImm>> output_size, String layout,
                          Optional<String> out_layout);
 
 }  // namespace relax

--- a/tests/python/relax/test_tvmscript_parser_op_nn.py
+++ b/tests/python/relax/test_tvmscript_parser_op_nn.py
@@ -57,13 +57,13 @@ def test_max_pool2d():
     def foo(
         x: R.Tensor((1, 1, 32, 32), dtype="float32")
     ) -> R.Tensor((1, 1, 30, 30), dtype="float32"):
-        gv: R.Tensor((1, 1, 30, 30), dtype="float32") = R.nn.max_pool2d(x, pool_size=[3])
+        gv: R.Tensor((1, 1, 30, 30), dtype="float32") = R.nn.max_pool2d(x, pool_size=(3,))
         return gv
 
     x = relax.Var("x", R.Tensor([1, 1, 32, 32], "float32"))
     bb = relax.BlockBuilder()
     with bb.function("foo", [x]):
-        gv = bb.emit(relax.op.nn.max_pool2d(x, pool_size=[3]))
+        gv = bb.emit(relax.op.nn.max_pool2d(x, pool_size=(3,)))
         bb.emit_func_output(gv)
 
     _check(foo, bb.get()["foo"])
@@ -72,7 +72,7 @@ def test_max_pool2d():
 def test_adaptive_avg_pool2d():
     @R.function
     def foo(x: R.Tensor((2, 64, 8, 9), "float32")) -> R.Tensor((2, 64, 7, 7), "float32"):
-        gv: R.Tensor((2, 64, 7, 7), "float32") = R.nn.adaptive_avg_pool2d(x, output_size=[7, 7])
+        gv: R.Tensor((2, 64, 7, 7), "float32") = R.nn.adaptive_avg_pool2d(x, output_size=(7, 7))
         return gv
 
     x = relax.Var("x", R.Tensor((2, 64, 8, 9), dtype="float32"))


### PR DESCRIPTION
This PR changes some shape-related operator attributes to operator arguments.

This is because we have the assumption that all attribute fields should be static constant at compile-time. But in fact, the fields touched in this PR can be dynamic at compile-time. Therefore, we should treat them as arguments, which is an Expr, and can be ShapeExpr or Var at compile-time.

Specifically, this fields are:

* `size` of `resize2d`.

Unit tests are updated correspondingly.