### PR TITLE
[VM][TVMScript] Shorten VM op names and add TVMScript support

### DIFF
--- a/python/tvm/relax/op/vm/__init__.py
+++ b/python/tvm/relax/op/vm/__init__.py
@@ -15,35 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=wildcard-import, redefined-builtin
-"""Relax core operators."""
+"""Relax vm operators."""
 
-# Operators
-from .base import *
-from .binary import *
-from .create import *
-from .datatype import *
-from .index import *
-from .linear_algebra import *
-from .manipulate import *
-from .op_attrs import *
-from .search import *
-from .set import *
-from .statistical import *
-from .ternary import *
-from .unary import *
-from . import builtin
-from . import image
-from . import memory
-from . import nn
-from . import vm
-
-
-def _register_op_make():
-    # pylint: disable=import-outside-toplevel
-    from . import _ffi_api
-    from .. import expr
-
-    expr._op_ffi_api = _ffi_api  # type: ignore
-
-
-_register_op_make()
+from .op import *

--- a/python/tvm/relax/op/vm/_ffi_api.py
+++ b/python/tvm/relax/op/vm/_ffi_api.py
@@ -13,37 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License.
-# pylint: disable=wildcard-import, redefined-builtin
-"""Relax core operators."""
+"""FFI APIs for tvm.relax.op.vm"""
+import tvm._ffi
 
-# Operators
-from .base import *
-from .binary import *
-from .create import *
-from .datatype import *
-from .index import *
-from .linear_algebra import *
-from .manipulate import *
-from .op_attrs import *
-from .search import *
-from .set import *
-from .statistical import *
-from .ternary import *
-from .unary import *
-from . import builtin
-from . import image
-from . import memory
-from . import nn
-from . import vm
-
-
-def _register_op_make():
-    # pylint: disable=import-outside-toplevel
-    from . import _ffi_api
-    from .. import expr
-
-    expr._op_ffi_api = _ffi_api  # type: ignore
-
-
-_register_op_make()
+tvm._ffi._init_api("relax.op.vm", __name__)

