### PR TITLE
[TVMScript] Fix py_print direction in IR builder

### DIFF
--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -17,6 +17,7 @@
 # pylint: disable=redefined-builtin, wrong-import-order, no-member, invalid-name
 """IRBuilder for Relax dialect"""
 
+import builtins
 import functools
 import inspect
 from typing import Dict, List, Optional, Tuple, Union
@@ -110,7 +111,7 @@ from . import _ffi_api, frame
 
 ##################### Python Native Function Alias ######################
 
-py_print = print
+py_print = builtins.print
 py_tuple = tuple
 py_str = str
 

--- a/tests/python/relax/test_tvmscript_ir_builder.py
+++ b/tests/python/relax/test_tvmscript_ir_builder.py
@@ -130,5 +130,12 @@ def test_dataflow_block():
     tvm.ir.assert_structural_equal(func, bb.get()["foo"])
 
 
+def test_regression_py_print():
+    # Test that the py_print directs to python builtin print
+    from tvm.script.ir_builder.relax.ir import py_print  # pylint: disable=import-outside-toplevel
+
+    assert py_print == print
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Prior to this PR, in `ir.py` of IR builder, the `py_print` directs to the operator `print` instead of Python builtin print.

This PR fixes this issue, with a regression test in `tests/python/relax/test_tvmscript_ir_builder.py`.

cc @Hzfengsy 