### PR TITLE
[BYOC] Add pattern-based partitioning pass

### DIFF
--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -45,6 +45,9 @@ namespace relax {
  */
 bool MatchExpr(DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> var2val = NullOpt);
 
+Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(
+    DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> bindings_opt = NullOpt);
+
 /**
  * \brief Match a sub-graph in a DataflowBlock with a graph of patterns and return the mapping.
  * \note This algorithm returns the first matched sub-graph. Use `start_hint` to specify the

--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -45,7 +45,6 @@ namespace relax {
  */
 bool MatchExpr(DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> bindings = NullOpt);
 
-
 /* \brief Similar to above, but return pairs of a matching pattern and an expression.  */
 Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(
     DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> bindings = NullOpt);

--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -39,14 +39,16 @@ namespace relax {
  *
  * \param pattern The pattern to match
  * \param expr The expression to match
- * \param var2val The mapping from relax.Var to relax.Expr
+ * \param binding The mapping from relax.Var to relax.Expr
  * \return true if matched
  * \return false if unmatched
  */
-bool MatchExpr(DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> var2val = NullOpt);
+bool MatchExpr(DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> bindings = NullOpt);
 
+
+/* \brief Similar to above, but return pairs of a matching pattern and an expression.  */
 Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(
-    DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> bindings_opt = NullOpt);
+    DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> bindings = NullOpt);
 
 /**
  * \brief Match a sub-graph in a DataflowBlock with a graph of patterns and return the mapping.

--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -39,7 +39,7 @@ namespace relax {
  *
  * \param pattern The pattern to match
  * \param expr The expression to match
- * \param binding The mapping from relax.Var to relax.Expr
+ * \param bindings The mapping from relax.Var to relax.Expr
  * \return true if matched
  * \return false if unmatched
  */

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -165,7 +165,7 @@ TVM_DLL Pass AnnotateTIROpPattern();
 TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
 
 /*!
- * \brief Apply pattern matching to each function in the given module, and groups matched
+ * \brief Apply pattern matching to each function in the given module, and group matched
  * expressions into a new function. The end result is similar to FuseOps, but fusion is driven
  * completely by the provided patterns.
  *

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -25,6 +25,7 @@
 #define TVM_RELAX_TRANSFORM_H_
 
 #include <tvm/ir/transform.h>
+#include <tvm/relax/dataflow_pattern.h>
 #include <tvm/relax/expr.h>
 
 namespace tvm {
@@ -162,6 +163,10 @@ TVM_DLL Pass AnnotateTIROpPattern();
  * \return The Pass.
  */
 TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
+
+// TODO
+TVM_DLL Pass FuseOpsByPattern(const tvm::Array<runtime::String>& pattern_names,
+                              const tvm::Array<DFPattern>& patterns);
 
 /*!
  * \brief Fuse relax sub-function into a larger TIR function if possible.

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -164,11 +164,10 @@ TVM_DLL Pass AnnotateTIROpPattern();
  */
 TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
 
-
 /*!
- * \brief Apply pattern matching to each function in the given module, and group matched expressions
- * into a new function. The end result is similar to FuseOps, but fusion is driven completely by
- * the provided patterns.
+ * \brief Apply pattern matching to each function in the given module, and groups matched
+ * expressions into a new function. The end result is similar to FuseOps, but fusion is driven
+ * completely by the provided patterns.
  *
  * \param pattern_names The name of each pattern. It becomes the value of the kComposite attribute
  * of a fused function after successful matching.

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -164,7 +164,18 @@ TVM_DLL Pass AnnotateTIROpPattern();
  */
 TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
 
-// TODO
+
+/*!
+ * \brief Apply pattern matching to each function in the given module, and group matched expressions
+ * into a new function. The end result is similar to FuseOps, but fusion is driven completely by
+ * the provided patterns.
+ *
+ * \param pattern_names The name of each pattern. It becomes the value of the kComposite attribute
+ * of a fused function after successful matching.
+ * \param patterns The patterns to detect. The order of the patterns determines the order
+ * of priority in which they are matched. Higher-priority patterns should come earlier in the list.
+ * \return The Pass.
+ */
 TVM_DLL Pass FuseOpsByPattern(const tvm::Array<runtime::String>& pattern_names,
                               const tvm::Array<DFPattern>& patterns);
 

--- a/python/tvm/relax/dpl/context.py
+++ b/python/tvm/relax/dpl/context.py
@@ -20,7 +20,7 @@
 from typing import Optional, Dict
 
 import tvm
-from tvm.relax import DataflowBlock, Var
+from ..expr import DataflowBlock, Var
 from .pattern import DFPattern
 from . import _ffi as ffi
 

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -1058,19 +1058,35 @@ def _only_used_by(
     return ffi.only_used_by(lhs, rhs, index)  # type: ignore
 
 
-def make_conv_pattern(conv_name, with_bias=False, activation=None):
-    """A simple utility to create patterns for fused convolution."""
-    data = wildcard()
-    weight = wildcard()
-    conv = is_op(conv_name)(data, weight)
+def make_fused_bias_activation_pattern(op_name, with_bias=False, activation=None):
+    """
+    A simple utility to create patterns for an operation fused with bias addition and activation.
+
+    Parameters
+    ----------
+    op_name: str
+        The name of a Relax op, such as "relax.nn.conv2d"
+
+    with_bias: bool
+        Whether or not to include bias addition
+
+    activation: str
+        The name of an activation Relax op, such as "relax.nn.relu"
+
+    Returns
+    -------
+    pattern: DFPattern
+        The resulting pattern describing a fused operation
+    """
+    lhs = wildcard()
+    rhs = wildcard()
+    out = is_op(op_name)(lhs, rhs)
 
     if with_bias:
         bias = wildcard()
-        conv_out = is_op("relax.add")(conv, bias)
-    else:
-        conv_out = conv
+        out = is_op("relax.add")(out, bias)
 
     if activation:
-        return is_op(activation)(conv_out)
+        return is_op(activation)(out)
 
-    return conv_out
+    return out

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -195,9 +195,9 @@ class DFPattern(Node):
 
         Note
         ----
-        Unlike Relay whose function is an expression, functions in Relax consists
-        of blocks of bindings that they are not syntactically connected. We use a
-        mapping (i.e., var2val) to migrate the gap. For example, to when matching
+        Unlike Relay whose function is an expression, functions in Relax consist
+        of blocks of bindings that are not syntactically connected. We use a
+        mapping (i.e., var2val) to mitigate the gap. For example, when matching
         "relax.add(lv0, lv1)", given var2val, we match lv0's bound expression
         when the recursive pattern matching goes to check lv0. The var2val mapping
         can be computed through the tvm.relax.analysis.get_var2val function.

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -1059,6 +1059,7 @@ def _only_used_by(
 
 
 def make_conv_pattern(conv_name, with_bias=False, activation=None):
+    """A simple utility to create patterns for fused convolution."""
     data = wildcard()
     weight = wildcard()
     conv = is_op(conv_name)(data, weight)

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -288,7 +288,7 @@ def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
 
 
 def FuseOpsByPattern(patterns: List[tuple]) -> tvm.ir.transform.Pass:
-    """Apply pattern matching to each function in the given module, and group matched expressions
+    """Apply pattern matching to each function in the given module, and groups matched expressions
     into a new function.
 
     The end result is similar to FuseOps, but fusion is driven completely by the provided patterns.

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -288,7 +288,26 @@ def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
 
 
 def FuseOpsByPattern(pattern_names: List[str], patterns: List[DFPattern]) -> tvm.ir.transform.Pass:
-    """TODO"""
+    """Apply pattern matching to each function in the given module, and group matched expressions
+    into a new function.
+
+    The end result is similar to FuseOps, but fusion is driven completely by the provided patterns.
+
+    Parameters
+    ----------
+    pattern_names : List[str]
+        The name of each pattern. It becomes the value of the kComposite attribute of a
+        fused function after successful matching.
+    patterns : List[DFPattern]
+        The patterns to detect. The order of the patterns determines the order of priority in which
+        they are matched. Higher-priority patterns should come earlier in the list.
+
+    Returns
+    -------
+    ret : tvm.transform.Pass
+        The registered pass for pattern-based fusion.
+
+    """
     return _ffi_api.FuseOpsByPattern(pattern_names, patterns)  # type: ignore
 
 

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -25,6 +25,7 @@ import numpy as np  # type: ignore
 import tvm.ir
 from tvm.runtime import NDArray
 from . import _ffi_api
+from ..dpl import DFPattern
 
 
 @tvm._ffi.register_object("relax.FunctionPass")
@@ -284,6 +285,11 @@ def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
         The registered pass for operator fusion.
     """
     return _ffi_api.FuseOps(fuse_opt_level)  # type: ignore
+
+
+def FuseOpsByPattern(pattern_names: List[str], patterns: List[DFPattern]) -> tvm.ir.transform.Pass:
+    """TODO"""
+    return _ffi_api.FuseOpsByPattern(pattern_names, patterns)  # type: ignore
 
 
 def FuseTIR() -> tvm.ir.transform.Pass:

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -19,7 +19,7 @@
 import functools
 import inspect
 import types
-from typing import Callable, Dict, Union, Optional, List
+from typing import Callable, Dict, Union, Optional, List, Tuple
 import numpy as np  # type: ignore
 
 import tvm.ir
@@ -286,8 +286,8 @@ def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
     return _ffi_api.FuseOps(fuse_opt_level)  # type: ignore
 
 
-def FuseOpsByPattern(patterns: List[tuple]) -> tvm.ir.transform.Pass:
-    """Apply pattern matching to each function in the given module, and groups matched expressions
+def FuseOpsByPattern(patterns: List[Tuple]) -> tvm.ir.transform.Pass:
+    """Apply pattern matching to each function in the given module, and group matched expressions
     into a new function.
 
     The end result is similar to FuseOps, but fusion is driven completely by the provided patterns.

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -25,7 +25,6 @@ import numpy as np  # type: ignore
 import tvm.ir
 from tvm.runtime import NDArray
 from . import _ffi_api
-from ..dpl import DFPattern
 
 
 @tvm._ffi.register_object("relax.FunctionPass")

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -287,7 +287,7 @@ def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
     return _ffi_api.FuseOps(fuse_opt_level)  # type: ignore
 
 
-def FuseOpsByPattern(pattern_names: List[str], patterns: List[DFPattern]) -> tvm.ir.transform.Pass:
+def FuseOpsByPattern(patterns: List[tuple]) -> tvm.ir.transform.Pass:
     """Apply pattern matching to each function in the given module, and group matched expressions
     into a new function.
 
@@ -295,12 +295,11 @@ def FuseOpsByPattern(pattern_names: List[str], patterns: List[DFPattern]) -> tvm
 
     Parameters
     ----------
-    pattern_names : List[str]
-        The name of each pattern. It becomes the value of the kComposite attribute of a
-        fused function after successful matching.
-    patterns : List[DFPattern]
+    patterns : List[Tuple[str, DFPattern]]
         The patterns to detect. The order of the patterns determines the order of priority in which
         they are matched. Higher-priority patterns should come earlier in the list.
+        The string is the name of the corresponding pattern. It becomes the value of the kComposite
+        attribute of a fused function after a successful matching.
 
     Returns
     -------
@@ -308,7 +307,8 @@ def FuseOpsByPattern(pattern_names: List[str], patterns: List[DFPattern]) -> tvm
         The registered pass for pattern-based fusion.
 
     """
-    return _ffi_api.FuseOpsByPattern(pattern_names, patterns)  # type: ignore
+    pattern_names, df_patterns = zip(*patterns)
+    return _ffi_api.FuseOpsByPattern(pattern_names, df_patterns)  # type: ignore
 
 
 def FuseTIR() -> tvm.ir.transform.Pass:

--- a/src/relax/analysis/var2value.cc
+++ b/src/relax/analysis/var2value.cc
@@ -28,6 +28,8 @@ class Var2ValAnalysis : public relax::ExprVisitor {
   tvm::runtime::Map<Var, Expr> var2value_;
   void VisitBinding_(const VarBindingNode* binding) override {
     var2value_.Set(binding->var, binding->value);
+    // Recursively visit the value to handle local functions.
+    VisitExpr(binding->value);
   }
 };
 

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -509,7 +509,7 @@ Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(DFPattern pattern, Expr expr,
 
   Map<DFPattern, Expr> matching;
   for (const auto& [pat, matches] : matcher.GetMemo()) {
-    ICHECK(matches.size() == 1) << "More than one match for the pattern " << pat;
+    ICHECK_EQ(matches.size(), 1) << "More than one match for the pattern " << pat;
     matching.Set(pat, matches[0]);
   }
   return matching;

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -499,13 +499,30 @@ bool DFPatternMatcher::VisitDFPattern_(const WildcardPatternNode* op, const Expr
 }
 
 bool MatchExpr(DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> var2val) {
-  if (var2val.defined())  // autojump is enabled with var2val.
+  if (var2val)  // autojump is enabled with var2val.
     return DFPatternMatcher(std::move(var2val.value())).Match(pattern, expr);
   else
     return DFPatternMatcher().Match(pattern, expr);
 }
 
 TVM_REGISTER_GLOBAL("relax.dpl.match_expr").set_body_typed(MatchExpr);
+
+Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(DFPattern pattern, Expr expr,
+                                                  Optional<Map<Var, Expr>> bindings_opt) {
+  auto bindings = bindings_opt ? bindings_opt.value() : Map<Var, Expr>{};
+  DFPatternMatcher matcher(bindings);
+
+  if (!matcher.Match(pattern, expr)) {
+    return NullOpt;
+  }
+
+  Map<DFPattern, Expr> matching;
+  for (const auto& [pat, matches] : matcher.GetMemo()) {
+    ICHECK(matches.size() == 1) << "More than one match for the pattern " << pat;
+    matching.Set(pat, matches[0]);
+  }
+  return matching;
+}
 
 struct PNode {
   const DFPatternNode* ptr;

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -54,7 +54,7 @@ bool DFPatternMatcher::Match(const DFPattern& pattern, const Expr& expr) {
   return VisitDFPattern(pattern, expr);
 }
 
-static Expr TryGetValOfVar(const Expr& expr, const runtime::Map<Var, Expr>& var2val) {
+static Expr TryGetValOfVar(const Expr& expr, const Map<Var, Expr>& var2val) {
   if (var2val.empty()) return expr;
 
   // if not match, try to match value of var if expr is a var.
@@ -498,18 +498,9 @@ bool DFPatternMatcher::VisitDFPattern_(const WildcardPatternNode* op, const Expr
   return true;
 }
 
-bool MatchExpr(DFPattern pattern, Expr expr, Optional<runtime::Map<Var, Expr>> var2val) {
-  if (var2val)  // autojump is enabled with var2val.
-    return DFPatternMatcher(std::move(var2val.value())).Match(pattern, expr);
-  else
-    return DFPatternMatcher().Match(pattern, expr);
-}
-
-TVM_REGISTER_GLOBAL("relax.dpl.match_expr").set_body_typed(MatchExpr);
-
 Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(DFPattern pattern, Expr expr,
                                                   Optional<Map<Var, Expr>> bindings_opt) {
-  auto bindings = bindings_opt ? bindings_opt.value() : Map<Var, Expr>{};
+  auto bindings = bindings_opt.value_or({});
   DFPatternMatcher matcher(bindings);
 
   if (!matcher.Match(pattern, expr)) {
@@ -523,6 +514,12 @@ Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(DFPattern pattern, Expr expr,
   }
   return matching;
 }
+
+bool MatchExpr(DFPattern pattern, Expr expr, Optional<Map<Var, Expr>> bindings_opt) {
+  return static_cast<bool>(ExtractMatchedExpr(pattern, expr, bindings_opt));
+}
+
+TVM_REGISTER_GLOBAL("relax.dpl.match_expr").set_body_typed(MatchExpr);
 
 struct PNode {
   const DFPatternNode* ptr;
@@ -681,9 +678,9 @@ class MatcherUseDefAnalysis : public relax::ExprVisitor {
   }
 };
 
-tvm::runtime::Map<DFPattern, Var> MatchGraph(const PatternContext& ctx, const DataflowBlock& dfb,
-                                             Optional<Var> start_hint, bool must_include_hint) {
-  tvm::runtime::Map<DFPattern, Var> ret{};
+Map<DFPattern, Var> MatchGraph(const PatternContext& ctx, const DataflowBlock& dfb,
+                               Optional<Var> start_hint, bool must_include_hint) {
+  Map<DFPattern, Var> ret;
   // TODO(@ganler): Handle non-may external use.
   ICHECK(ctx->allow_extern_use == PatternContextNode::kMay) << "Only kMay is supported yet.";
   ICHECK(!must_include_hint || start_hint.defined())

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -873,7 +873,7 @@ IRModule FuseOpsByPattern(const tvm::Array<String>& pattern_names,
   support::Arena arena;
   for (size_t i = 0; i < pattern_names.size(); ++i) {
     OperatorFusor::GroupMap group_map;
-    for (const auto& [gv, func] : mod->functions) {
+    for (const auto& [_, func] : mod->functions) {
       auto map = PatternBasedPartitioner::Run(pattern_names[i], patterns[i], func, &arena);
       group_map.insert(map.begin(), map.end());
     }

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -826,13 +826,13 @@ class PatternBasedPartitioner : ExprVisitor {
       ICHECK(parent_group);
       parent_group->composite_name = pat_name_;
 
-      for (const auto& [_, match] : matches_opt.value()) {
+      for (const auto& [pat, match] : matches_opt.value()) {
         ICHECK(group_map_.count(match.get()));
         // The op node itself is also a part of the matched expressions, but it can be ignored.
         if (!match->IsInstance<OpNode>()) {
           // Put all matching expressions into the parent group.
           AddToGroup(match, parent_group);
-          if (value_to_bound_var_.count(match) && GetGroupForBoundVar(match)->num_nodes == 1) {
+          if (match != GetRef<Call>(call) && !pat->IsInstance<WildcardPatternNode>()) {
             // In the example above, we hit this code path when "match" is the conv2d call node
             // on the RHS.
             // After we put the conv2d into the parent group, "conv1", we also need to put "lv"

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -807,7 +807,7 @@ class OperatorFusor : public ExprMutator {
   /*! \brief Record the index for TupleGetItem if the variable needs to be remapped to an output
    * tuple element after fusion. */
   std::unordered_map<const VarNode*, int> tuple_get_indices_;
-  // A map from a group to its dependent groups, used to detect cyclic dependencies.
+  /*! \brief A map from a group to its dependent groups, used to detect cyclic dependencies. */
   std::unordered_map<Group*, std::unordered_set<Group*>> group_deps_;
 };
 

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -27,6 +27,9 @@
  * A follow-up pass named "FuseTIR" will generate a TIR PrimFunc for each grouped function.
  */
 
+#include <tvm/relax/analysis.h>
+#include <tvm/relax/dataflow_matcher.h>
+#include <tvm/relax/dataflow_pattern.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/struct_info.h>
 #include <tvm/relax/transform.h>
@@ -372,15 +375,22 @@ class FunctionCreator : public ExprMutator {
 
     if (const auto* var_binding = binding.as<VarBindingNode>()) {
       if (const auto* call = var_binding->value.as<CallNode>()) {
-        ICHECK(call->op == Op::Get("relax.call_tir"));
-        // Update the name of the function.
-        name_hint_ = name_hint_ + "_" + Downcast<GlobalVar>(call->args[0])->name_hint;
+        if (call->op == Op::Get("relax.call_tir")) {
+          // Update the name of the function.
+          name_hint_ = name_hint_ + "_" + Downcast<GlobalVar>(call->args[0])->name_hint;
 
-        const Tuple& args = Downcast<Tuple>(call->args[1]);
-        for (const Expr& arg : args->fields) {
-          CheckDefAndUpdateParam(arg);
+          const Tuple& args = Downcast<Tuple>(call->args[1]);
+          for (const Expr& arg : args->fields) {
+            CheckDefAndUpdateParam(arg);
+          }
+          // TODO(tvm-team): handle shape expr
+        } else {
+          ICHECK(call->op->IsInstance<OpNode>());
+          name_hint_ = name_hint_ + "_" + Downcast<Op>(call->op)->name;
+          for (const Expr& arg : call->args) {
+            CheckDefAndUpdateParam(arg);
+          }
         }
-        // TODO(tvm-team): handle shape expr
       } else {
         const auto* tuple_item = var_binding->value.as<TupleGetItemNode>();
         ICHECK(tuple_item != nullptr);
@@ -407,9 +417,9 @@ class FunctionCreator : public ExprMutator {
 
   /*!
    * \brief Create the grouped function according according to the collected bindings and parameters
-   * \note The created function won't be returned immediately. Tt's stored in the `function_` field.
+   * \note The created function won't be returned immediately. It's stored in the `function_` field.
    */
-  void CreateFunction() {
+  void CreateFunction(const std::string& composite_name) {
     // Step 1. Start constructing a new dataflow block.
     builder_->BeginDataflowBlock();
 
@@ -439,6 +449,9 @@ class FunctionCreator : public ExprMutator {
     body = builder_->Normalize(SeqExpr({new_block}, body));
     Map<String, ObjectRef> attrs;
     attrs.Set(tvm::relax::attr::kPrimitive, Integer(1));
+    if (!composite_name.empty()) {
+      attrs.Set(tvm::relax::attr::kComposite, String(composite_name));
+    }
     function_ = Function(/*params=*/params_,           //
                          /*body=*/body,                //
                          /*ret_struct_info=*/NullOpt,  //
@@ -543,14 +556,16 @@ class OperatorFusor : public ExprMutator {
     }
   }
 
+  OperatorFusor(IRModule mod,
+                const std::unordered_map<const Object*, GraphPartitioner::Group*>& obj2group)
+      : ExprMutator(mod), mod_(std::move(mod)), obj2group_(obj2group) {}
+
   /*!
    * \brief The main transformation on the IRModule
    * \return The new IRModule after transformation
    */
   IRModule Transform() {
-    for (const auto& kv : mod_->functions) {
-      const GlobalVar& gv = kv.first;
-      const BaseFunc& func = kv.second;
+    for (const auto& [gv, func] : mod_->functions) {
       // Only visit Relax function without attr kPrimitive.
       if (func->IsInstance<relax::FunctionNode>() && !func->HasNonzeroAttr(attr::kPrimitive)) {
         auto updated_func = Downcast<Function>(VisitExpr(func));
@@ -579,9 +594,8 @@ class OperatorFusor : public ExprMutator {
     CollectFuncBoundary(block->bindings);
 
     // Step 3. Create the grouped function for each group.
-    for (auto& kv : group2func_) {
-      FunctionCreator& creator = kv.second;
-      creator.CreateFunction();
+    for (auto& [g, creator] : group2func_) {
+      creator.CreateFunction(g->composite_name);
     }
 
     // Step 4. Start generating the new binding block.
@@ -757,6 +771,101 @@ IRModule FuseOps(IRModule mod, int opt_level, size_t max_fuse_depth) {
   return mod;
 }
 
+static Map<Expr, Var> GetBindingInverse(const Map<Var, Expr>& binding) {
+  Map<Expr, Var> value_to_bound_var;
+  for (const auto& [var, val] : binding) {
+    value_to_bound_var.Set(val, var);
+  }
+  return value_to_bound_var;
+}
+
+class PatternBasedPartitioner : ExprVisitor {
+ public:
+  using Group = GraphPartitioner::Group;
+  using ExprVisitor::VisitExpr_;
+
+  static std::unordered_map<const Object*, Group*> Run(runtime::String pattern_name,
+                                                       DFPattern pattern, Expr expr,
+                                                       support::Arena* arena) {
+    PatternBasedPartitioner part(pattern_name, pattern, AnalyzeVar2Value(expr));
+    PostOrderVisit(
+        expr, [arena, &part](const Expr& e) { part.group_map_[e.get()] = arena->make<Group>(); });
+    part.VisitExpr(expr);
+    return part.group_map_;
+  }
+
+  PatternBasedPartitioner(const std::string& pattern_name, DFPattern pattern,
+                          const tvm::runtime::Map<Var, Expr>& bindings)
+      : pat_name_(pattern_name),
+        pat_(pattern),
+        bindings_(bindings),
+        value_to_bound_var_(GetBindingInverse(bindings)) {}
+
+  void VisitBindingBlock_(const DataflowBlockNode* block) final {
+    for (const auto& binding : block->bindings) {
+      auto it = group_map_.find(binding->var.get());
+      ICHECK(it != group_map_.end());
+      if (const auto* var_binding = binding.as<VarBindingNode>()) {
+        VisitExpr(var_binding->value);
+      }
+    }
+  }
+
+  void VisitExpr_(const CallNode* call) override {
+    if (auto matches_opt = ExtractMatchedExpr(pat_, GetRef<Call>(call), bindings_)) {
+      auto parent_group = GetGroupForBoundVar(GetRef<Call>(call));
+      ICHECK(parent_group);
+      parent_group->composite_name = pat_name_;
+
+      for (const auto& [_, match] : matches_opt.value()) {
+        ICHECK(group_map_.count(match.get()));
+        if (!match->IsInstance<OpNode>()) {
+          AddToGroup(match, parent_group);
+          if (value_to_bound_var_.count(match) && GetGroupForBoundVar(match)->num_nodes == 1) {
+            AddToGroup(value_to_bound_var_[match], parent_group);
+          }
+        }
+      }
+    }
+  }
+
+ private:
+  void AddToGroup(Expr e, Group* to) {
+    if (group_map_[e.get()] != to) {
+      --group_map_[e.get()]->num_nodes;
+      group_map_[e.get()] = to;
+      ++to->num_nodes;
+    }
+  }
+
+  Group* GetGroupForBoundVar(Expr e) {
+    ICHECK(value_to_bound_var_.count(e));
+    auto bound_var = value_to_bound_var_[e];
+    ICHECK(group_map_.count(bound_var.get()));
+    return group_map_[bound_var.get()];
+  }
+
+  std::string pat_name_;
+  DFPattern pat_;
+  Map<Var, Expr> bindings_;
+  Map<Expr, Var> value_to_bound_var_;
+  std::unordered_map<const Object*, Group*> group_map_;
+};
+
+IRModule FuseOpsByPattern(const tvm::Array<runtime::String>& pattern_names,
+                          const tvm::Array<DFPattern>& patterns, IRModule mod) {
+  support::Arena arena;
+  for (size_t i = 0; i < pattern_names.size(); ++i) {
+    std::unordered_map<const Object*, PatternBasedPartitioner::Group*> group_map;
+    for (const auto& [gv, func] : mod->functions) {
+      auto map = PatternBasedPartitioner::Run(pattern_names[i], patterns[i], func, &arena);
+      group_map.insert(map.begin(), map.end());
+    }
+    mod = OperatorFusor(mod, group_map).Transform();
+  }
+  return mod;
+}
+
 namespace transform {
 
 Pass FuseOps(int fuse_opt_level) {
@@ -773,6 +882,20 @@ Pass FuseOps(int fuse_opt_level) {
 }
 
 TVM_REGISTER_GLOBAL("relax.transform.FuseOps").set_body_typed(FuseOps);
+
+Pass FuseOpsByPattern(const tvm::Array<runtime::String>& pattern_names,
+                      const tvm::Array<DFPattern>& patterns) {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =  //
+      [=](IRModule m, PassContext pc) {
+        return relax::FuseOpsByPattern(pattern_names, patterns, m);
+      };
+  return CreateModulePass(/*pass_function=*/pass_func,       //
+                          /*opt_level=*/0,                   //
+                          /*pass_name=*/"FuseOpsByPattern",  //
+                          /*required=*/{});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.FuseOpsByPattern").set_body_typed(FuseOpsByPattern);
 
 }  // namespace transform
 

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -418,9 +418,11 @@ class FunctionCreator : public ExprMutator {
 
   /*!
    * \brief Create the grouped function according according to the collected bindings and parameters
+   * \param composite_name The name to identify the pattern this function is created from, if any.
+   * It will become the value of the kComposite attribute of the created function.
    * \note The created function won't be returned immediately. It's stored in the `function_` field.
    */
-  void CreateFunction(const std::string& composite_name) {
+  void CreateFunction(std::optional<std::string> composite_name) {
     // Step 1. Start constructing a new dataflow block.
     builder_->BeginDataflowBlock();
 
@@ -450,8 +452,8 @@ class FunctionCreator : public ExprMutator {
     body = builder_->Normalize(SeqExpr({new_block}, body));
     Map<String, ObjectRef> attrs;
     attrs.Set(tvm::relax::attr::kPrimitive, Integer(1));
-    if (!composite_name.empty()) {
-      attrs.Set(tvm::relax::attr::kComposite, String(composite_name));
+    if (composite_name) {
+      attrs.Set(tvm::relax::attr::kComposite, String(*composite_name));
     }
     function_ = Function(/*params=*/params_,           //
                          /*body=*/body,                //

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -922,8 +922,8 @@ IRModule FuseOpsByPattern(const tvm::Array<String>& pattern_names,
   support::Arena arena;
   for (size_t i = 0; i < pattern_names.size(); ++i) {
     OperatorFusor::GroupMap group_map;
-    for (const auto& [_, func] : mod->functions) {
-      auto map = PatternBasedPartitioner::Run(pattern_names[i], patterns[i], func, &arena);
+    for (const auto& entry : mod->functions) {
+      auto map = PatternBasedPartitioner::Run(pattern_names[i], patterns[i], entry.second, &arena);
       group_map.insert(map.begin(), map.end());
     }
     mod = OperatorFusor(mod, group_map).Transform();

--- a/src/relay/analysis/graph_partitioner.h
+++ b/src/relay/analysis/graph_partitioner.h
@@ -176,6 +176,7 @@ class GraphPartitioner {
      */
     uint32_t num_nodes{1};
 
+    std::string composite_name;
     /*!
      * \brief Find the group root, perform path compression
      * \return The root type node.

--- a/src/relay/analysis/graph_partitioner.h
+++ b/src/relay/analysis/graph_partitioner.h
@@ -24,6 +24,8 @@
 
 #include <tvm/relay/op_attr_types.h>
 
+#include <optional>
+
 #include "../../support/arena.h"
 
 namespace tvm {

--- a/src/relay/analysis/graph_partitioner.h
+++ b/src/relay/analysis/graph_partitioner.h
@@ -177,7 +177,7 @@ class GraphPartitioner {
     uint32_t num_nodes{1};
 
     /*! \brief The name to identify the pattern this group is created from, if any. */
-    std::string composite_name;
+    std::optional<std::string> composite_name;
     /*!
      * \brief Find the group root, perform path compression
      * \return The root type node.

--- a/src/relay/analysis/graph_partitioner.h
+++ b/src/relay/analysis/graph_partitioner.h
@@ -176,6 +176,7 @@ class GraphPartitioner {
      */
     uint32_t num_nodes{1};
 
+    /*! \brief The name to identify the pattern this group is created from, if any. */
     std::string composite_name;
     /*!
      * \brief Find the group root, perform path compression

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -31,8 +31,8 @@ class Conv2dReLUx2:
         weight2: R.Tensor((64, 64, 3, 3), "float32"),
     ):
         with R.dataflow():
-            conv1 = relax.op.nn.relu(relax.op.nn.conv2d(data, weight1, padding=(1, 1)))
-            conv2 = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
+            conv1 = R.nn.relu(R.nn.conv2d(data, weight1, padding=(1, 1)))
+            conv2 = R.nn.relu(R.nn.conv2d(conv1, weight2, padding=(0, 0)))
             R.output(conv2)
 
         return conv2
@@ -137,8 +137,8 @@ class Conv2dConv2dReLU:
         weight2: R.Tensor((64, 64, 3, 3), "float32"),
     ):
         with R.dataflow():
-            conv1 = relax.op.nn.conv2d(data, weight1, padding=(1, 1))
-            conv2d = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
+            conv1 = R.nn.conv2d(data, weight1, padding=(1, 1))
+            conv2d = R.nn.relu(R.nn.conv2d(conv1, weight2, padding=(0, 0)))
             R.output(conv2d)
 
         return conv2d
@@ -196,10 +196,10 @@ class BranchTupleOutput:
         weight: R.Tensor((64, 64, 3, 3), "float32"),
     ):
         with R.dataflow():
-            conv1 = relax.op.nn.conv2d(data, weight)
-            relu1 = relax.op.nn.relu(conv1)
-            gelu1 = relax.op.nn.gelu(relu1)
-            gelu2 = relax.op.nn.gelu(conv1)
+            conv1 = R.nn.conv2d(data, weight)
+            relu1 = R.nn.relu(conv1)
+            gelu1 = R.nn.gelu(relu1)
+            gelu2 = R.nn.gelu(conv1)
             out = relax.op.add(gelu1, gelu2)
             R.output(out)
 
@@ -249,9 +249,9 @@ class Branch:
         weight: R.Tensor((64, 64, 3, 3), "float32"),
     ):
         with R.dataflow():
-            conv1 = relax.op.nn.conv2d(data, weight)
-            relu1 = relax.op.nn.relu(conv1)
-            gelu1 = relax.op.nn.gelu(conv1)
+            conv1 = R.nn.conv2d(data, weight)
+            relu1 = R.nn.relu(conv1)
+            gelu1 = R.nn.gelu(conv1)
 
             out = relax.op.add(relu1, gelu1)
             R.output(out)

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -19,7 +19,7 @@ import tvm
 
 from tvm import relax
 from tvm.script import relax as R
-from tvm.relax.dpl.pattern import make_conv_pattern
+from tvm.relax.dpl.pattern import make_fused_bias_activation_pattern
 
 
 @tvm.script.ir_module
@@ -32,10 +32,10 @@ class Conv2dReLUx2:
     ):
         with R.dataflow():
             conv1 = relax.op.nn.relu(relax.op.nn.conv2d(data, weight1, padding=(1, 1)))
-            conv2d = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
-            R.output(conv2d)
+            conv2 = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
+            R.output(conv2)
 
-        return conv2d
+        return conv2
 
 
 @tvm.script.ir_module
@@ -188,8 +188,8 @@ class Conv2dReLUx2Partitioned_only_conv2d:
         return gv1
 
 
-conv2d_pat = make_conv_pattern("relax.nn.conv2d", activation=None)
-conv2d_relu_pat = make_conv_pattern("relax.nn.conv2d", activation="relax.nn.relu")
+conv2d_pat = make_fused_bias_activation_pattern("relax.nn.conv2d", activation=None)
+conv2d_relu_pat = make_fused_bias_activation_pattern("relax.nn.conv2d", activation="relax.nn.relu")
 
 
 def test_partition_conv2d_relu():

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import numpy as np
+import tvm
+
+from tvm import relax
+from tvm.script import relax as R
+from tvm.relax.dpl.pattern import make_conv_pattern
+
+
+@tvm.script.ir_module
+class Conv2dReLUx2:
+    @R.function
+    def main(
+        data: R.Tensor((1, 64, 56, 56), "float32"),
+        weight1: R.Tensor((64, 64, 3, 3), "float32"),
+        weight2: R.Tensor((64, 64, 3, 3), "float32"),
+    ):
+        with R.dataflow():
+            conv1 = relax.op.nn.relu(relax.op.nn.conv2d(data, weight1, padding=(1, 1)))
+            conv2d = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
+            R.output(conv2d)
+
+        return conv2d
+
+
+def test_partition_conv2d_relu():
+    pat = make_conv_pattern("relax.nn.conv2d", with_bias=False, activation="relax.nn.relu")
+
+    partitioned = relax.transform.FuseOpsByPattern(["dnnl.conv2d_relu"], [pat])(Conv2dReLUx2)
+    print(partitioned.script())
+
+
+if __name__ == "__main__":
+    test_partition_conv2d_relu()

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -14,8 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import numpy as np
+import pytest
 import tvm
 
 from tvm import relax
@@ -39,12 +38,182 @@ class Conv2dReLUx2:
         return conv2d
 
 
-def test_partition_conv2d_relu():
-    pat = make_conv_pattern("relax.nn.conv2d", with_bias=False, activation="relax.nn.relu")
+@tvm.script.ir_module
+class Conv2dConv2dReLU:
+    @R.function
+    def main(
+        data: R.Tensor((1, 64, 56, 56), "float32"),
+        weight1: R.Tensor((64, 64, 3, 3), "float32"),
+        weight2: R.Tensor((64, 64, 3, 3), "float32"),
+    ):
+        with R.dataflow():
+            conv1 = relax.op.nn.conv2d(data, weight1, padding=(1, 1))
+            conv2d = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
+            R.output(conv2d)
 
-    partitioned = relax.transform.FuseOpsByPattern(["dnnl.conv2d_relu"], [pat])(Conv2dReLUx2)
-    print(partitioned.script())
+        return conv2d
+
+
+@tvm.script.ir_module
+class Conv2dReLUx2Partitioned:
+    @R.function
+    def main(
+        data: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
+        weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        with R.dataflow():
+            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu(
+                data, weight1
+            )
+            gv: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu1(
+                lv, weight2
+            )
+            R.output(gv)
+        return gv
+
+    @R.function
+    def fused_relax_nn_conv2d_relax_nn_relu(
+        data1: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight11: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d_relu"})
+        with R.dataflow():
+            lv1: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.conv2d(
+                data1, weight11, padding=[1, 1, 1, 1]
+            )
+            gv1: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.relu(lv1)
+            R.output(gv1)
+        return gv1
+
+    @R.function
+    def fused_relax_nn_conv2d_relax_nn_relu1(
+        conv1: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight21: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d_relu"})
+        with R.dataflow():
+            lv2: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.conv2d(
+                conv1, weight21, padding=[0, 0, 0, 0]
+            )
+            gv2: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.relu(lv2)
+            R.output(gv2)
+        return gv2
+
+
+@tvm.script.ir_module
+class Conv2dConv2dReLUPartitioned:
+    @R.function
+    def main(
+        data: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
+        weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        with R.dataflow():
+            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(data, weight1)
+            gv: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu(
+                lv, weight2
+            )
+            R.output(gv)
+        return gv
+
+    @R.function
+    def fused_relax_nn_conv2d_relax_nn_relu(
+        conv1: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight21: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d_relu"})
+        with R.dataflow():
+            lv1: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.conv2d(
+                conv1, weight21, padding=[0, 0, 0, 0]
+            )
+            gv1: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.relu(lv1)
+            R.output(gv1)
+        return gv1
+
+    @R.function
+    def fused_relax_nn_conv2d(
+        data1: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight11: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d"})
+        with R.dataflow():
+            gv2: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.conv2d(
+                data1, weight11, padding=[1, 1, 1, 1]
+            )
+            R.output(gv2)
+        return gv2
+
+
+@tvm.script.ir_module
+class Conv2dReLUx2Partitioned_only_conv2d:
+    @R.function
+    def main(
+        data: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
+        weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        with R.dataflow():
+            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(data, weight1)
+            conv1: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.relu(lv)
+            lv1: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d1(conv1, weight2)
+            conv2d: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.relu(lv1)
+            R.output(conv2d)
+        return conv2d
+
+    @R.function
+    def fused_relax_nn_conv2d(
+        data1: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight11: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d"})
+        with R.dataflow():
+            gv: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.conv2d(
+                data1, weight11, padding=[1, 1, 1, 1]
+            )
+            R.output(gv)
+        return gv
+
+    @R.function
+    def fused_relax_nn_conv2d1(
+        conv11: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight21: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d"})
+        with R.dataflow():
+            gv1: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.conv2d(
+                conv11, weight21, padding=[0, 0, 0, 0]
+            )
+            R.output(gv1)
+        return gv1
+
+
+conv2d_pat = make_conv_pattern("relax.nn.conv2d", activation=None)
+conv2d_relu_pat = make_conv_pattern("relax.nn.conv2d", activation="relax.nn.relu")
+
+
+def test_partition_conv2d_relu():
+    partitioned = relax.transform.FuseOpsByPattern([("dnnl.conv2d_relu", conv2d_relu_pat)])(
+        Conv2dReLUx2
+    )
+    tvm.ir.assert_structural_equal(partitioned, Conv2dReLUx2Partitioned)
+
+
+def test_partition_multiple_patterns():
+    partitioned = relax.transform.FuseOpsByPattern(
+        [("dnnl.conv2d_relu", conv2d_relu_pat), ("dnnl.conv2d", conv2d_pat)]
+    )(Conv2dConv2dReLU)
+
+    tvm.ir.assert_structural_equal(partitioned, Conv2dConv2dReLUPartitioned)
+
+
+def test_partition_order():
+    partitioned = relax.transform.FuseOpsByPattern(
+        [("dnnl.conv2d", conv2d_pat), ("dnnl.conv2d_relu", conv2d_relu_pat)]
+    )(Conv2dReLUx2)
+
+    tvm.ir.assert_structural_equal(partitioned, Conv2dReLUx2Partitioned_only_conv2d)
 
 
 if __name__ == "__main__":
-    test_partition_conv2d_relu()
+    pytest.main([__file__])

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -39,22 +39,6 @@ class Conv2dReLUx2:
 
 
 @tvm.script.ir_module
-class Conv2dConv2dReLU:
-    @R.function
-    def main(
-        data: R.Tensor((1, 64, 56, 56), "float32"),
-        weight1: R.Tensor((64, 64, 3, 3), "float32"),
-        weight2: R.Tensor((64, 64, 3, 3), "float32"),
-    ):
-        with R.dataflow():
-            conv1 = relax.op.nn.conv2d(data, weight1, padding=(1, 1))
-            conv2d = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
-            R.output(conv2d)
-
-        return conv2d
-
-
-@tvm.script.ir_module
 class Conv2dReLUx2Partitioned:
     @R.function
     def main(
@@ -97,50 +81,6 @@ class Conv2dReLUx2Partitioned:
                 conv1, weight21, padding=[0, 0, 0, 0]
             )
             gv2: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.relu(lv2)
-            R.output(gv2)
-        return gv2
-
-
-@tvm.script.ir_module
-class Conv2dConv2dReLUPartitioned:
-    @R.function
-    def main(
-        data: R.Tensor((1, 64, 56, 56), dtype="float32"),
-        weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
-        weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
-    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
-        with R.dataflow():
-            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(data, weight1)
-            gv: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu(
-                lv, weight2
-            )
-            R.output(gv)
-        return gv
-
-    @R.function
-    def fused_relax_nn_conv2d_relax_nn_relu(
-        conv1: R.Tensor((1, 64, 56, 56), dtype="float32"),
-        weight21: R.Tensor((64, 64, 3, 3), dtype="float32"),
-    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
-        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d_relu"})
-        with R.dataflow():
-            lv1: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.conv2d(
-                conv1, weight21, padding=[0, 0, 0, 0]
-            )
-            gv1: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.relu(lv1)
-            R.output(gv1)
-        return gv1
-
-    @R.function
-    def fused_relax_nn_conv2d(
-        data1: R.Tensor((1, 64, 56, 56), dtype="float32"),
-        weight11: R.Tensor((64, 64, 3, 3), dtype="float32"),
-    ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
-        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d"})
-        with R.dataflow():
-            gv2: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.conv2d(
-                data1, weight11, padding=[1, 1, 1, 1]
-            )
             R.output(gv2)
         return gv2
 
@@ -189,6 +129,66 @@ class Conv2dReLUx2Partitioned_only_conv2d:
 
 
 @tvm.script.ir_module
+class Conv2dConv2dReLU:
+    @R.function
+    def main(
+        data: R.Tensor((1, 64, 56, 56), "float32"),
+        weight1: R.Tensor((64, 64, 3, 3), "float32"),
+        weight2: R.Tensor((64, 64, 3, 3), "float32"),
+    ):
+        with R.dataflow():
+            conv1 = relax.op.nn.conv2d(data, weight1, padding=(1, 1))
+            conv2d = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
+            R.output(conv2d)
+
+        return conv2d
+
+
+@tvm.script.ir_module
+class Conv2dConv2dReLUPartitioned:
+    @R.function
+    def main(
+        data: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
+        weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        with R.dataflow():
+            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(data, weight1)
+            gv: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu(
+                lv, weight2
+            )
+            R.output(gv)
+        return gv
+
+    @R.function
+    def fused_relax_nn_conv2d_relax_nn_relu(
+        conv1: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight21: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d_relu"})
+        with R.dataflow():
+            lv1: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.conv2d(
+                conv1, weight21, padding=[0, 0, 0, 0]
+            )
+            gv1: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.relu(lv1)
+            R.output(gv1)
+        return gv1
+
+    @R.function
+    def fused_relax_nn_conv2d(
+        data1: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        weight11: R.Tensor((64, 64, 3, 3), dtype="float32"),
+    ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d"})
+        with R.dataflow():
+            gv2: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.conv2d(
+                data1, weight11, padding=[1, 1, 1, 1]
+            )
+            R.output(gv2)
+        return gv2
+
+
+@tvm.script.ir_module
 class BranchTupleOutput:
     @R.function
     def main(
@@ -218,8 +218,8 @@ class BranchTupleOutputPartitioned:
                 R.Tensor((1, 64, 54, 54), dtype="float32"),
                 R.Tensor((1, 64, 54, 54), dtype="float32"),
             ) = fused_relax_nn_conv2d_relax_nn_relu(data, weight)
-            lv1: R.Tensor((1, 64, 54, 54), dtype="float32") = lv[1] # conv1
-            lv2: R.Tensor((1, 64, 54, 54), dtype="float32") = lv[0] # relu(conv1)
+            lv1: R.Tensor((1, 64, 54, 54), dtype="float32") = lv[1]  # conv1
+            lv2: R.Tensor((1, 64, 54, 54), dtype="float32") = lv[0]  # relu(conv1)
             gelu1: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.gelu(lv2)
             gelu2: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.gelu(lv1)
             out: R.Tensor((1, 64, 54, 54), dtype="float32") = R.add(gelu1, gelu2)
@@ -268,7 +268,7 @@ def test_partition_order():
     tvm.ir.assert_structural_equal(partitioned, Conv2dReLUx2Partitioned_only_conv2d)
 
 
-def test_branch():
+def test_branch_tuple_output():
     partitioned = relax.transform.FuseOpsByPattern([("dnnl.conv2d_relu", conv2d_relu_pat)])(
         BranchTupleOutput
     )


### PR DESCRIPTION
A part of https://github.com/tlc-pack/relax/issues/364

This adds a new pass, `FuseOpsByPattern`, which applies pattern matching to each function in the given module, and groups matched expressions into a new function. The end result is similar to FuseOps, but fusion is driven completely by
the provided patterns. The implementation also reuses `OperatorFusor` used by `FuseOps` to create grouped functions from partitioned groups, further illustrating the similarity between the two passes. 

The new pass will serve the same role the `MergeComposite` pass plays in Relay BYOC - grouped functions are annotated with the "composite" attribute to denote what operations a given function consists of, and offloaded to external backends. But it can be also useful in non-BYOC settings, for example to support advanced fusion that the op-kind based one doesn't handle (fused MHA, conv2d / gemm + reduction fusion, etc).

@tqchen @Hzfengsy @sunggg @ganler @junrushao 