--- a/python/tvm/relax/op/vm/op.py
+++ b/python/tvm/relax/op/vm/op.py
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+"""The builtin Relax operators."""
+
+from typing import List, Tuple, Union
+
+from tvm import DataType
+from tvm.ir.expr import PrimExpr
+
+from ...expr import Call, Expr, ExternFunc, ShapeExpr
+from ...expr import Tuple as RxTuple
+from ...utils import convert_to_expr
+from . import _ffi_api
+
+
+def alloc_storage(size: Expr, dtype: Union[DataType, str], runtime_device_index: int) -> Call:
+    """Construct a Call to allocate storage with specific size, dtype, runtime_device_index.
+
+    Parameters
+    ----------
+    size: Expr
+        The size of the storage to be allocated.
+
+    dtype: Union[DataType, str]
+        The data type of the storage to be allocated.
+
+    runtime_device_index : int
+        The device index indicating on which device the storage is to be allocated at runtime.
+        Index -1 is reserved for the host device.
+
+    Returns
+    -------
+    result : Call
+        A relax Call, which gets the allocated storage.
+    """
+    if isinstance(size, (tuple, list)):
+        size = ShapeExpr(size)
+    elif not isinstance(size, Expr):
+        raise TypeError("size must be a tuple of PrimExpr or relax.Expr")
+    return _ffi_api.alloc_storage(size, dtype, runtime_device_index)  # type: ignore
+
+
+def alloc_tensor(
+    storage: Expr,
+    shape: Union[Tuple[PrimExpr], Expr],
+    offset: int,
+    dtype: Union[DataType, str],
+) -> Call:
+    """Construct a Call to allocate a tensor with specific shape, dtype, runtime_device_index.
+
+    Parameters
+    ----------
+    storage: Expr
+        The storage location to be allocated.
+
+    shape: Union[Tuple[PrimExpr], Expr]
+        The shape of the tensor to be allocated.
+
+    offset: int
+        The offset of the tensor to be allocated.
+
+    dtype: Union[DataType, str]
+        The datatype of the tensor to be allocated.
+
+    Returns
+    -------
+    result : Call
+        A relax Call, which gets the allocated tensor.
+    """
+    if isinstance(shape, (tuple, list)):
+        shape = ShapeExpr(shape)
+    elif not isinstance(shape, Expr):
+        raise TypeError("storage must be a tuple of PrimExpr or relax.Expr")
+    return _ffi_api.alloc_tensor(storage, shape, offset, dtype)  # type: ignore
+
+
+def store_shape(
+    shape: Union[Tuple[PrimExpr], Expr],
+    heap: Expr,
+    indices: List[int],
+) -> Call:
+    """Construct a Call to store the shape of a tensor to the heap.
+
+    Parameters
+    ----------
+    shape: Union[Tuple[PrimExpr], Expr]
+        The shape of the tensor to be stored.
+
+    heap: Expr
+        The heap to store the shape.
+
+    indices: List[int]
+        The indices of the shape to be stored.
+
+    Returns
+    -------
+    result : Call
+        A relax Call, which stores the shape.
+    """
+    if isinstance(shape, (tuple, list)):
+        shape = ShapeExpr(shape)
+    elif not isinstance(shape, Expr):
+        raise TypeError("shape must be a tuple of PrimExpr or relax.Expr")
+    return _ffi_api.store_shape(shape, heap, indices)  # type: ignore
+
+
+def load_shape(
+    heap: Expr,
+    indices: List[int],
+) -> Call:
+    """Construct a Call to load the shape of a tensor from the heap.
+
+    Parameters
+    ----------
+    heap: Expr
+        The heap to load the shape.
+
+    indices: List[int]
+        The indices of the shape to be loaded.
+
+    Returns
+    -------
+    result : Call
+        A relax Call, which loads the shape.
+    """
+    return _ffi_api.load_shape(heap, indices)  # type: ignore
+
+
+def call_tir_dyn(
+    func: Union[str, Expr],
+    args: Union[Expr, List[Expr]],
+) -> Call:
+    """Construct a Call to call a tir function with dynamic shape.
+
+    Parameters
+    ----------
+    func: Union[str, Expr],
+        The destination-passing-style function, can be ExternFunc or PrimFunc.
+
+    args: Union[Expr, List[Expr]]
+        The arguments to the tir function.
+
+    Returns
+    -------
+    result : Call
+        A relax Call, which calls the tir function.
+    """
+    if isinstance(func, str):
+        func = ExternFunc(func)
+
+    args = convert_to_expr(args)
+
+    return _ffi_api.call_tir_dyn(func, args)  # type: ignore

