### PR TITLE
[IR] Initial PrimValue Support

### DIFF
--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -152,6 +152,9 @@ class ExprFunctor<R(const Expr& n, Args...)> {
   virtual R VisitExpr_(const IfNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const OpNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const TupleGetItemNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
+  virtual R VisitExpr_(const PrimValueNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
+  virtual R VisitExpr_(const StringImmNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
+  virtual R VisitExpr_(const DataTypeImmNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExprDefault_(const Object* op, Args...) {
     LOG(FATAL) << "Do not have a default for " << op->GetTypeKey();
     throw;
@@ -175,6 +178,9 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     RELAX_EXPR_FUNCTOR_DISPATCH(IfNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(OpNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(TupleGetItemNode);
+    RELAX_EXPR_FUNCTOR_DISPATCH(PrimValueNode);
+    RELAX_EXPR_FUNCTOR_DISPATCH(StringImmNode);
+    RELAX_EXPR_FUNCTOR_DISPATCH(DataTypeImmNode);
     return vtable;
   }
 };
@@ -204,6 +210,9 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
   void VisitExpr_(const IfNode* op) override;
   void VisitExpr_(const OpNode* op) override;
   void VisitExpr_(const TupleGetItemNode* op) override;
+  void VisitExpr_(const PrimValueNode* op) override;
+  void VisitExpr_(const StringImmNode* op) override;
+  void VisitExpr_(const DataTypeImmNode* op) override;
 
   /*!
    * \brief Generic dispatcher for bindings.
@@ -228,6 +237,9 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
   virtual void VisitBinding_(const VarBindingNode* binding, const IfNode* val);
   virtual void VisitBinding_(const VarBindingNode* binding, const OpNode* val);
   virtual void VisitBinding_(const VarBindingNode* binding, const TupleGetItemNode* val);
+  virtual void VisitBinding_(const VarBindingNode* binding, const PrimValueNode* val);
+  virtual void VisitBinding_(const VarBindingNode* binding, const StringImmNode* val);
+  virtual void VisitBinding_(const VarBindingNode* binding, const DataTypeImmNode* val);
   /*!
    * \brief Generic dispatcher for binding blocks.
    * \param block The binding block to be visited.
@@ -326,6 +338,9 @@ class ExprMutatorBase : public ExprFunctor<Expr(const Expr&)> {
   Expr VisitExpr_(const IfNode* op) override;
   Expr VisitExpr_(const OpNode* op) override;
   Expr VisitExpr_(const TupleGetItemNode* op) override;
+  Expr VisitExpr_(const PrimValueNode* op) override;
+  Expr VisitExpr_(const StringImmNode* op) override;
+  Expr VisitExpr_(const DataTypeImmNode* op) override;
 
   /*!
    * \brief Mutate BindingBlock.
@@ -451,6 +466,9 @@ class ExprMutator : public ExprMutatorBase {
   virtual void VisitBinding_(const VarBindingNode* binding, const IfNode* val);
   virtual void VisitBinding_(const VarBindingNode* binding, const OpNode* val);
   virtual void VisitBinding_(const VarBindingNode* binding, const TupleGetItemNode* val);
+  virtual void VisitBinding_(const VarBindingNode* binding, const PrimValueNode* val);
+  virtual void VisitBinding_(const VarBindingNode* binding, const StringImmNode* val);
+  virtual void VisitBinding_(const VarBindingNode* binding, const DataTypeImmNode* val);
   /*!
    * \brief Generic dispatcher for binding blocks.
    * \param block The binding block to be visited.
@@ -576,6 +594,12 @@ class PyExprVisitorNode : public Object, public ExprVisitor {
   PackedFunc f_visit_op_{nullptr};
   /*! \brief The packed function to the `VisitExpr_(const TupleGetItemNode* op)` function. */
   PackedFunc f_visit_tuple_getitem_{nullptr};
+  /*! \brief The packed function to the `VisitExpr_(const PrimValueNode* op)` function. */
+  PackedFunc f_visit_prim_value_{nullptr};
+  /*! \brief The packed function to the `VisitExpr_(const StringImmNode* op)` function. */
+  PackedFunc f_visit_string_imm_{nullptr};
+  /*! \brief The packed function to the `VisitExpr_(const DataTypeImmNode* op)` function. */
+  PackedFunc f_visit_data_type_imm_{nullptr};
   /*! \brief The packed function to the `VisitBinding(const Binding& binding)` function. */
   PackedFunc f_visit_binding{nullptr};
   /*! \brief The packed function to the `VisitBinding_(const VarBindingNode* binding)`
@@ -668,6 +692,9 @@ class PyExprVisitorNode : public Object, public ExprVisitor {
     PY_EXPR_VISITOR_DISPATCH(IfNode, f_visit_if_);
     PY_EXPR_VISITOR_DISPATCH(OpNode, f_visit_op_);
     PY_EXPR_VISITOR_DISPATCH(TupleGetItemNode, f_visit_tuple_getitem_);
+    PY_EXPR_VISITOR_DISPATCH(PrimValueNode, f_visit_prim_value_);
+    PY_EXPR_VISITOR_DISPATCH(StringImmNode, f_visit_string_imm_);
+    PY_EXPR_VISITOR_DISPATCH(DataTypeImmNode, f_visit_data_type_imm_);
     return vtable;
   }
 };
@@ -696,6 +723,9 @@ class PyExprVisitor : public ObjectRef {
    * \param f_visit_if_ The packed function of `VisitExpr_(const IfNode* op)`.
    * \param f_visit_op_ The packed function of `VisitExpr_(const OpNode* op)`.
    * \param f_visit_tuple_getitem_ The packed function of `VisitExpr_(const TupleGetItemNode* op)`.
+   * \param f_visit_prim_value_ The packed function of `VisitExpr_(const PrimValueNode* op)`.
+   * \param f_visit_string_imm_ The packed function of `VisitExpr_(const StringImmNode* op)`.
+   * \param f_visit_data_type_imm_ The packed function of `VisitExpr_(const DataTypeImmNode* op)`.
    * \param f_visit_binding The packed function of `VisitBinding(const Binding& binding)`.
    * \param f_visit_var_binding_ The packed function of `VisitBinding_(const VarBindingNode*
    * binding)`.
@@ -720,7 +750,8 @@ class PyExprVisitor : public ObjectRef {
       PackedFunc f_visit_var_, PackedFunc f_visit_dataflow_var_, PackedFunc f_visit_shape_expr_,
       PackedFunc f_visit_extern_func_, PackedFunc f_visit_global_var_, PackedFunc f_visit_function_,
       PackedFunc f_visit_call_, PackedFunc f_visit_seq_expr_, PackedFunc f_visit_if_,
-      PackedFunc f_visit_op_, PackedFunc f_visit_tuple_getitem_, PackedFunc f_visit_binding,
+      PackedFunc f_visit_op_, PackedFunc f_visit_tuple_getitem_, PackedFunc f_visit_prim_value_,
+      PackedFunc f_visit_string_imm_, PackedFunc f_visit_data_type_imm_, PackedFunc f_visit_binding,
       PackedFunc f_visit_var_binding_, PackedFunc f_visit_match_cast_,
       PackedFunc f_visit_binding_block, PackedFunc f_visit_binding_block_,
       PackedFunc f_visit_dataflow_block_, PackedFunc f_visit_var_def, PackedFunc f_visit_var_def_,
@@ -745,6 +776,9 @@ class PyExprVisitor : public ObjectRef {
     n->f_visit_if_ = f_visit_if_;
     n->f_visit_op_ = f_visit_op_;
     n->f_visit_tuple_getitem_ = f_visit_tuple_getitem_;
+    n->f_visit_prim_value_ = f_visit_prim_value_;
+    n->f_visit_string_imm_ = f_visit_string_imm_;
+    n->f_visit_data_type_imm_ = f_visit_data_type_imm_;
     n->f_visit_var_binding_ = f_visit_var_binding_;
     n->f_visit_match_cast_ = f_visit_match_cast_;
     n->f_visit_binding_block_ = f_visit_binding_block_;
@@ -794,6 +828,12 @@ class PyExprMutatorNode : public Object, public ExprMutator {
   PackedFunc f_visit_op_{nullptr};
   /*! \brief The packed function to the `VisitExpr_(const TupleGetItemNode* op)` function. */
   PackedFunc f_visit_tuple_getitem_{nullptr};
+  /*! \brief The packed function to the `VisitExpr_(const PrimValueNode* op)` function. */
+  PackedFunc f_visit_prim_value_{nullptr};
+  /*! \brief The packed function to the `VisitExpr_(const StringImmNode* op)` function. */
+  PackedFunc f_visit_string_imm_{nullptr};
+  /*! \brief The packed function to the `VisitExpr_(const DataTypeImmNode* op)` function. */
+  PackedFunc f_visit_data_type_imm_{nullptr};
   /*! \brief The packed function to the `VisitBinding(const Binding& binding)` function. */
   PackedFunc f_visit_binding{nullptr};
   /*! \brief The packed function to the `VisitBinding_(const VarBindingNode* binding)`
@@ -912,6 +952,9 @@ class PyExprMutatorNode : public Object, public ExprMutator {
     PY_EXPR_MUTATOR_DISPATCH(IfNode, f_visit_if_);
     PY_EXPR_MUTATOR_DISPATCH(OpNode, f_visit_op_);
     PY_EXPR_MUTATOR_DISPATCH(TupleGetItemNode, f_visit_tuple_getitem_);
+    PY_EXPR_MUTATOR_DISPATCH(PrimValueNode, f_visit_prim_value_);
+    PY_EXPR_MUTATOR_DISPATCH(StringImmNode, f_visit_string_imm_);
+    PY_EXPR_MUTATOR_DISPATCH(DataTypeImmNode, f_visit_data_type_imm_);
     return vtable;
   }
 
@@ -932,6 +975,9 @@ class PyExprMutatorNode : public Object, public ExprMutator {
     PY_EXPR_MUTATOR_VISIT_EXPR_POST_ORDER_DISPATCH(IfNode);
     PY_EXPR_MUTATOR_VISIT_EXPR_POST_ORDER_DISPATCH(OpNode);
     PY_EXPR_MUTATOR_VISIT_EXPR_POST_ORDER_DISPATCH(TupleGetItemNode);
+    PY_EXPR_MUTATOR_VISIT_EXPR_POST_ORDER_DISPATCH(PrimValueNode);
+    PY_EXPR_MUTATOR_VISIT_EXPR_POST_ORDER_DISPATCH(StringImmNode);
+    PY_EXPR_MUTATOR_VISIT_EXPR_POST_ORDER_DISPATCH(DataTypeImmNode);
     return post_order_vtable;
   }
 };
@@ -960,6 +1006,9 @@ class PyExprMutator : public ObjectRef {
    * \param f_visit_if_ The packed function of `VisitExpr_(const IfNode* op)`.
    * \param f_visit_op_ The packed function of `VisitExpr_(const OpNode* op)`.
    * \param f_visit_tuple_getitem_ The packed function of `VisitExpr_(const TupleGetItemNode* op)`.
+   * \param f_visit_prim_value_ The packed function of `VisitExpr_(const PrimValueNode* op)`.
+   * \param f_visit_string_imm_ The packed function of `VisitExpr_(const StringImmNode* op)`.
+   * \param f_visit_data_type_imm_ The packed function of `VisitExpr_(const DataTypeImmNode* op)`.
    * \param f_visit_binding The packed function of `VisitBinding(const Binding& binding)`.
    * \param f_visit_var_binding_ The packed function of `VisitBinding_(const VarBindingNode*
    * binding)`.
@@ -985,7 +1034,8 @@ class PyExprMutator : public ObjectRef {
       PackedFunc f_visit_shape_expr_, PackedFunc f_visit_extern_func_,
       PackedFunc f_visit_global_var_, PackedFunc f_visit_function_, PackedFunc f_visit_call_,
       PackedFunc f_visit_seq_expr_, PackedFunc f_visit_if_, PackedFunc f_visit_op_,
-      PackedFunc f_visit_tuple_getitem_, PackedFunc f_visit_binding,
+      PackedFunc f_visit_tuple_getitem_, PackedFunc f_visit_prim_value_,
+      PackedFunc f_visit_string_imm_, PackedFunc f_visit_data_type_imm_, PackedFunc f_visit_binding,
       PackedFunc f_visit_var_binding_, PackedFunc f_visit_match_cast_,
       PackedFunc f_visit_binding_block, PackedFunc f_visit_binding_block_,
       PackedFunc f_visit_dataflow_block_, PackedFunc f_visit_var_def, PackedFunc f_visit_var_def_,
@@ -1006,6 +1056,9 @@ class PyExprMutator : public ObjectRef {
     n->f_visit_if_ = f_visit_if_;
     n->f_visit_op_ = f_visit_op_;
     n->f_visit_tuple_getitem_ = f_visit_tuple_getitem_;
+    n->f_visit_prim_value_ = f_visit_prim_value_;
+    n->f_visit_string_imm_ = f_visit_string_imm_;
+    n->f_visit_data_type_imm_ = f_visit_data_type_imm_;
     n->f_visit_binding = f_visit_binding;
     n->f_visit_var_binding_ = f_visit_var_binding_;
     n->f_visit_match_cast_ = f_visit_match_cast_;

--- a/include/tvm/relax/ir_functor.h
+++ b/include/tvm/relax/ir_functor.h
@@ -84,6 +84,9 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
   virtual R VisitNode_(const relax::SeqExprNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::FunctionNode* op, Args... args) IR_FUNCTOR_DEFAULT;
   virtual R VisitNode_(const relax::ExternFuncNode* op, Args... args) IR_FUNCTOR_DEFAULT;
+  virtual R VisitNode_(const relax::PrimValueNode* op, Args... args) IR_FUNCTOR_DEFAULT;
+  virtual R VisitNode_(const relax::StringImmNode* op, Args... args) IR_FUNCTOR_DEFAULT;
+  virtual R VisitNode_(const relax::DataTypeImmNode* op, Args... args) IR_FUNCTOR_DEFAULT;
 
   virtual R VisitNodeDefault_(const Object* op, Args...) {
     LOG(FATAL) << "no default visitor implemented for " << op->GetTypeKey();
@@ -110,6 +113,9 @@ class IRFunctor<R(const ObjectRef& n, Args...)> {
     RELAX_IR_FUNCTOR_DISPATCH(relax::SeqExprNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::FunctionNode);
     RELAX_IR_FUNCTOR_DISPATCH(relax::ExternFuncNode);
+    RELAX_IR_FUNCTOR_DISPATCH(relax::PrimValueNode);
+    RELAX_IR_FUNCTOR_DISPATCH(relax::StringImmNode);
+    RELAX_IR_FUNCTOR_DISPATCH(relax::DataTypeImmNode);
     return vtable;
   }
 };

--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -124,9 +124,11 @@ TVM_DLL bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank = true,
                               bool permit_unknown_dtype = true);
 
 /*!
- * \brief Check if the given expression is a "leaf" node for normalization purposes.
+ * \brief Check if the given expression is a "leaf" node or tuple node for normalization purposes.
+ *
  *    The following expressions are defined as leaf nodes: Var, Constant, ShapeExpr,
- *    GlobalVar, Op, ExternFunc, and Tuple.
+ *    GlobalVar, Op, ExternFunc.
+ *
  *    Tuples are included in this list mainly for convenience in grouping operator arguments.
  *    *Note*: Since tuples can contain nested expressions, it is necessary to ensure that
  *    values nested inside them are also leaves.
@@ -136,7 +138,7 @@ TVM_DLL bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank = true,
  * \return True iff the input expression is a "leaf" node (a value allowed to appear
  *    inline without being bound to a var during normalization).
  */
-TVM_DLL bool IsLeafExpr(const Expr& expr);
+TVM_DLL bool IsLeafOrTuple(const Expr& expr);
 
 }  // namespace relax
 }  // namespace tvm

--- a/python/tvm/ir/expr.py
+++ b/python/tvm/ir/expr.py
@@ -198,6 +198,9 @@ def is_relax_expr(expr: RelayExpr) -> bool:
             relax.SeqExpr,
             relax.Function,
             relax.ExternFunc,
+            relax.PrimValue,
+            relax.StringImm,
+            relax.DataTypeImm,
         ),
     ):
         return True

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -51,6 +51,9 @@ from .expr import (
     Call,
     If,
     Constant,
+    PrimValue,
+    DataTypeImm,
+    StringImm,
 )
 
 from .expr import const, extern, get_shape_of

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -423,6 +423,36 @@ class DataflowVar(Var):
         )
 
 
+@tvm._ffi.register_object("relax.expr.PrimValue")
+class PrimValue(Expr):
+    """The prim expr representing the value."""
+
+    value: PrimExpr
+
+    def __init__(self, value: PrimExpr, span: Span = None) -> None:
+        self.__init_handle_by_constructor__(_ffi_api.PrimValue, value, span)  # type: ignore
+
+
+@tvm._ffi.register_object("relax.expr.StringImm")
+class StringImm(Expr):
+    """Represent a string literal constant."""
+
+    value: str
+
+    def __init__(self, value: str, span: Span = None) -> None:
+        self.__init_handle_by_constructor__(_ffi_api.StringImm, value, span)  # type: ignore
+
+
+@tvm._ffi.register_object("relax.expr.DataTypeImm")
+class DataTypeImm(Expr):
+    """Represent a data type constant."""
+
+    value: DataType
+
+    def __init__(self, value: Union[DataType, str], span: Span = None) -> None:
+        self.__init_handle_by_constructor__(_ffi_api.DataTypeImm, value, span)  # type: ignore
+
+
 @tvm._ffi.register_object("relax.expr.Binding")
 class Binding(Node):
     """The base class of a binding in Relax."""

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -22,9 +22,18 @@ import inspect
 from typing import Dict, List, Optional, Tuple, Union
 
 import tvm
-from tvm import relax
-from tvm.ir import Type
-from tvm.relax import Call, Expr, ExternFunc, TupleGetItem, Var, const
+
+from tvm import relax, DataType
+from tvm.ir import Type, PrimExpr
+from tvm.relax import (
+    Call,
+    Expr,
+    ExternFunc,
+    TupleGetItem,
+    Var,
+    const,
+)
+
 from tvm.relax.analysis import get_static_type
 
 ############################### Operators ###############################
@@ -103,6 +112,7 @@ from . import _ffi_api, frame
 
 py_print = print
 py_tuple = tuple
+py_str = str
 
 
 ############################### Function ################################
@@ -385,6 +395,51 @@ def tuple(*fields: List[Expr]) -> Expr:
     return relax.Tuple(fields)  # pylint: disable=no-member # type: ignore
 
 
+############################### PrimValue ##############################
+
+
+def prim_value(value: PrimExpr) -> Expr:
+    """Create a prim value expression.
+    Parameters
+    ----------
+    value : PrimExpr
+        The value of the prim value.
+    Returns
+    -------
+    res : Expr
+        The result prim value.
+    """
+    return relax.PrimValue(value)  # pylint: disable=no-member # type: ignore
+
+
+def str(value: py_str) -> Expr:
+    """Create a string imm expression.
+    Parameters
+    ----------
+    value : str
+        The value of the str.
+    Returns
+    -------
+    res : Expr
+        The result str.
+    """
+    return relax.StringImm(value)  # pylint: disable=no-member # type: ignore
+
+
+def dtype(value: Union[py_str, DataType]) -> Expr:
+    """Create a dtype imm expression.
+    Parameters
+    ----------
+    value : dtype
+        The value of the dtype.
+    Returns
+    -------
+    res : Expr
+        The result dtype.
+    """
+    return relax.DataTypeImm(value)  # pylint: disable=no-member # type: ignore
+
+
 ############################### Importer ###############################
 
 __all__ = [
@@ -406,6 +461,7 @@ __all__ = [
     "const",
     "dataflow",
     "divide",
+    "dtype",
     "emit",
     "emit_match_cast",
     "equal",
@@ -443,6 +499,7 @@ __all__ = [
     "ones_like",
     "output",
     "permute_dims",
+    "prim_value",
     "print",
     "prod",
     "reshape",
@@ -453,6 +510,7 @@ __all__ = [
     "sqrt",
     "squeeze",
     "std",
+    "str",
     "strided_slice",
     "subtract",
     "sum",

--- a/python/tvm/script/parser/relax/__init__.py
+++ b/python/tvm/script/parser/relax/__init__.py
@@ -18,11 +18,12 @@
 from ...ir_builder.relax import *  # pylint: disable=redefined-builtin
 from ...ir_builder.relax import ir as _relax
 from . import parser as _parser
-from .entry import Callable, Object, Shape, Tensor, Tuple, function, match_cast
+from .entry import Callable, Object, Prim, Shape, Tensor, Tuple, function, match_cast
 
 __all__ = _relax.__all__ + [
     "Callable",
     "Object",
+    "Prim",
     "Shape",
     "Tensor",
     "Tuple",

--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -25,6 +25,7 @@ from tvm.relax import (
     FuncStructInfo,
     Function,
     ObjectStructInfo,
+    PrimStructInfo,
     ShapeStructInfo,
     StructInfo,
     TensorStructInfo,
@@ -279,6 +280,33 @@ class ObjectProxy(StructInfoProxy):
 
 def Object() -> ObjectProxy:
     return ObjectProxy()
+
+
+################################ R.Prim ################################
+
+
+class PrimProxy(StructInfoProxy):
+    dtype: str
+    """The type of shape values.
+
+    Parameters
+    ----------
+    dtype : str
+       The data type.
+    """
+
+    def __init__(self, dtype: str) -> None:
+        self.dtype = dtype
+
+    def get_symbolic_vars(self) -> Set[str]:
+        return set()
+
+    def as_struct_info(self, dict_globals: Optional[Dict[str, Any]] = None) -> ShapeStructInfo:
+        return PrimStructInfo(self.dtype)
+
+
+def Prim(dtype: str) -> PrimProxy:
+    return PrimProxy(dtype)
 
 
 ############################ R.match_cast #############################

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -361,6 +361,18 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::ExternFuncNode* op) {
   return Doc::StrLiteral(op->global_symbol);
 }
 
+Doc RelaxScriptPrinter::VisitNode_(const relax::PrimValueNode* op) {
+  return Doc::Text("R.prim_value(") << Print(op->value) << ")";
+}
+
+Doc RelaxScriptPrinter::VisitNode_(const relax::StringImmNode* op) {
+  return Doc::Text("R.str(") << Print(op->value) << ")";
+}
+
+Doc RelaxScriptPrinter::VisitNode_(const relax::DataTypeImmNode* op) {
+  return Doc::Text("R.dtype(") << PrintDType(op->value) << ")";
+}
+
 Doc RelaxScriptPrinter::PrintPrimExpr(const PrimExpr& expr) {
   Doc body = VisitExpr(expr);
   if (print_symbolic_shape_as_str_ && !expr->IsInstance<IntImmNode>()) {
@@ -655,9 +667,7 @@ Doc RelaxScriptPrinter::VisitStructInfo_(const ObjectStructInfoNode* op) {
 }
 
 Doc RelaxScriptPrinter::VisitStructInfo_(const PrimStructInfoNode* op) {
-  // TODO(@relax-team): support PrimStructInfo printing and parsing
-  LOG(FATAL) << "Not allowed to print PrimStructInfo for now.";
-  return Doc::Text("");
+  return Doc::Text("R.Prim(") << PrintDType(op->dtype) << ")";
 }
 
 Doc RelaxScriptPrinter::VisitStructInfo_(const ShapeStructInfoNode* op) {

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -283,6 +283,9 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
   Doc VisitNode_(const relax::SeqExprNode* op) override;
   Doc VisitNode_(const relax::FunctionNode* op) override;
   Doc VisitNode_(const relax::ExternFuncNode* op) override;
+  Doc VisitNode_(const relax::PrimValueNode* op) override;
+  Doc VisitNode_(const relax::StringImmNode* op) override;
+  Doc VisitNode_(const relax::DataTypeImmNode* op) override;
 
   // PrimExpr nodes allowed in Relax
   Doc VisitExpr_(const tir::VarNode* op) override;

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -153,7 +153,7 @@ class WellFormedChecker : public relax::ExprVisitor,
   void VisitExpr_(const TupleNode* op) final {
     for (size_t i = 0; i < op->fields.size(); i++) {
       Expr expr = op->fields[i];
-      if (IsLeafExpr(expr)) {
+      if (IsLeafOrTuple(expr)) {
         this->VisitExpr(expr);
       } else {
         Malformed(Diagnostic::Error(expr)
@@ -165,7 +165,7 @@ class WellFormedChecker : public relax::ExprVisitor,
   }
 
   void VisitExpr_(const TupleGetItemNode* op) final {
-    if (IsLeafExpr(op->tuple)) {
+    if (IsLeafOrTuple(op->tuple)) {
       this->VisitExpr(op->tuple);
     } else {
       Malformed(Diagnostic::Error(op)
@@ -225,14 +225,14 @@ class WellFormedChecker : public relax::ExprVisitor,
   }
 
   void VisitExpr_(const CallNode* op) final {
-    if (IsLeafExpr(op->op)) {
+    if (IsLeafOrTuple(op->op)) {
       this->VisitExpr(op->op);
     } else {
       Malformed(Diagnostic::Error(op) << "The called expression must be a leaf expression");
     }
     for (size_t i = 0; i < op->args.size(); i++) {
       Expr arg = op->args[i];
-      if (IsLeafExpr(arg)) {
+      if (IsLeafOrTuple(arg)) {
         this->VisitExpr(arg);
       } else {
         Malformed(Diagnostic::Error(arg->span)
@@ -244,7 +244,7 @@ class WellFormedChecker : public relax::ExprVisitor,
   }
 
   void VisitExpr_(const IfNode* op) final {
-    if (IsLeafExpr(op->cond)) {
+    if (IsLeafOrTuple(op->cond)) {
       this->VisitExpr(op->cond);
     } else {
       Malformed(Diagnostic::Error(op) << "The condition for an if node must be a leaf expression.");
@@ -290,7 +290,7 @@ class WellFormedChecker : public relax::ExprVisitor,
     for (BindingBlock block : op->blocks) {
       this->VisitBindingBlock(block);
     }
-    if (!IsLeafExpr(op->body)) {
+    if (!IsLeafOrTuple(op->body)) {
       Malformed(Diagnostic::Error(op) << "SeqExpr bodies must be leaf expressions.");
     }
     this->VisitExpr(op->body);

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -245,6 +245,24 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     return builder_->ConvertConstant(ShapeTuple(shape));
   }
 
+  Instruction::Arg VisitExpr_(const PrimValueNode* op) final {
+    if (auto* int_imm = op->value.as<IntImmNode>()) {
+      return builder_->ConvertConstant(int_imm->value);
+    } else {
+      auto* float_imm = op->value.as<FloatImmNode>();
+      ICHECK(float_imm) << "PrimValue can only be IntImm/FloatImm for now";
+      return builder_->ConvertConstant(float_imm->value);
+    }
+  }
+
+  Instruction::Arg VisitExpr_(const StringImmNode* op) final {
+    return builder_->ConvertConstant(op->value);
+  }
+
+  Instruction::Arg VisitExpr_(const DataTypeImmNode* op) final {
+    return builder_->ConvertConstant(op->value);
+  }
+
   Instruction::Arg VisitExpr_(const TupleNode* op) final {
     Tuple tuple = GetRef<Tuple>(op);
     std::vector<Instruction::Arg> args;

--- a/src/relax/backend/vm/codegen_vm_tir.cc
+++ b/src/relax/backend/vm/codegen_vm_tir.cc
@@ -36,6 +36,7 @@
 #include <tvm/tir/function.h>
 #include <tvm/tir/stmt.h>
 
+#include <cctype>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -290,6 +291,16 @@ class CodeGenVMTIR : public ExprFunctor<Optional<PrimExpr>(const Expr&)> {
       }
     }
     return ConstListGet(builder_->ConvertConstant(ShapeTuple(shape)).value());
+  }
+
+  Optional<PrimExpr> VisitExpr_(const PrimValueNode* op) final { return op->value; }
+
+  Optional<PrimExpr> VisitExpr_(const StringImmNode* op) final {
+    return ConstListGet(builder_->ConvertConstant(op->value).value());
+  }
+
+  Optional<PrimExpr> VisitExpr_(const DataTypeImmNode* op) final {
+    return ConstListGet(builder_->ConvertConstant(op->value).value());
   }
 
   Optional<PrimExpr> VisitExpr_(const TupleNode* op) final {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -487,7 +487,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
     // skip visit expr's cache, normalize arg
     Expr post = ExprFunctor::VisitExpr(arg);
 
-    if (!IsLeafExpr(arg)) {
+    if (!IsLeafOrTuple(arg)) {
       ICHECK(!block_stack_.empty()) << "Cannot normalize non-leaf without a scope";
       Var var = this->Emit(post, "");
       // NOTE: current frame addr can change due to underlying vector
@@ -504,6 +504,9 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
   RELAX_EXPR_NORMALIZER_LEAF(OpNode);
   RELAX_EXPR_NORMALIZER_LEAF(ConstantNode);
   RELAX_EXPR_NORMALIZER_LEAF(ShapeExprNode);
+  RELAX_EXPR_NORMALIZER_LEAF(PrimValueNode);
+  RELAX_EXPR_NORMALIZER_LEAF(StringImmNode);
+  RELAX_EXPR_NORMALIZER_LEAF(DataTypeImmNode);
 
   template <typename T>
   Expr VisitVar_(const typename T::ContainerType* var) {

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -322,6 +322,53 @@ TVM_REGISTER_GLOBAL("relax.Constant").set_body_typed([](runtime::NDArray data, S
   return Constant(data, span);
 });
 
+PrimValue::PrimValue(PrimExpr value, Span span) {
+  ObjectPtr<PrimValueNode> n = make_object<PrimValueNode>();
+  n->checked_type_ = PrimType(value.dtype());
+  n->struct_info_ = PrimStructInfo(value.dtype());
+  n->value = std::move(value);
+  n->span = std::move(span);
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(PrimValueNode);
+
+TVM_REGISTER_GLOBAL("relax.PrimValue").set_body_typed([](PrimExpr value, Span span) {
+  return PrimValue(value, span);
+});
+
+StringImm::StringImm(String value, Span span) {
+  ObjectPtr<StringImmNode> n = make_object<StringImmNode>();
+  n->value = std::move(value);
+  n->span = std::move(span);
+  // use the base structinfo for now
+  n->checked_type_ = ObjectType();
+  n->struct_info_ = ObjectStructInfo();
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(StringImmNode);
+
+TVM_REGISTER_GLOBAL("relax.StringImm").set_body_typed([](String value, Span span) {
+  return StringImm(value, span);
+});
+
+DataTypeImm::DataTypeImm(DataType value, Span span) {
+  ObjectPtr<DataTypeImmNode> n = make_object<DataTypeImmNode>();
+  n->value = std::move(value);
+  n->span = std::move(span);
+  // use the base structinfo for now
+  n->checked_type_ = ObjectType();
+  n->struct_info_ = ObjectStructInfo();
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(DataTypeImmNode);
+
+TVM_REGISTER_GLOBAL("relax.DataTypeImm").set_body_typed([](DataType value, Span span) {
+  return DataTypeImm(value, span);
+});
+
 TVM_REGISTER_NODE_TYPE(MatchCastNode);
 
 MatchCast::MatchCast(Var var, Expr value, StructInfo struct_info, Span span) {

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -342,6 +342,7 @@ StringImm::StringImm(String value, Span span) {
   n->value = std::move(value);
   n->span = std::move(span);
   // use the base structinfo for now
+  // we can choose to introduce more fine-grained struct info later if necessary.
   n->checked_type_ = ObjectType();
   n->struct_info_ = ObjectStructInfo();
   data_ = std::move(n);
@@ -358,6 +359,7 @@ DataTypeImm::DataTypeImm(DataType value, Span span) {
   n->value = std::move(value);
   n->span = std::move(span);
   // use the base structinfo for now
+  // we can choose to introduce more fine-grained struct info later if necessary.
   n->checked_type_ = ObjectType();
   n->struct_info_ = ObjectStructInfo();
   data_ = std::move(n);

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -77,11 +77,9 @@ bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank, bool permit_unkn
   return correct_dtype && correct_rank;
 }
 
-bool IsLeafExpr(const Expr& expr) {
-  // NB: tuples are treated as leaf nodes for ergonomics
-  return expr.as<VarNode>() || expr.as<GlobalVarNode>() || expr.as<ConstantNode>() ||
-         expr.as<ShapeExprNode>() || expr.as<ExternFuncNode>() || expr.as<OpNode>() ||
-         expr.as<TupleNode>();
+bool IsLeafOrTuple(const Expr& expr) {
+  return expr.as<LeafExprNode>() || expr.as<GlobalVarNode>() || expr.as<ExternFuncNode>() ||
+         expr.as<OpNode>() || expr.as<TupleNode>();
 }
 
 }  // namespace relax

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -435,7 +435,11 @@ int TVMBackendAnyListMoveFromPackedReturn(void* anylist, int index, TVMValue* ar
   using namespace tvm::runtime;
   API_BEGIN();
   auto* list = static_cast<TVMRetValue*>(anylist);
-  list[index] = TVMRetValue::MoveFromCHost(args[ret_offset], type_codes[ret_offset]);
+  if (type_codes[ret_offset] == kTVMStr || type_codes[ret_offset] == kTVMBytes) {
+    list[index] = TVMArgValue(args[ret_offset], type_codes[ret_offset]);
+  } else {
+    list[index] = TVMRetValue::MoveFromCHost(args[ret_offset], type_codes[ret_offset]);
+  }
   API_END();
 }
 }  // extern "C"

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -236,5 +236,28 @@ def test_shape_expr():
         rx.ShapeExpr([m, 3])
 
 
+def test_prim_value():
+    pv = rx.PrimValue(tir.IntImm("int64", 1))
+    assert pv.value.value == 1
+    _check_equal(pv, rx.PrimValue(tir.IntImm("int64", 1)))
+    _check_json_roundtrip(pv)
+
+
+def test_string_imm():
+    s0 = rx.StringImm("hello")
+    s1 = rx.StringImm("hello")
+    assert s0.value == "hello"
+    _check_equal(s0, s1)
+    _check_json_roundtrip(s0)
+
+
+def test_datatype_imm():
+    d0 = rx.DataTypeImm("int32")
+    d1 = rx.DataTypeImm("int32")
+    assert d0.value == "int32"
+    _check_equal(d0, d1)
+    _check_json_roundtrip(d0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_expr_functor.py
+++ b/tests/python/relax/test_expr_functor.py
@@ -35,6 +35,9 @@ from tvm.relax.expr import (
     ShapeExpr,
     Tuple,
     TupleGetItem,
+    PrimValue,
+    StringImm,
+    DataTypeImm,
     Var,
     VarBinding,
 )
@@ -133,6 +136,15 @@ class ASTPrinter(PyExprVisitor):
         self.log.push_scope()
         self.visit_expr(op.tuple_value)
         self.log.pop_scope()
+
+    def visit_prim_value_(self, op: PrimValue) -> None:
+        self.log.add("PrimValue")
+
+    def visit_string_imm_(self, op: StringImm) -> None:
+        self.log.add("StringImm")
+
+    def visit_data_type_imm_(self, op: DataTypeImm) -> None:
+        self.log.add("DataTypeImm")
 
     def visit_shape_expr_(self, op: ShapeExpr) -> None:
         self.log.add("ShapeExpr")
@@ -244,6 +256,21 @@ class ASTPostPrinterMutator(PyExprMutator):
     def visit_tuple_getitem_(self, op: TupleGetItem) -> Expr:
         op = self.visit_expr_post_order(op)
         self.log.add("TupleGetItem")
+        return op
+
+    def visit_prim_value_(self, op: PrimValue) -> Expr:
+        op = self.visit_expr_post_order(op)
+        self.log.add("PrimValue")
+        return op
+
+    def visit_string_imm_(self, op: StringImm) -> Expr:
+        op = self.visit_expr_post_order(op)
+        self.log.add("StringImm")
+        return op
+
+    def visit_data_type_imm_(self, op: DataTypeImm) -> Expr:
+        op = self.visit_expr_post_order(op)
+        self.log.add("DataTypeImm")
         return op
 
     def visit_shape_expr_(self, op: ShapeExpr) -> Expr:

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -965,7 +965,6 @@ def test_datatype_imm():
         gv = R.call_packed("test", R.dtype("float32"), type_args=R.Tensor((32, 32), "float32"))
         return gv
 
-
     _check(foo, None)
 
 

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -940,6 +940,32 @@ def test_vm_ops():
         gv = tensor
         return alloc, gv
 
+
+def test_prim_value():
+    @R.function
+    def foo():
+        gv = R.call_packed("test", R.prim_value(1), type_args=R.Tensor((32, 32), "float32"))
+        return gv
+
+    _check(foo, None)
+
+
+def test_string_imm():
+    @R.function
+    def foo():
+        gv = R.call_packed("test", R.str("hello"), type_args=R.Tensor((32, 32), "float32"))
+        return gv
+
+    _check(foo, None)
+
+
+def test_datatype_imm():
+    @R.function
+    def foo():
+        gv = R.call_packed("test", R.dtype("float32"), type_args=R.Tensor((32, 32), "float32"))
+        return gv
+
+
     _check(foo, None)
 
 


### PR DESCRIPTION
This PR introduces PrimValue, StringImm and DataTypeImm.

These constructs are only used in low-level builtin functions for now. They will enable us to effectively represent POD, string and dtype arguments to builtin functions.

Followup PRs can be introduced to move some of the BuiltinAttrs to directly using these values. We can also simplify the handling of unique and print.

Co-Authored-by: Siyuan Feng <Hzfengsy@sjtu.edu.cn>