### PR TITLE
[Refacror][AST] `sinfo_args` A0: Introduce `sinfo_args`

### DIFF
--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -48,6 +48,11 @@ def get_static_type(sinfo: StructInfo) -> Type:
     return _ffi_api.GetStaticType(sinfo)  # type: ignore
 
 
+# Todo(ruihang): introduced to make call_packed work. To be removed in the followup PR.
+def struct_info_from_type(ty: Type):  # pylint: disable=invalid-name
+    return _ffi_api.StructInfoFromType(ty)  # type: ignore
+
+
 def erase_to_well_defined(
     sinfo: StructInfo,
     shape_var_map: Dict[tir.Var, tir.PrimExpr] = None,

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -232,9 +232,11 @@ class Call(ExprWithOp):
     attrs: Optional[tvm.ir.Attrs]
         Attributes to the call, can be None
 
-    type_args: Optional[Union[List[Type], typing.Tuple[Type, ...]]]
-        The additional type arguments, this is only
-        used in advanced usecase of template functions.
+    sinfo_args: Optional[Union[List[StructInfo], typing.Tuple[StructInfo, ...]]]
+        The structure info arguments of a CallNode.
+        sinfo_args is designed to be non-empty only for intrinsic op (e.g.,
+        call_tir, call_builtin, etc.) and calls to ExternFuncs, with the main
+        usage of structure info inference.
 
     span: Optional[Span]
         Span that points to original source code
@@ -245,13 +247,13 @@ class Call(ExprWithOp):
         op: Union[Expr, tvm.ir.Op],
         args: Union[List[Expr], typing.Tuple[Expr, ...]],
         attrs: Optional[tvm.ir.Attrs] = None,
-        type_args: Optional[Union[List[Type], typing.Tuple[Type, ...]]] = None,
+        sinfo_args: Optional[Union[List[StructInfo], typing.Tuple[StructInfo, ...]]] = None,
         span: Optional[Span] = None,
     ):
-        if not type_args:
-            type_args = []
+        if not sinfo_args:
+            sinfo_args = []
         self.__init_handle_by_constructor__(
-            _ffi_api.Call, op, args, attrs, type_args, span  # type: ignore
+            _ffi_api.Call, op, args, attrs, sinfo_args, span  # type: ignore
         )
 
 

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -164,8 +164,8 @@ class ASTPrinter(ExprFunctor):
             "op": self.visit_expr(op.op),
             "args": self.build_list(map(self.visit_expr, op.args)),
         }
-        if op.type_args:
-            fields["type_args"] = self.build_list(map(self.visit_type_, op.type_args))
+        if op.sinfo_args:
+            fields["sinfo_args"] = self.build_list(map(self.visit_struct_info_, op.sinfo_args))
         if op.attrs and self.include_call_attrs:
 
             def display_attrs(attr_key):

--- a/src/relax/analysis/analysis.cc
+++ b/src/relax/analysis/analysis.cc
@@ -115,8 +115,8 @@ class VarVisitor : protected ExprVisitor {
     VisitSpan(call_node->span);
     VisitExpr(call_node->op);
 
-    for (Type ty_arg : call_node->type_args) {
-      VisitType(ty_arg);
+    for (StructInfo sinfo_arg : call_node->sinfo_args) {
+      VisitExprDepStructInfoField(sinfo_arg);
     }
 
     for (Expr arg : call_node->args) {

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -101,6 +101,11 @@ StructInfo StructInfoFromType(const Type& type) {
   }
 }
 
+// Todo(ruihang): introduced to make call_packed work. To be removed in the followup PR.
+TVM_REGISTER_GLOBAL("relax.analysis.StructInfoFromType").set_body_typed([](const Type& type) {
+  return StructInfoFromType(type);
+});
+
 //--------------------------
 // EraseToWellDefined
 //--------------------------

--- a/src/relax/backend/vm/vm_builtin_lower.cc
+++ b/src/relax/backend/vm/vm_builtin_lower.cc
@@ -76,7 +76,7 @@ class VMBuiltinLowerMutator : public ExprMutator {
       auto attrs = DefaultBuiltinAttrs();
       attrs->dtype_arg = dtype;
       return Call(call_builtin_op_, {builtin_compute_alloc_shape_, Tuple({shape})}, Attrs(attrs),
-                  {GetStaticType(GetStructInfo(shape))});
+                  {StructInfoFromType(GetStaticType(GetStructInfo(shape)))});
     }
   }
 
