### PR TITLE
[Fix][TVMScript] Parse and print `tir_vars` of `call_tir` properly

### DIFF
--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # pylint: disable=redefined-builtin
 """The base Relax operators."""
-from typing import Union, List, Optional
+from typing import Union, List, Tuple, Optional
 
 
 import tvm
@@ -47,7 +47,7 @@ def call_tir(
     args: Union[Expr, List[Expr]],
     shape: Union[RxTuple, ShapeExpr, List[int]],
     dtype: Union[str, List[str]],
-    tir_vars: Optional[ShapeExpr] = None,
+    tir_vars: Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]] = None,
 ) -> Call:
     """
     Call a destination-passing-style function and return the output.
@@ -66,7 +66,7 @@ def call_tir(
     dtype: Union[str, List[str]]
         The output dtype. List[str] if multiple outputs, str if single output.
 
-    tir_vars : ShapeExpr, optional
+    tir_vars : Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]]
         ShapeExpr representing a tuple of integers to unpack when calling func. Is null if not used
 
     Returns
@@ -121,6 +121,9 @@ def call_tir(
         output_type = TupleType([DynTensorType(len(x), y) for x, y in zip(shape, dtype)])
     else:
         raise TypeError("Not supported dtype for call_tir: " + str(type(dtype)))
+
+    if isinstance(tir_vars, (list, tuple)):
+        tir_vars = ShapeExpr(tir_vars)
 
     return _ffi_api.call_tir(func, args, shape, output_type, tir_vars)  # type: ignore
 

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -91,14 +91,14 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::CallNode* op) {
   if (op->op == call_tir_op) {
     doc << "R.call_tir";
 
-    for (const Expr& arg : op->args) {
-      args.push_back(Print(arg));
+    for (int i = 0; i < 3; ++i) {
+      args.push_back(Print(op->args[i]));
     }
     doc << "(" << Doc::Concat(args, Doc::Text(", "));
 
     Type output_type = op->type_args[0];
     if (const auto* out_type = output_type.as<DynTensorTypeNode>()) {
-      doc << ", dtype=" << PrintDType(out_type->dtype) << ")";
+      doc << ", dtype=" << PrintDType(out_type->dtype);
     } else if (const auto* out_type = output_type.as<TupleTypeNode>()) {
       std::vector<Doc> dtypes;
       for (auto field : out_type->fields) {
@@ -110,10 +110,16 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::CallNode* op) {
           LOG(FATAL) << "TypeError: Invalid type: " << field_type->GetTypeKey();
         }
       }
-      doc << ", dtype=(" << Doc::Concat(dtypes, Doc::Text(", ")) << "))";
+      doc << ", dtype=(" << Doc::Concat(dtypes, Doc::Text(", ")) << ")";
     } else {
       LOG(FATAL) << "TypeError: Invalid type: " << output_type->GetTypeKey();
     }
+
+    if (op->args.size() == 4) {
+      doc << ", tir_vars=" << Print(op->args[3]);
+    }
+    doc << ")";
+
     return doc;
   }
 


### PR DESCRIPTION
This PR patches both the TVMScript parser and printer on handling the `tir_vars` parameter of `call_tir`.

When a TIR function contains symbolic shapes, its signature can have trailing TIR vars in the param list. In such cases, when using `call_tir` to call into the TIR function, we should provide the instances of those TIR vars through the param `tir_vars`. `tir_vars` is the last parameter of `call_tir`, one behind `dtype`.
https://github.com/tlc-pack/relax/blob/697675bf8f137488e0f38237b046ce671cdbad9f/python/tvm/relax/op/base.py#L45-L51

The specific issues fixed in this PR is:
* Printer: prior to this PR, when printing `call_tir`, the printer always explicitly prints `"dtype="`, while doesn’t print `"tir_vars="` when there is. This will make the printed script looks like
    ```python
    y = R.call_tir(copy, (x,), ((n * 2,)), dtype="float32", (n,))
    ```
    which doesn’t conform to Python syntax.
* `call_tir`’s handling on TIR vars: the TIR vars will be parsed as a list or a tuple of Python, while on the `call_tir` side the parsed tuple/list will be treated as a Expr and passed to C++ side through FFI. This will incur FFI error like
    ```
    error:   Check failed: (!checked_type.defined()) is false: Expected RelayExpr, but got Array
    ```

Therefore, this PR fixes both sides. On printer side, we now print `tir_vars` after `dtype` and explicitly print `"tir_vars="`. On `call_tir` side, we wrap the input `tir_vars` to ShapeExpr if we find it a tuple or list. One regression test that covers both issues is provided.

cc @YuchenJin 