--- a/python/tvm/relax/op/vm/op.py
+++ b/python/tvm/relax/op/vm/op.py
@@ -47,8 +47,7 @@ def alloc_storage(size: Expr, dtype: Union[DataType, str], runtime_device_index:
     """
     if isinstance(size, (tuple, list)):
         size = ShapeExpr(size)
-    elif not isinstance(size, Expr):
-        raise TypeError("size must be a tuple of PrimExpr or relax.Expr")
+
     return _ffi_api.alloc_storage(size, dtype, runtime_device_index)  # type: ignore
 
 
@@ -81,8 +80,7 @@ def alloc_tensor(
     """
     if isinstance(shape, (tuple, list)):
         shape = ShapeExpr(shape)
-    elif not isinstance(shape, Expr):
-        raise TypeError("storage must be a tuple of PrimExpr or relax.Expr")
+
     return _ffi_api.alloc_tensor(storage, shape, offset, dtype)  # type: ignore
 
 

--- a/python/tvm/relax/op/vm/op.py
+++ b/python/tvm/relax/op/vm/op.py
@@ -87,58 +87,6 @@ def alloc_tensor(
     return _ffi_api.alloc_tensor(storage, shape, offset, dtype)  # type: ignore
 
 
-def store_shape(
-    shape: Union[Tuple[PrimExpr], Expr],
-    heap: Expr,
-    indices: List[int],
-) -> Call:
-    """Construct a Call to store the shape of a tensor to the heap.
-
-    Parameters
-    ----------
-    shape: Union[Tuple[PrimExpr], Expr]
-        The shape of the tensor to be stored.
-
-    heap: Expr
-        The heap to store the shape.
-
-    indices: List[int]
-        The indices of the shape to be stored.
-
-    Returns
-    -------
-    result : Call
-        A relax Call, which stores the shape.
-    """
-    if isinstance(shape, (tuple, list)):
-        shape = ShapeExpr(shape)
-    elif not isinstance(shape, Expr):
-        raise TypeError("shape must be a tuple of PrimExpr or relax.Expr")
-    return _ffi_api.store_shape(shape, heap, indices)  # type: ignore
-
-
-def load_shape(
-    heap: Expr,
-    indices: List[int],
-) -> Call:
-    """Construct a Call to load the shape of a tensor from the heap.
-
-    Parameters
-    ----------
-    heap: Expr
-        The heap to load the shape.
-
-    indices: List[int]
-        The indices of the shape to be loaded.
-
-    Returns
-    -------
-    result : Call
-        A relax Call, which loads the shape.
-    """
-    return _ffi_api.load_shape(heap, indices)  # type: ignore
-
-
 def call_tir_dyn(
     func: Union[str, Expr],
     args: Union[Expr, List[Expr]],

--- a/python/tvm/relax/op/vm/op.py
+++ b/python/tvm/relax/op/vm/op.py
@@ -21,7 +21,6 @@ from tvm import DataType
 from tvm.ir.expr import PrimExpr
 
 from ...expr import Call, Expr, ExternFunc, ShapeExpr
-from ...expr import Tuple as RxTuple
 from ...utils import convert_to_expr
 from . import _ffi_api
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -22,10 +22,9 @@ import inspect
 from typing import Dict, List, Optional, Tuple, Union
 
 import tvm
-from tvm.ir import Type
 from tvm import relax
+from tvm.ir import Type
 from tvm.relax import Call, Expr, ExternFunc, TupleGetItem, Var, const
-from tvm.relax.struct_info import StructInfo
 from tvm.relax.analysis import get_static_type
 
 ############################### Operators ###############################
@@ -35,9 +34,8 @@ from tvm.relax.op import (
     astype,
     broadcast_to,
     builtin,
-    null_value,
-    call_tir,
     call_builtin,
+    call_tir,
     concat,
     cos,
     divide,
@@ -66,6 +64,7 @@ from tvm.relax.op import (
     negative,
     nn,
     not_equal,
+    null_value,
     ones,
     ones_like,
     permute_dims,
@@ -88,12 +87,15 @@ from tvm.relax.op import (
     triu,
     unique,
     variance,
+    vm,
     where,
     zeros,
     zeros_like,
 )
+from tvm.relax.struct_info import StructInfo
 from tvm.relax.utils import convert_to_expr
-from tvm.runtime import Object as tvm_Object, ObjectGeneric
+from tvm.runtime import Object as tvm_Object
+from tvm.runtime import ObjectGeneric
 
 from . import _ffi_api, frame
 
@@ -400,7 +402,6 @@ __all__ = [
     "call_tir",
     "call_builtin",
     "cos",
-    "null_value",
     "concat",
     "const",
     "dataflow",
@@ -437,6 +438,7 @@ __all__ = [
     "negative",
     "nn",
     "not_equal",
+    "null_value",
     "ones",
     "ones_like",
     "output",
@@ -461,6 +463,7 @@ __all__ = [
     "tuple",
     "unique",
     "variance",
+    "vm",
     "where",
     "zeros",
     "zeros_like",

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -443,8 +443,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   /*! \brief the context module. */
   IRModule ctx_mod_;
   /*! \brief Cache ops that need to be frequently used later to reduce lookup overhead. */
-  const Op& alloc_storage_op_ = Op::Get("relax.vm.builtin.alloc_storage");
-  const Op& alloc_tensor_op_ = Op::Get("relax.vm.builtin.alloc_tensor");
+  const Op& alloc_storage_op_ = Op::Get("relax.vm.alloc_storage");
+  const Op& alloc_tensor_op_ = Op::Get("relax.vm.alloc_tensor");
   const Op& call_builtin_op_ = Op::Get("relax.call_builtin");
   const Op& null_value_op_ = Op::Get("relax.null_value");
   const Op& unique_op_ = Op::Get("relax.unique");

--- a/src/relax/backend/vm/codegen_vm_tir.cc
+++ b/src/relax/backend/vm/codegen_vm_tir.cc
@@ -506,8 +506,8 @@ class CodeGenVMTIR : public ExprFunctor<Optional<PrimExpr>(const Expr&)> {
   /*! \brief the context module. */
   IRModule ctx_mod_;
   /*! \brief Cache ops that need to be frequently used later to reduce lookup overhead. */
-  const Op& alloc_storage_op_ = Op::Get("relax.vm.builtin.alloc_storage");
-  const Op& alloc_tensor_op_ = Op::Get("relax.vm.builtin.alloc_tensor");
+  const Op& alloc_storage_op_ = Op::Get("relax.vm.alloc_storage");
+  const Op& alloc_tensor_op_ = Op::Get("relax.vm.alloc_tensor");
   const Op& call_builtin_op_ = Op::Get("relax.call_builtin");
   const Op& null_value_op_ = Op::Get("relax.null_value");
 };

--- a/src/relax/backend/vm/vm_builtin_lower.cc
+++ b/src/relax/backend/vm/vm_builtin_lower.cc
@@ -160,8 +160,8 @@ class VMBuiltinLowerMutator : public ExprMutator {
   const Op& invoke_closure_op_ = Op::Get("relax.invoke_closure");
   const Op& alloc_tensor_op_ = Op::Get("relax.builtin.alloc_tensor");
   // functions to lower to
-  const Op& vm_alloc_storage_op_ = Op::Get("relax.vm.builtin.alloc_storage");
-  const Op& vm_alloc_tensor_op_ = Op::Get("relax.vm.builtin.alloc_tensor");
+  const Op& vm_alloc_storage_op_ = Op::Get("relax.vm.alloc_storage");
+  const Op& vm_alloc_tensor_op_ = Op::Get("relax.vm.alloc_tensor");
   // Function to compute allocated shape.
   const ExternFunc builtin_compute_alloc_shape_{"vm.builtin.compute_alloc_shape"};
   const ExternFunc builtin_call_tir_dyn_{"vm.builtin.call_tir_dyn"};

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -390,7 +390,7 @@ TVM_REGISTER_GLOBAL("relax.op.memory.kill_tensor").set_body_typed(MakeMemKillTen
 
 // vm alloc_storage
 
-RELAY_REGISTER_OP("relax.vm.builtin.alloc_storage")
+RELAY_REGISTER_OP("relax.vm.alloc_storage")
     .set_attrs_type<VMAllocStorageAttrs>()
     .set_num_inputs(1)
     .add_argument("size", "Expr", "The size of the storage to allocate.")
@@ -400,11 +400,11 @@ Expr MakeVMAllocStorage(Expr size, DataType dtype, int64_t runtime_device_index)
   auto attrs = make_object<VMAllocStorageAttrs>();
   attrs->dtype = std::move(dtype);
   attrs->runtime_device_index = std::move(runtime_device_index);
-  static const Op& op = Op::Get("relax.vm.builtin.alloc_storage");
+  static const Op& op = Op::Get("relax.vm.alloc_storage");
   return Call(op, {size}, Attrs(attrs), {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_storage").set_body_typed(MakeVMAllocStorage);
+TVM_REGISTER_GLOBAL("relax.op.vm.alloc_storage").set_body_typed(MakeVMAllocStorage);
 
 // vm alloc_tensor
 
@@ -421,7 +421,7 @@ StructInfo InferStructInfoVMAllocTensor(const Call& call, const BlockBuilder& ct
   return TensorStructInfo(attrs->dtype, kUnknownNDim);
 }
 
-RELAY_REGISTER_OP("relax.vm.builtin.alloc_tensor")
+RELAY_REGISTER_OP("relax.vm.alloc_tensor")
     .set_attrs_type<VMAllocTensorAttrs>()
     .set_num_inputs(2)
     .add_argument("storage", "Expr", "The storage to allocate the tensor to.")
@@ -432,15 +432,15 @@ Expr MakeVMAllocTensor(Expr storage, Expr shape, int offset, DataType dtype) {
   auto attrs = make_object<VMAllocTensorAttrs>();
   attrs->offset = std::move(offset);
   attrs->dtype = std::move(dtype);
-  static const Op& op = Op::Get("relax.vm.builtin.alloc_tensor");
+  static const Op& op = Op::Get("relax.vm.alloc_tensor");
   return Call(op, {storage, shape}, Attrs(attrs), {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.vm.builtin.alloc_tensor").set_body_typed(MakeVMAllocTensor);
+TVM_REGISTER_GLOBAL("relax.op.vm.alloc_tensor").set_body_typed(MakeVMAllocTensor);
 
 // vm store_shape
 
-RELAY_REGISTER_OP("relax.vm.builtin.store_shape")
+RELAY_REGISTER_OP("relax.vm.store_shape")
     .set_attrs_type<ShapeHeapAttrs>()
     .set_num_inputs(2)
     .add_argument("shape", "Expr", "The shape to be stored.")
@@ -450,15 +450,15 @@ RELAY_REGISTER_OP("relax.vm.builtin.store_shape")
 Expr MakeStoreShape(Expr shape, Expr heap, Array<Integer> indices) {
   auto attrs = make_object<ShapeHeapAttrs>();
   attrs->indices = std::move(indices);
-  static const Op& op = Op::Get("relax.vm.builtin.store_shape");
+  static const Op& op = Op::Get("relax.vm.store_shape");
   return Call(op, {shape, heap}, Attrs(attrs), {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.vm.builtin.store_shape").set_body_typed(MakeStoreShape);
+TVM_REGISTER_GLOBAL("relax.op.vm.store_shape").set_body_typed(MakeStoreShape);
 
 // vm load_shape
 
-RELAY_REGISTER_OP("relax.vm.builtin.load_shape")
+RELAY_REGISTER_OP("relax.vm.load_shape")
     .set_attrs_type<ShapeHeapAttrs>()
     .set_num_inputs(1)
     .add_argument("heap", "Expr", "The heap to load the shape from.")
@@ -467,11 +467,11 @@ RELAY_REGISTER_OP("relax.vm.builtin.load_shape")
 Expr MakeLoadShape(Expr heap, Array<Integer> indices) {
   auto attrs = make_object<ShapeHeapAttrs>();
   attrs->indices = std::move(indices);
-  static const Op& op = Op::Get("relax.vm.builtin.load_shape");
+  static const Op& op = Op::Get("relax.vm.load_shape");
   return Call(op, {heap}, Attrs(attrs), {});
 }
 
-TVM_REGISTER_GLOBAL("relax.op.vm.builtin.load_shape").set_body_typed(MakeLoadShape);
+TVM_REGISTER_GLOBAL("relax.op.vm.load_shape").set_body_typed(MakeLoadShape);
 
 // vm call_tir_dyn
 
@@ -481,6 +481,14 @@ RELAY_REGISTER_OP("relax.vm.call_tir_dyn")
     .add_argument("args", "Tuple",
                   "The input arguments (list of tensors and last argument is ShapeExpr)")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnVoidStructInfo);
+
+Expr MakeCallTIRDyn(Expr func, Tuple args) {
+  static const Op& op = Op::Get("relax.vm.call_tir_dyn");
+  return Call(op, {func, args}, Attrs(), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.vm.call_tir_dyn").set_body_typed(MakeCallTIRDyn);
+
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -438,41 +438,6 @@ Expr MakeVMAllocTensor(Expr storage, Expr shape, int offset, DataType dtype) {
 
 TVM_REGISTER_GLOBAL("relax.op.vm.alloc_tensor").set_body_typed(MakeVMAllocTensor);
 
-// vm store_shape
-
-RELAY_REGISTER_OP("relax.vm.store_shape")
-    .set_attrs_type<ShapeHeapAttrs>()
-    .set_num_inputs(2)
-    .add_argument("shape", "Expr", "The shape to be stored.")
-    .add_argument("heap", "Expr", "The heap to store the shape.")
-    .set_attr<FInferStructInfo>("FInferStructInfo", ReturnVoidStructInfo);
-
-Expr MakeStoreShape(Expr shape, Expr heap, Array<Integer> indices) {
-  auto attrs = make_object<ShapeHeapAttrs>();
-  attrs->indices = std::move(indices);
-  static const Op& op = Op::Get("relax.vm.store_shape");
-  return Call(op, {shape, heap}, Attrs(attrs), {});
-}
-
-TVM_REGISTER_GLOBAL("relax.op.vm.store_shape").set_body_typed(MakeStoreShape);
-
-// vm load_shape
-
-RELAY_REGISTER_OP("relax.vm.load_shape")
-    .set_attrs_type<ShapeHeapAttrs>()
-    .set_num_inputs(1)
-    .add_argument("heap", "Expr", "The heap to load the shape from.")
-    .set_attr<FInferStructInfo>("FInferStructInfo", ReturnShapeStructInfo);
-
-Expr MakeLoadShape(Expr heap, Array<Integer> indices) {
-  auto attrs = make_object<ShapeHeapAttrs>();
-  attrs->indices = std::move(indices);
-  static const Op& op = Op::Get("relax.vm.load_shape");
-  return Call(op, {heap}, Attrs(attrs), {});
-}
-
-TVM_REGISTER_GLOBAL("relax.op.vm.load_shape").set_body_typed(MakeLoadShape);
-
 // vm call_tir_dyn
 
 RELAY_REGISTER_OP("relax.vm.call_tir_dyn")
@@ -488,7 +453,6 @@ Expr MakeCallTIRDyn(Expr func, Tuple args) {
 }
 
 TVM_REGISTER_GLOBAL("relax.op.vm.call_tir_dyn").set_body_typed(MakeCallTIRDyn);
-
 
 }  // namespace relax
 }  // namespace tvm

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -311,7 +311,7 @@ def test_vm_memory_lower():
     block = func.body.blocks[0]
     s1 = block.bindings[0].value
     assert isinstance(s1, relax.Call)
-    assert s1.op.name == "relax.vm.builtin.alloc_storage"
+    assert s1.op.name == "relax.vm.alloc_storage"
     s2 = block.bindings[1].value
     assert isinstance(s2, relax.Call)
     s3 = block.bindings[2].value

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -938,8 +938,6 @@ def test_vm_ops():
         tensor = R.builtin.alloc_tensor((m, n), dtype="float32", runtime_device_index=0)
         _ = R.vm.call_tir_dyn("te_func", (x, tensor, (m, n)))
         gv = tensor
-        # TODO: add testcase for store_shape / load_shape
-        # Need some context of how to use them.
         return alloc, gv
 
     _check(foo, None)

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -928,6 +928,23 @@ def test_arith_operators():
     _check(foo, bb.get()["foo"])
 
 
+def test_vm_ops():
+    @R.function
+    def foo(x: R.Tensor(("m", "n"), dtype="float32")):
+        m = T.var("int64")
+        n = T.var("int64")
+        storage = R.vm.alloc_storage((4 * m * n,), dtype="float32", runtime_device_index=0)
+        alloc = R.vm.alloc_tensor(storage, (m, n), offset=0, dtype="float32")
+        tensor = R.builtin.alloc_tensor((m, n), dtype="float32", runtime_device_index=0)
+        _ = R.vm.call_tir_dyn("te_func", (x, tensor, (m, n)))
+        gv = tensor
+        # TODO: add testcase for store_shape / load_shape
+        # Need some context of how to use them.
+        return alloc, gv
+
+    _check(foo, None)
+
+
 @pytest.mark.skip(reason="potential upstream Metadata changes.")
 def test_meta():
     metadata = tvm.ir.load_json(


### PR DESCRIPTION
This PR contains the following changes:
1. Shorten the VM op prefix from `relax.op.vm.builtin` to `relax.op.vm`, e.g. `relax.op.vm.builtin.alloc_tensor` -> `relax.op.vm.alloc_tensor`.
2. Add TVMScript support for VM ops.
3. remove unused `vm.store_shape` and `vm.load_shape`.

cc @vinx13 @YuchenJin 