@@ -129,7 +129,7 @@ class VMBuiltinLowerMutator : public ExprMutator {
     auto attrs = DefaultBuiltinAttrs();
 
     return Call(call_builtin_op_, {builtin_make_closure_, Tuple(args)}, Attrs(attrs),
-                {object_type_});
+                {object_sinfo_});
   }
 
   Expr InvokeClosure(const Call& call_node) {
@@ -149,11 +149,11 @@ class VMBuiltinLowerMutator : public ExprMutator {
     auto attrs = DefaultBuiltinAttrs();
     attrs->require_ctx = true;
     return Call(call_builtin_op_, {builtin_invoke_closure_, Tuple(args)}, Attrs(attrs),
-                {object_type_});
+                {object_sinfo_});
   }
 
   const Op& call_builtin_op_ = Op::Get("relax.call_builtin");
-  const Type object_type_ = ObjectType();
+  const StructInfo object_sinfo_ = ObjectStructInfo();
   // object to pattern match.
   const Op& call_tir_dyn_op_ = Op::Get("relax.vm.call_tir_dyn");
   const Op& make_closure_op_ = Op::Get("relax.make_closure");

--- a/src/relax/backend/vm/vm_builtin_lower.cc
+++ b/src/relax/backend/vm/vm_builtin_lower.cc
@@ -75,6 +75,7 @@ class VMBuiltinLowerMutator : public ExprMutator {
     } else {
       auto attrs = DefaultBuiltinAttrs();
       attrs->dtype_arg = dtype;
+      // Todo(ruihang): reorganize in the followup PR
       return Call(call_builtin_op_, {builtin_compute_alloc_shape_, Tuple({shape})}, Attrs(attrs),
                   {StructInfoFromType(GetStaticType(GetStructInfo(shape)))});
     }

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -358,7 +358,7 @@ class VMShapeLowerMutator
       n->str_args = NullValue<Array<String>>();
       n->require_ctx = true;
       Call call(call_builtin_op_, {builtin_alloc_shape_heap_, Tuple(Array<Expr>())}, Attrs(n),
-                {GetStaticType(heap_sinfo)});
+                {StructInfoFromType(GetStaticType(heap_sinfo))});
       UpdateStructInfo(call, heap_sinfo);
       return VarBinding(var, call);
     } else {
@@ -404,7 +404,7 @@ class VMShapeLowerMutator
 
     // make_shape(heap, n, c[0], r[0], c[1], r[1] ..., c[n], r[n])
     Call call(call_builtin_op_, {builtin_make_shape_, Tuple({shape_heap_})}, ExtraIntArgs(int_args),
-              {ShapeType(static_cast<int>(op->values.size()))});
+              {StructInfoFromType(ShapeType(static_cast<int>(op->values.size())))});
     return call;
   }
 
@@ -673,7 +673,7 @@ class VMShapeLowerMutator
     } else {
       // call runtime tuple get item, and return a object.
       Call call(call_builtin_op_, {builtin_tuple_getitem_, Tuple({value})}, ExtraIntArgs({index}),
-                {object_type_});
+                {object_sinfo_});
       UpdateStructInfo(call, ObjectStructInfo());
       return call;
     }
@@ -730,8 +730,8 @@ class VMShapeLowerMutator
   // call builtin cop
   const Op& call_builtin_op_ = Op::Get("relax.call_builtin");
   const Op& null_value_op_ = Op::Get("relax.null_value");
-  // common types
-  const Type object_type_ = ObjectType();
+  // common struct info
+  const StructInfo object_sinfo_ = ObjectStructInfo();
   // check function
   const ExternFunc builtin_alloc_shape_heap_{"vm.builtin.alloc_shape_heap"};
   const ExternFunc builtin_match_shape_{"vm.builtin.match_shape"};

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -357,6 +357,7 @@ class VMShapeLowerMutator
       n->dtype_arg = DataType::Void();
       n->str_args = NullValue<Array<String>>();
       n->require_ctx = true;
+      // Todo(ruihang): reorganize in the followup PR
       Call call(call_builtin_op_, {builtin_alloc_shape_heap_, Tuple(Array<Expr>())}, Attrs(n),
                 {StructInfoFromType(GetStaticType(heap_sinfo))});
       UpdateStructInfo(call, heap_sinfo);
@@ -404,7 +405,7 @@ class VMShapeLowerMutator
 
     // make_shape(heap, n, c[0], r[0], c[1], r[1] ..., c[n], r[n])
     Call call(call_builtin_op_, {builtin_make_shape_, Tuple({shape_heap_})}, ExtraIntArgs(int_args),
-              {StructInfoFromType(ShapeType(static_cast<int>(op->values.size())))});
+              {ShapeStructInfo(static_cast<int>(op->values.size()))});
     return call;
   }
 

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -597,7 +597,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
     if (unchanged) {
       call = GetRef<Call>(op);
     } else {
-      call = Call(new_op, new_args, op->attrs, op->type_args);
+      call = Call(new_op, new_args, op->attrs, op->sinfo_args);
     }
 
     if (!call->struct_info_.defined()) {

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -527,6 +527,7 @@ TVM_REGISTER_GLOBAL("relax.FunctionCreateEmpty")
 // TODO(relax-team): revisit sinfo_args related deduction.
 TVM_REGISTER_GLOBAL("tvm.relax.struct_info.infer_by_ty_args")
     .set_body_typed([](const Call& call, const BlockBuilder& ctx) -> StructInfo {
+      // Todo(ruihang): reorganize in the followup PR
       if (call->sinfo_args.defined()) {
         if (call->sinfo_args.size() == 0) {
           return ObjectStructInfo();

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -160,8 +160,8 @@ void ExprVisitor::VisitExpr_(const CallNode* op) {
   this->VisitSpan(op->span);
   this->VisitExpr(op->op);
 
-  for (Type ty_arg : op->type_args) {
-    this->VisitType(ty_arg);
+  for (StructInfo sinfo_arg : op->sinfo_args) {
+    this->VisitExprDepStructInfoField(sinfo_arg);
   }
 
   for (Expr arg : op->args) {
@@ -420,11 +420,11 @@ Expr ExprMutatorBase::VisitExpr_(const CallNode* call_node) {
   Expr new_op = this->VisitExpr(call_node->op);
   bool unchanged = call_node->op.same_as(new_op);
 
-  tvm::Array<Type> ty_args;
-  for (Type ty_arg : call_node->type_args) {
-    Type new_ty_arg = this->VisitType(ty_arg);
-    ty_args.push_back(new_ty_arg);
-    unchanged &= new_ty_arg.same_as(ty_arg);
+  Array<StructInfo> sinfo_args;
+  for (StructInfo sinfo_arg : call_node->sinfo_args) {
+    StructInfo new_sinfo_arg = this->VisitExprDepStructInfoField(sinfo_arg);
+    sinfo_args.push_back(new_sinfo_arg);
+    unchanged &= new_sinfo_arg.same_as(sinfo_arg);
   }
 
   tvm::Array<Expr> call_args;
@@ -437,7 +437,7 @@ Expr ExprMutatorBase::VisitExpr_(const CallNode* call_node) {
   if (unchanged && VisitAndCheckStructInfoFieldUnchanged(call_node->struct_info_)) {
     return GetRef<Expr>(call_node);
   } else {
-    return Call(new_op, call_args, call_node->attrs, ty_args, call_node->span);
+    return Call(new_op, call_args, call_node->attrs, sinfo_args, call_node->span);
   }
 }
 

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -89,6 +89,7 @@ StructInfo CallTIRStructInfoFromShapeType(Expr shape, Type type) {
 }
 
 StructInfo InferStructInfoCallTIR(const Call& call, const BlockBuilder& ctx) {
+  // Todo(ruihang): reorganize in the followup PR
   Expr output_shape = call->args[2];
   if (call->sinfo_args.size() != 1) {
     ctx->ReportFatal(Diagnostic::Error(call)
@@ -110,6 +111,7 @@ RELAY_REGISTER_OP("relax.call_tir")
 
 Expr MakeCallTIR(Expr func, Tuple args, Expr output_shape, Type output_type,
                  Optional<Expr> packed_ints) {
+  // Todo(ruihang): reorganize in the followup PR
   static const Op& op = Op::Get("relax.call_tir");
   Call call;
   if (!packed_ints) {
@@ -126,6 +128,7 @@ TVM_REGISTER_GLOBAL("relax.op.call_tir").set_body_typed(MakeCallTIR);
 
 // call builtin
 StructInfo InferStructInfoCallBuiltin(const Call& call, const BlockBuilder& ctx) {
+  // Todo(ruihang): reorganize in the followup PR
   if (call->sinfo_args.size() == 0) {
     // by default return void.
     return TupleStructInfo(Array<StructInfo>());
@@ -143,6 +146,7 @@ TVM_REGISTER_OP("relax.call_builtin")
 
 Expr MakeCallBuiltin(Expr func, Tuple args, Array<Type> type_args, Array<IntImm> int_args,
                      DataType dtype_arg, Array<String> str_args, bool require_ctx) {
+  // Todo(ruihang): reorganize in the followup PR
   Array<StructInfo> sinfo_args = type_args.Map([](Type type) { return StructInfoFromType(type); });
 
   auto attrs = make_object<BuiltinFuncAttrs>();
@@ -255,6 +259,7 @@ TVM_REGISTER_GLOBAL("relax.op.make_closure").set_body_typed(MakeClosure);
 // invoke_closure
 
 StructInfo InferStructInfoInvokeClosure(const Call& call, const BlockBuilder& ctx) {
+  // Todo(ruihang): reorganize in the followup PR
   if (call->sinfo_args.empty()) {
     return ObjectStructInfo();
   } else if (call->sinfo_args.size() == 1) {
@@ -271,6 +276,7 @@ RELAY_REGISTER_OP("relax.invoke_closure")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoInvokeClosure);
 
 Expr InvokeClosure(Expr closure, Tuple args, Array<Type> type_args) {
+  // Todo(ruihang): reorganize in the followup PR
   Array<StructInfo> sinfo_args = type_args.Map([](Type type) { return StructInfoFromType(type); });
   static const Op& op = Op::Get("relax.invoke_closure");
   return Call(op, {closure, args}, {}, sinfo_args);

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -90,10 +90,11 @@ StructInfo CallTIRStructInfoFromShapeType(Expr shape, Type type) {
 
 StructInfo InferStructInfoCallTIR(const Call& call, const BlockBuilder& ctx) {
   Expr output_shape = call->args[2];
-  if (call->type_args.size() != 1) {
-    ctx->ReportFatal(Diagnostic::Error(call) << "type_args should have exact 1 output type.");
+  if (call->sinfo_args.size() != 1) {
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << "sinfo_args should have exact 1 output struct info.");
   }
-  Type output_type = call->type_args[0];
+  Type output_type = GetStaticType(call->sinfo_args[0]);
   return CallTIRStructInfoFromShapeType(output_shape, output_type);
 }
 
@@ -113,9 +114,10 @@ Expr MakeCallTIR(Expr func, Tuple args, Expr output_shape, Type output_type,
   Call call;
   if (!packed_ints) {
     // don't use additional optional argument
-    call = Call(op, {func, args, output_shape}, {}, {output_type});
+    call = Call(op, {func, args, output_shape}, {}, {StructInfoFromType(output_type)});
   } else {
-    call = Call(op, {func, args, output_shape, packed_ints.value()}, {}, {output_type});
+    call = Call(op, {func, args, output_shape, packed_ints.value()}, {},
+                {StructInfoFromType(output_type)});
   }
   return call;
 }
@@ -124,12 +126,12 @@ TVM_REGISTER_GLOBAL("relax.op.call_tir").set_body_typed(MakeCallTIR);
 
 // call builtin
 StructInfo InferStructInfoCallBuiltin(const Call& call, const BlockBuilder& ctx) {
-  if (call->type_args.size() == 0) {
+  if (call->sinfo_args.size() == 0) {
     // by default return void.
     return TupleStructInfo(Array<StructInfo>());
   } else {
-    ICHECK(call->type_args[0].defined()) << call;
-    return StructInfoFromType(call->type_args[0]);
+    ICHECK(call->sinfo_args[0].defined()) << call;
+    return StructInfoFromType(GetStaticType(call->sinfo_args[0]));
   }
 }
 
@@ -141,6 +143,8 @@ TVM_REGISTER_OP("relax.call_builtin")
 
 Expr MakeCallBuiltin(Expr func, Tuple args, Array<Type> type_args, Array<IntImm> int_args,
                      DataType dtype_arg, Array<String> str_args, bool require_ctx) {
+  Array<StructInfo> sinfo_args = type_args.Map([](Type type) { return StructInfoFromType(type); });
+
   auto attrs = make_object<BuiltinFuncAttrs>();
   attrs->int_args = int_args.Map([](IntImm value) {
     if (value->dtype != DataType::Int(64)) {
@@ -153,7 +157,7 @@ Expr MakeCallBuiltin(Expr func, Tuple args, Array<Type> type_args, Array<IntImm>
   attrs->str_args = std::move(str_args);
   attrs->require_ctx = require_ctx;
   static const Op& op = Op::Get("relax.call_builtin");
-  return Call(op, {func, args}, Attrs(attrs), type_args);
+  return Call(op, {func, args}, Attrs(attrs), sinfo_args);
 }
 
 TVM_REGISTER_GLOBAL("relax.op.call_builtin").set_body_typed(MakeCallBuiltin);
@@ -251,12 +255,12 @@ TVM_REGISTER_GLOBAL("relax.op.make_closure").set_body_typed(MakeClosure);
 // invoke_closure
 
 StructInfo InferStructInfoInvokeClosure(const Call& call, const BlockBuilder& ctx) {
-  if (call->type_args.empty()) {
+  if (call->sinfo_args.empty()) {
     return ObjectStructInfo();
-  } else if (call->type_args.size() == 1) {
-    return StructInfoFromType(call->type_args[0]);
+  } else if (call->sinfo_args.size() == 1) {
+    return StructInfoFromType(GetStaticType(call->sinfo_args[0]));
   } else {
-    return StructInfoFromType(TupleType(call->type_args));
+    return StructInfoFromType(GetStaticType(TupleStructInfo(call->sinfo_args)));
   }
 }
 
@@ -267,8 +271,9 @@ RELAY_REGISTER_OP("relax.invoke_closure")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoInvokeClosure);
 
 Expr InvokeClosure(Expr closure, Tuple args, Array<Type> type_args) {
+  Array<StructInfo> sinfo_args = type_args.Map([](Type type) { return StructInfoFromType(type); });
   static const Op& op = Op::Get("relax.invoke_closure");
-  return Call(op, {closure, args}, {}, type_args);
+  return Call(op, {closure, args}, {}, sinfo_args);
 }
 
 TVM_REGISTER_GLOBAL("relax.op.invoke_closure").set_body_typed(InvokeClosure);

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -151,7 +151,7 @@ class ConstantFolder : public ExprMutator {
     Optional<Array<runtime::NDArray>> arr_args =
         MatchConstArrayArgs(call->args[1].as<TupleNode>()->fields);
     Optional<runtime::ShapeTuple> shape = MatchConstShape(call->args[2]);
-    bool output_not_tuple = call->type_args.size() == 1;
+    bool output_not_tuple = call->sinfo_args.size() == 1;
     // Pattern 0: call constant function, const argument with const shape.
     if (func && arr_args && shape && output_not_tuple) {
       DynTensorType ret_type = Downcast<DynTensorType>(call->checked_type());

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <tvm/relax/analysis.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/struct_info.h>
 #include <tvm/relax/transform.h>
@@ -663,7 +664,8 @@ class TIRFuseMutator : public ExprMutator {
         // Step b. Create call_tir
         Array<Expr> call_args = {fused_tir_gv, Tuple(arg_list),
                                  GetCallTIRShape(GetStructInfo(call))};
-        return Call(call_tir_op_, call_args, call->attrs, {call->checked_type()});
+        return Call(call_tir_op_, call_args, call->attrs,
+                    {StructInfoFromType(call->checked_type())});
       } else {
         // Case 1.2. The callee function is not primitive, nothing to do.
         return call;
@@ -673,7 +675,7 @@ class TIRFuseMutator : public ExprMutator {
       GlobalVar gv = Downcast<GlobalVar>(call->args[0]);
       tir::PrimFunc func = Downcast<tir::PrimFunc>(mod_->Lookup(gv));
       GlobalVar new_gv = this->builder_->AddFunction(func, gv->name_hint);
-      return Call(call->op, {new_gv, call->args[1], call->args[2]}, call->attrs, call->type_args,
+      return Call(call->op, {new_gv, call->args[1], call->args[2]}, call->attrs, call->sinfo_args,
                   call->span);
     } else {
       // Case 3. CallNode in other types. Leave it as it is.

--- a/src/relax/transform/lambda_lift.cc
+++ b/src/relax/transform/lambda_lift.cc
@@ -58,7 +58,7 @@ class LambdaLifter : public ExprMutator {
           clo_arg = this->var_remap_.at(var->vid);
         }
         return Call(invoke_closure_op_, {clo_arg, Tuple(call_node->args)}, {},
-                    {call_node->checked_type_});
+                    {StructInfoFromType(call_node->checked_type_)});
       }
     }
     if (auto global_var_node = call_node->op.as<GlobalVarNode>()) {
@@ -75,9 +75,9 @@ class LambdaLifter : public ExprMutator {
           for (const auto arg : nest_call->args) {
             new_args.push_back(arg);
           }
-          return Call(nest_call->op, new_args, call_node->attrs, call_node->type_args);
+          return Call(nest_call->op, new_args, call_node->attrs, call_node->sinfo_args);
         }
-        return Call(it->second, call->args, call_node->attrs, call_node->type_args);
+        return Call(it->second, call->args, call_node->attrs, call_node->sinfo_args);
       }
     }
     return std::move(call);

--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -86,7 +86,8 @@ class CodeGenRunner : ExprMutator {
         func = (*RemoveFuncAttrFunc)(func, attr::kCodegen);
         builder_->UpdateFunction(gvar, func);
 
-        return Call(call_op, new_args, tvm::Attrs(), {GetStaticType(func->ret_struct_info)});
+        return Call(call_op, new_args, tvm::Attrs(),
+                    {StructInfoFromType(GetStaticType(func->ret_struct_info))});
       }
     }
     Array<Expr> new_args;
@@ -94,7 +95,7 @@ class CodeGenRunner : ExprMutator {
       new_args.push_back(VisitExpr(arg));
     }
 
-    return Call(call_node->op, new_args, call_node->attrs, call_node->type_args, call_node->span);
+    return Call(call_node->op, new_args, call_node->attrs, call_node->sinfo_args, call_node->span);
   }
 
   Expr VisitExpr_(const FunctionNode* func_node) override {

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -362,7 +362,7 @@ def test_call_packed():
         t = R.add(w, z)
         sh: R.Shape = R.shape_of(t)
         o: R.Object = R.call_packed(
-            "contrib.tensor_array_stack", x, y, type_args=R.Object, test_attr=True
+            "contrib.tensor_array_stack", x, y, type_args=R.Object(), test_attr=True
         )
         return o
 
@@ -393,7 +393,7 @@ def test_call_packed():
         {
             "op": 'ExternFunc(global_symbol="contrib.tensor_array_stack")',
             "args": '[Var(name_hint="x"), Var(name_hint="y")]',
-            "type_args": "[ObjectType()]",
+            "sinfo_args": "[ObjectStructInfo()]",
             "attrs": '{"test_attr": 1}',
         },
         extern_call_text,
@@ -459,7 +459,12 @@ def test_call_tir():
                     PrimExpr(value=`n: int64`)
                 ])
             ]""",
-            "type_args": "[DynTensorType(ndim=2, dtype=float32)]",
+            "sinfo_args": """[
+                TensorStructInfo(
+                    dtype=float32,
+                    ndim=2
+                )
+            ]""",
         },
         tir_call_text,
     )

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -87,7 +87,7 @@ def test_annotations():
     assert isinstance(f.ret_struct_info, relax.ObjectStructInfo)
 
     assert isinstance(o._checked_type_, relax.ty.ObjectType)
-    assert len(o_call_packed.type_args) == 1
+    assert len(o_call_packed.sinfo_args) == 1
 
 
 def test_mismatch_cast_dims_and_ndim():
@@ -475,7 +475,7 @@ def test_call_tir():
     call_tir_node = foo.body.blocks[0].bindings[0].value
     assert call_tir_node.attrs is None
     assert_structural_equal(
-        call_tir_node.type_args[0], relax.DynTensorType(ndim=2, dtype="float32")
+        call_tir_node.sinfo_args[0], relax.TensorStructInfo(ndim=2, dtype="float32")
     )
 
 
@@ -552,25 +552,28 @@ def test_call_packed():
     assert z_value.op.global_symbol == "contrib.my_matmul"
     assert "mp" in z_value.attrs and z_value.attrs["mp"] == False
     assert_structural_equal(z_value.args, [x, x])
-    assert len(z_value.type_args) == 1
-    assert_structural_equal(z_value.type_args[0], relax.ty.DynTensorType(2, "float32"))
+    assert len(z_value.sinfo_args) == 1
+    assert_structural_equal(z_value.sinfo_args[0], relax.TensorStructInfo(ndim=2, dtype="float32"))
 
     w_value = w_bind.value
     assert isinstance(w_value.attrs, relay.op.op_attrs.ShapeOfAttrs)
-    assert_structural_equal(w_value.type_args[0], relax.ty.ShapeType())
+    assert_structural_equal(w_value.sinfo_args[0], relax.ShapeStructInfo())
 
     o_value = o_bind.value
-    assert_structural_equal(o_value.type_args[0], relax.ty.ObjectType())
+    assert_structural_equal(o_value.sinfo_args[0], relax.ObjectStructInfo())
 
     k_value = k_bind.value
     assert_structural_equal(
-        k_value.type_args[0],
-        relax.ty.TupleType(
+        k_value.sinfo_args[0],
+        relax.TupleStructInfo(
             [
-                relax.TupleType(
-                    [relax.ty.DynTensorType(2, "float32"), relax.ty.DynTensorType(-1, None)]
+                relax.TupleStructInfo(
+                    [
+                        relax.TensorStructInfo(ndim=2, dtype="float32"),
+                        relax.TensorStructInfo(dtype=""),
+                    ]
                 ),
-                relax.ty.DynTensorType(-1, None),
+                relax.TensorStructInfo(dtype=""),
             ]
         ),
     )

--- a/tests/python/relax/test_pass_manager.py
+++ b/tests/python/relax/test_pass_manager.py
@@ -76,7 +76,7 @@ class SwapMAVar(relax.PyExprMutator):
         else:
             new_op = self.visit_expr(call.op)
 
-        new_call = Call(new_op, call.args, call.attrs, call.type_args, call.span)
+        new_call = Call(new_op, call.args, call.attrs, call.sinfo_args, call.span)
         return self.builder_.normalize(new_call)
 
 

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -469,7 +469,7 @@ def test_call_pretty_print():
     x = relax.Var("x", R.Tensor((32,), "float32"))
 
     extern_func = relax.ExternFunc("my_func")
-    call = relax.Call(extern_func, [x], type_args=[relax.DynTensorType(ndim=1, dtype="float32")])
+    call = relax.Call(extern_func, [x], sinfo_args=[R.Tensor(ndim=1, dtype="float32")])
     assert (
         call.__str__()
         == 'R.call_packed("my_func", x, type_args=(R.Tensor(ndim=1, dtype="float32") ,))'

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -456,7 +456,7 @@ def test_call_packed():
                 relax.ExternFunc("vm.builtin.copy"),
                 (x,),
                 None,
-                type_args=[DynTensorType(2, "float32")],
+                sinfo_args=[R.Tensor("float32", ndim=2)],
             )
         )
         bb.emit_func_output(z)


### PR DESCRIPTION
This PR is the kickoff action of our switch towards `sinfo_args` in CallNode, as discussed in #356 and tracked by #377.
* CallNode field `type_args` is changed to `sinfo_args`, with type `Array<StructInfo>`.
* For intrinsic ops like `call_tir`/`call_packed`, this PR keeps the `sinfo_args` value as **the plain StructInfo generated from the static type**, even if those op calls were provided with richer StructInfo at the time of creation. The API changes, creations and structure info deductions of these intrinsic ops will be left to the next PR, as the tracking issue #377. Since that PR, our APIs and structure info deductions of these ops will no longer rely on types.

cc @tqchen @Hzfengsy @slyubomirsky 