### PR TITLE
[Utils] Introduce Auto Arg Converter for Relax Ops and Functions

### DIFF
--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -26,6 +26,7 @@ from ..expr import Expr, ShapeExpr, Call, ExternFunc
 from ..expr import Tuple as RxTuple
 from ..ty import DynTensorType, TupleType
 from ...ir import Array, Type, PrimExpr
+from ..utils import args_converter
 
 
 py_print = print  # pylint: disable=invalid-name
@@ -42,9 +43,10 @@ def null_value() -> Call:
     return _ffi_api.null_value()  # type: ignore
 
 
+@args_converter.auto
 def call_tir(
     func: Union[str, Expr],
-    args: Union[Expr, List[Expr]],
+    args: Expr,
     shape: Union[RxTuple, ShapeExpr, List[int]],
     dtype: Union[str, List[str]],
     tir_vars: Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]] = None,
@@ -57,7 +59,7 @@ def call_tir(
     func : Union[str, Expr]
         The destination-passing-style function, can be ExternFunc or PrimFunc.
 
-    args : Union[Expr, List[Expr]]
+    args : Expr
         The input arguments.
 
     shape: Union[RxTuple, ShapeExpr, List[int]]
@@ -110,9 +112,6 @@ def call_tir(
     if isinstance(args, Expr) and not isinstance(args, RxTuple):  # type: ignore
         args = RxTuple((args,))
 
-    if isinstance(args, (list, tuple)):
-        args = RxTuple(args)
-
     if isinstance(dtype, str):
         output_type = DynTensorType(len(shape), dtype)
     elif isinstance(dtype, (list, tuple)):
@@ -128,9 +127,10 @@ def call_tir(
     return _ffi_api.call_tir(func, args, shape, output_type, tir_vars)  # type: ignore
 
 
+@args_converter.auto
 def call_builtin(
     func: Union[str, Expr],
-    args: Union[RxTuple, List[Expr]],
+    args: Expr,
     *,
     type_args: Optional[Union[Type, List[Type]]] = None,
     int_args: Optional[List[int]] = None,
@@ -145,7 +145,7 @@ def call_builtin(
     func : Expr
         The builtin function to be called.
 
-    args : Union[RxTuple, List[Expr]]
+    args : Expr
         The input arguments.
 
     type_args: Optional[Union[Type, List[Type]]]
@@ -171,9 +171,6 @@ def call_builtin(
     if isinstance(func, str):
         func = ExternFunc(func)
 
-    if isinstance(args, (list, tuple)):
-        args = RxTuple(args)
-
     if type_args is not None and not isinstance(type_args, (list, tuple)):
         type_args = [type_args]
 
@@ -182,9 +179,10 @@ def call_builtin(
     )
 
 
+@args_converter.auto
 def make_closure(
     func: Expr,
-    args: Union[RxTuple, List[Expr]],
+    args: Expr,
 ) -> Object:
     """
     Create a closure with free variables and return the closure.
@@ -194,7 +192,7 @@ def make_closure(
     func : Expr
         The closure, can be ExternFunc or PrimFunc.
 
-    args : Union[Tuple, List[Expr]]
+    args : Expr
         The input arguments.
 
 
@@ -204,15 +202,13 @@ def make_closure(
         The VMClosure.
     """
 
-    if isinstance(args, (list, tuple)):
-        args = RxTuple(args)
-
     return _ffi_api.make_closure(func, args)  # type: ignore
 
 
+@args_converter.auto
 def invoke_closure(
     closure: Expr,
-    args: Union[RxTuple, List[Expr]],
+    args: Expr,
     type_args: Union[List[Type], Type],
 ) -> Object:
     """
@@ -223,7 +219,7 @@ def invoke_closure(
     closure : Expr
         The VMClosure object.
 
-    args : Union[Tuple, List[Expr]]
+    args : Expr
         The input arguments.
 
     type_args: Union[Tuple[Type], Type]
@@ -235,8 +231,6 @@ def invoke_closure(
         The result.
     """
 
-    if isinstance(args, (list, tuple)):
-        args = RxTuple(args)
     if not isinstance(type_args, (list, tuple)):
         type_args = (type_args,)
 

--- a/python/tvm/relax/op/builtin/builtin.py
+++ b/python/tvm/relax/op/builtin/builtin.py
@@ -15,11 +15,7 @@
 # specific language governing permissions and limitations
 """The builtin Relax operators."""
 
-from typing import List, Union
-
-from tvm.ir.expr import PrimExpr
-
-from ...expr import Call, ShapeExpr, Expr
+from ...expr import Call, Expr
 from ...utils import args_converter
 from . import _ffi_api
 

--- a/python/tvm/relax/op/builtin/builtin.py
+++ b/python/tvm/relax/op/builtin/builtin.py
@@ -16,19 +16,21 @@
 """The builtin Relax operators."""
 
 from typing import List, Union
+
 from tvm.ir.expr import PrimExpr
+
+from ...expr import Call, ShapeExpr, Expr
+from ...utils import args_converter
 from . import _ffi_api
-from ...expr import ShapeExpr, Call
 
 
-def alloc_tensor(
-    shape: Union[ShapeExpr, PrimExpr, List[PrimExpr]], dtype: str, runtime_device_index: int
-) -> Call:
+@args_converter.auto
+def alloc_tensor(shape: Expr, dtype: str, runtime_device_index: int) -> Call:
     """Construct a Call to allocate a tensor with specific shape, dtype, runtime_device_index.
 
     Parameters
     ----------
-    shape : Union[ShapeExpr, PrimExpr, List[PrimExpr]]
+    shape : Expr
         The shape of the tensor to be allocated.
 
     dtype : str
@@ -43,8 +45,4 @@ def alloc_tensor(
     result : Call
         A relax Call, which gets the allocated tensor.
     """
-    if not isinstance(shape, ShapeExpr):
-        if not isinstance(shape, (tuple, list)):
-            shape = (shape,)
-        shape = ShapeExpr(shape)
     return _ffi_api.alloc_tensor(shape, dtype, runtime_device_index)  # type: ignore

--- a/python/tvm/relax/op/memory/memory.py
+++ b/python/tvm/relax/op/memory/memory.py
@@ -17,9 +17,10 @@
 
 from . import _ffi_api
 from ...expr import Expr, Call
-from ...utils import convert_to_expr
+from ...utils import args_converter
 
 
+@args_converter.auto
 def alloc_storage(size: Expr, virtual_device_index: int, storage_scope: str, dtype: str) -> Call:
     """Construct a Call to allocate a storage with specific size, virtual_device_index,
     storage_scope and dtype.
@@ -44,10 +45,10 @@ def alloc_storage(size: Expr, virtual_device_index: int, storage_scope: str, dty
     result : Call
         A relax Call, which gets the allocated storage.
     """
-    size = convert_to_expr(size)
     return _ffi_api.alloc_storage(size, virtual_device_index, storage_scope, dtype)  # type: ignore
 
 
+@args_converter.auto
 def alloc_tensor(storage: Expr, shape: Expr, offset: int, dtype: str) -> Call:
     """Construct a Call to allocate a tensor on a certain storage starting from the given offset.
 
@@ -70,10 +71,10 @@ def alloc_tensor(storage: Expr, shape: Expr, offset: int, dtype: str) -> Call:
     result : Call
         A relax Call, which gets the allocated tensor.
     """
-    shape = convert_to_expr(shape)
     return _ffi_api.alloc_tensor(storage, shape, offset, dtype)  # type: ignore
 
 
+@args_converter.auto
 def kill_storage(storage: Expr) -> Call:
     """Construct a Call to kill a storage.
 
@@ -90,6 +91,7 @@ def kill_storage(storage: Expr) -> Call:
     return _ffi_api.kill_storage(storage)  # type: ignore
 
 
+@args_converter.auto
 def kill_tensor(tensor: Expr) -> Call:
     """Construct a Call to kill a tensor.
 

--- a/python/tvm/relax/op/vm/op.py
+++ b/python/tvm/relax/op/vm/op.py
@@ -15,16 +15,16 @@
 # specific language governing permissions and limitations
 """The builtin Relax operators."""
 
-from typing import List, Tuple, Union
+from typing import Union
 
 from tvm import DataType
-from tvm.ir.expr import PrimExpr
 
-from ...expr import Call, Expr, ExternFunc, ShapeExpr
-from ...utils import convert_to_expr
+from ...expr import Call, Expr, ExternFunc
+from ...utils import args_converter
 from . import _ffi_api
 
 
+@args_converter.auto
 def alloc_storage(size: Expr, dtype: Union[DataType, str], runtime_device_index: int) -> Call:
     """Construct a Call to allocate storage with specific size, dtype, runtime_device_index.
 
@@ -45,18 +45,12 @@ def alloc_storage(size: Expr, dtype: Union[DataType, str], runtime_device_index:
     result : Call
         A relax Call, which gets the allocated storage.
     """
-    if isinstance(size, (tuple, list)):
-        size = ShapeExpr(size)
 
     return _ffi_api.alloc_storage(size, dtype, runtime_device_index)  # type: ignore
 
 
-def alloc_tensor(
-    storage: Expr,
-    shape: Union[Tuple[PrimExpr], Expr],
-    offset: int,
-    dtype: Union[DataType, str],
-) -> Call:
+@args_converter.auto
+def alloc_tensor(storage: Expr, shape: Expr, offset: int, dtype: Union[DataType, str]) -> Call:
     """Construct a Call to allocate a tensor with specific shape, dtype, runtime_device_index.
 
     Parameters
@@ -64,7 +58,7 @@ def alloc_tensor(
     storage: Expr
         The storage location to be allocated.
 
-    shape: Union[Tuple[PrimExpr], Expr]
+    shape: Expr
         The shape of the tensor to be allocated.
 
     offset: int
@@ -78,16 +72,11 @@ def alloc_tensor(
     result : Call
         A relax Call, which gets the allocated tensor.
     """
-    if isinstance(shape, (tuple, list)):
-        shape = ShapeExpr(shape)
-
     return _ffi_api.alloc_tensor(storage, shape, offset, dtype)  # type: ignore
 
 
-def call_tir_dyn(
-    func: Union[str, Expr],
-    args: Union[Expr, List[Expr]],
-) -> Call:
+@args_converter.auto
+def call_tir_dyn(func: Union[str, Expr], args: Expr) -> Call:
     """Construct a Call to call a tir function with dynamic shape.
 
     Parameters
@@ -95,7 +84,7 @@ def call_tir_dyn(
     func: Union[str, Expr],
         The destination-passing-style function, can be ExternFunc or PrimFunc.
 
-    args: Union[Expr, List[Expr]]
+    args: Expr
         The arguments to the tir function.
 
     Returns
@@ -105,7 +94,5 @@ def call_tir_dyn(
     """
     if isinstance(func, str):
         func = ExternFunc(func)
-
-    args = convert_to_expr(args)
 
     return _ffi_api.call_tir_dyn(func, args)  # type: ignore

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -121,6 +121,22 @@ class _ArgsConverter:
 
     @staticmethod
     def convert(args_to_expr: List[str], args_to_list_expr: List[str]):
+        """Convert the arguments to Expr.
+
+        Parameters
+        ----------
+        args_to_expr : List[str]
+            The argument names to be converted to Expr.
+
+        args_to_list_expr : List[str]
+            The argument names to be converted to List[Expr].
+
+        Returns
+        -------
+        output : Callable[[FType], FType]
+            The decorator.
+        """
+
         if any([x in args_to_list_expr for x in args_to_expr]):
             raise ValueError(f"`args_to_expr` and `args_to_list_expr` should be disjoint.")
 
@@ -237,4 +253,4 @@ class _ArgsConverter:
         return _ArgsConverter.convert(args_to_expr, args_to_list_expr)(func)
 
 
-args_converter = _ArgsConverter()
+args_converter = _ArgsConverter()  # pylint: disable=invalid-name

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -69,7 +69,7 @@ def metadata_partitioner(rx_txt: str) -> List[str]:
 
 
 def convert_to_expr(value: Any) -> Expr:
-    """Helper function to convert tuple to Expr, which follows the rules:
+    """Helper function to convert the input to Expr, which follows the rules:
     1. Return the input itself if it's already a `relax.Expr`;
     2. Return `relax.PrimValue` if the input is a `PrimExpr`;
     3. Return `relax.StringImm` if the input is `tvm.String` or `str`;
@@ -86,7 +86,7 @@ def convert_to_expr(value: Any) -> Expr:
     # Case 1
     if isinstance(tvm_value, Expr):
         return tvm_value
-    # Notes 1
+    # Note`` 1
     if isinstance(tvm_value, tir.StringImm):
         raise TypeError(
             "Cannot convert `tir.StringImm` to `relax.Expr` because of ambiguity,"
@@ -132,7 +132,7 @@ class _ArgsConverter:
                     return convert_to_expr(value)
                 except:
                     raise TypeError(
-                        f"Argument `{name}` is expected to be convert to `Expr`, "
+                        f"Argument `{name}` is expected to be converted to `Expr`, "
                         f"but failed with input value: {value}"
                     )
             elif name in args_to_list_expr:
@@ -140,7 +140,7 @@ class _ArgsConverter:
                     return [convert_to_expr(x) for x in value]
                 except:
                     raise TypeError(
-                        f"Argument `{name}` is expected to be convert to `List[Expr]`, "
+                        f"Argument `{name}` is expected to be converted to `List[Expr]`, "
                         f"but failed with input value: {value}"
                     )
             else:

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -15,12 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """Utility functions for Relax"""
-from typing import List, Tuple, Union
+import functools
+import inspect
+from typing import Any, Callable, List, Optional, TypeVar
 
-from tvm.relax.expr import Expr, ShapeExpr
-from tvm.relax.expr import Tuple as rx_Tuple
-from ..runtime import convert_to_object
+from .. import tir
+from ..runtime import String, convert_to_object
 from ..tir import PrimExpr
+from .expr import Expr, PrimValue, ShapeExpr, StringImm
+from .expr import Tuple as rx_Tuple
 
 
 def metadata_partitioner(rx_txt: str) -> List[str]:
@@ -65,16 +68,173 @@ def metadata_partitioner(rx_txt: str) -> List[str]:
     return partitions
 
 
-def convert_to_expr(value: Union[PrimExpr, Expr, Tuple[PrimExpr, Expr]]) -> Expr:
-    """Helper function to convert tuple to Expr."""
-    if not isinstance(value, tuple):
-        return convert_to_object(value)
-    value = list(value)
-    for i, v in enumerate(value):
-        value[i] = convert_to_expr(v)
-    if all([isinstance(f, PrimExpr) for f in value]):
-        return ShapeExpr(value)
-    elif all([isinstance(f, Expr) for f in value]):  # type: ignore
-        return rx_Tuple(value)
-    else:
-        raise TypeError("Return types, with mixed PrimExpr and Relax Expr, is not supported.")
+def convert_to_expr(value: Any) -> Expr:
+    """Helper function to convert tuple to Expr, which follows the rules:
+    1. Return the input itself if it's already a `relax.Expr`;
+    2. Return `relax.PrimValue` if the input is a `PrimExpr`;
+    3. Return `relax.StringImm` if the input is `tvm.String` or `str`;
+    4. Return `relax.ShapeExpr` if the input is a tuple/list of `PrimExpr` w/ int dtype;
+    5. Return `relax.Tuple` if the input is a tuple/list of `Expr`.
+
+    Notes
+    -----
+    1. `tvm.tir.StringImm` is not allowed because of ambiguity,
+       which can be either `relax.StringImm` or `relax.PrimValue`.
+    2. We regard empty tuple/list as `relax.Tuple` instead of `relax.ShapeExpr`
+    """
+    tvm_value = convert_to_object(value)
+    # Case 1
+    if isinstance(tvm_value, Expr):
+        return tvm_value
+    # Notes 1
+    if isinstance(tvm_value, tir.StringImm):
+        raise TypeError(
+            "Cannot convert `tir.StringImm` to `relax.Expr` because of ambiguity,"
+            "which can be either `relax.StringImm` or `relax.PrimValue` "
+        )
+    # Case 2
+    if isinstance(tvm_value, PrimExpr):
+        return PrimValue(value)
+    # Case 3
+    if isinstance(tvm_value, String):
+        return StringImm(value)
+    # Case 4 & 5
+    if isinstance(value, (tuple, list)):
+        # Note 2
+        if len(value) == 0:
+            return rx_Tuple([])
+        # Case 4
+        opt_prim_value = [convert_to_object(v) for v in value]
+        if all([isinstance(v, PrimExpr) and v.dtype.startswith("int") for v in opt_prim_value]):
+            return ShapeExpr(value)
+        # Case 5
+        # `convert_to_expr` ensures that all elements are `Expr` if no exception raises
+        return rx_Tuple([convert_to_expr(v) for v in value])
+    raise TypeError(f"Cannot convert {value} with type {type(value)} to `relax.Expr`")
+
+
+FType = TypeVar("FType", bound=Callable[..., Expr])
+
+
+class _ArgsConverter:
+    """A helper class to convert the arguments to Expr."""
+
+    @staticmethod
+    def convert(args_to_expr: List[str], args_to_list_expr: List[str]):
+        if any([x in args_to_list_expr for x in args_to_expr]):
+            raise ValueError(f"`args_to_expr` and `args_to_list_expr` should be disjoint.")
+
+        def _convert(name: str, value: Any) -> Any:
+            if value is None:
+                return value
+            if name in args_to_expr:
+                try:
+                    return convert_to_expr(value)
+                except:
+                    raise TypeError(
+                        f"Argument `{name}` is expected to be convert to `Expr`, "
+                        f"but failed with input value: {value}"
+                    )
+            elif name in args_to_list_expr:
+                try:
+                    return [convert_to_expr(x) for x in value]
+                except:
+                    raise TypeError(
+                        f"Argument `{name}` is expected to be convert to `List[Expr]`, "
+                        f"but failed with input value: {value}"
+                    )
+            else:
+                return value
+
+        def inner(func: FType) -> FType:
+            sig = inspect.signature(func)
+            param_names = list(sig.parameters.keys())
+            for name in args_to_expr + args_to_list_expr:
+                if name not in param_names:
+                    raise ValueError(f"Argument `{name}` is not found in function signature.")
+
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+                for param in sig.parameters.values():
+                    if param.kind == param.VAR_POSITIONAL:
+                        # *args case
+                        values = [_convert(param.name, x) for x in bound.arguments[param.name]]
+                        bound.arguments[param.name] = tuple(values)
+                    elif param.kind == param.VAR_KEYWORD:
+                        # **kwargs case
+                        key_value = {
+                            key: _convert(param.name, value)
+                            for key, value in bound.arguments[param.name].items()
+                        }
+                        bound.arguments[param.name] = key_value
+                    else:
+                        bound.arguments[param.name] = _convert(
+                            param.name, bound.arguments[param.name]
+                        )
+                return func(*bound.args, **bound.kwargs)
+
+            return wrapper
+
+        return inner
+
+    @staticmethod
+    def to_expr(*arg_names: str) -> Callable:
+        """Convert the arguments to Expr.
+
+        Parameters
+        ----------
+        *arg_names: str
+            The list of argument names that need to be converted to Expr.
+
+        Returns
+        -------
+        output: Callable
+            The decorator.
+        """
+
+        return _ArgsConverter.convert(args_to_expr=list(arg_names), args_to_list_expr=[])
+
+    @staticmethod
+    def to_list_expr(*arg_names: str) -> Callable:
+        """Convert the arguments to List of Expr.
+
+        Parameters
+        ----------
+        *arg_names: str
+            The list of argument names that need to be converted to List of Expr.
+
+        Returns
+        -------
+        output: Callable
+            The decorator.
+        """
+
+        return _ArgsConverter.convert(args_to_expr=[], args_to_list_expr=list(arg_names))
+
+    @staticmethod
+    def auto(func: FType) -> FType:
+        """Decorator for automatically convert the arguments to Expr according to type annotation.
+        Only two patterns are supported:
+
+        1. The argument is Expr or Optional[Expr].
+
+        2. The argument is List[Expr] or Optional[List[Expr]].
+
+        """
+        sig = inspect.signature(func)
+        args_to_expr = []
+        args_to_list_expr = []
+
+        for param in sig.parameters.values():
+            anno = param.annotation
+            if anno is Expr or anno is Optional[Expr]:
+                args_to_expr.append(param.name)
+            elif anno is List[Expr] or anno is Optional[List[Expr]]:
+                args_to_list_expr.append(param.name)
+
+        return _ArgsConverter.convert(args_to_expr, args_to_list_expr)(func)
+
+
+args_converter = _ArgsConverter()

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -84,7 +84,7 @@ def convert_to_expr(value: Any) -> Expr:
     """
     tvm_value = convert_to_object(value)
     # Case 1
-    if isinstance(tvm_value, Expr):
+    if isinstance(tvm_value, Expr):  # type: ignore
         return tvm_value
     # Note`` 1
     if isinstance(tvm_value, tir.StringImm):
@@ -191,7 +191,7 @@ class _ArgsConverter:
                         )
                 return func(*bound.args, **bound.kwargs)
 
-            return wrapper
+            return wrapper  # type: ignore
 
         return inner
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -20,21 +20,12 @@
 import builtins
 import functools
 import inspect
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import tvm
-
-from tvm import relax, DataType
-from tvm.ir import Type, PrimExpr
-from tvm.relax import (
-    Call,
-    Expr,
-    ExternFunc,
-    TupleGetItem,
-    Var,
-    const,
-)
-
+from tvm import DataType, relax
+from tvm.ir import PrimExpr, Type
+from tvm.relax import Call, Expr, ExternFunc, TupleGetItem, Var, const
 from tvm.relax.analysis import get_static_type
 
 # Todo(ruihang): introduced to make call_packed work. To be removed in the followup PR.
@@ -106,7 +97,7 @@ from tvm.relax.op import (
     zeros_like,
 )
 from tvm.relax.struct_info import StructInfo
-from tvm.relax.utils import convert_to_expr
+from tvm.relax.utils import args_converter
 from tvm.runtime import Object as tvm_Object
 from tvm.runtime import ObjectGeneric
 
@@ -216,11 +207,12 @@ def output(*vars: Tuple[Var]) -> None:
 ################################## Ops #################################
 
 
+@args_converter.auto
 def call_packed(
     func: str,
-    *args: List[Expr],
+    *args: Expr,
     type_args: Optional[Union[StructInfo, List[StructInfo]]] = None,
-    **kwargs: Dict[str, Expr],
+    **kwargs: Any,
 ) -> Call:
     """Create a relax Call, which calls a packed function.
     Parameters
@@ -231,7 +223,7 @@ def call_packed(
         The arguments.
     type_args: Optional[Union[StructInfo, List[StructInfo]]]
         List of Types
-    kwargs: Dict[str, Expr]
+    kwargs: Expr
         The keyword arguments.
 
     Returns
@@ -242,7 +234,6 @@ def call_packed(
     # Todo(ruihang): reorganize API in the followup PR of A1.
     sinfo_args = type_args
     op = ExternFunc(func)
-    args = [convert_to_expr(arg) for arg in args]
     if sinfo_args is None:
         raise ValueError("R.call_packed is required to have type_args")
     if isinstance(sinfo_args, py_tuple):

--- a/tests/python/relax/test_backend_transform_shape_lower.py
+++ b/tests/python/relax/test_backend_transform_shape_lower.py
@@ -409,5 +409,4 @@ def test_return_match_check():
 
 
 if __name__ == "__main__":
-    test_static_fn_check()
     tvm.testing.main()

--- a/tests/python/relax/test_expr_args_converter.py
+++ b/tests/python/relax/test_expr_args_converter.py
@@ -1,0 +1,146 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Callable, List, Optional, Union
+
+import pytest
+import tvm
+import tvm.testing
+from tvm import relax
+from tvm.relax import Expr
+from tvm.relax.utils import args_converter
+
+
+def _test_base(f_checker: Callable, arg: Any, *args: Any, **kwargs: Any) -> None:
+    # Test converting to `Expr`
+    assert f_checker(arg)
+    # Test converting `*args`
+    assert isinstance(args, tuple)
+    assert all([f_checker(arg) for arg in args])
+    # Test converting `**kwargs`
+    assert isinstance(kwargs, dict)
+    assert all([f_checker(arg) for arg in kwargs.values()])
+
+
+def _test_expr(arg: Expr, *args: Expr, **kwargs: Expr) -> None:
+    f_checker = lambda x: isinstance(x, Expr)
+    _test_base(f_checker, arg, *args, **kwargs)
+
+
+def _test_optional_expr(
+    arg: Optional[Expr], *args: Optional[Expr], **kwargs: Optional[Expr]
+) -> None:
+    f_checker = lambda x: x is None or isinstance(x, Expr)
+    _test_base(f_checker, arg, *args, **kwargs)
+
+
+def _test_list_expr(arg: List[Expr], *args: List[Expr], **kwargs: List[Expr]) -> None:
+    f_checker = lambda x: isinstance(x, list) and all([isinstance(arg, Expr) for arg in x])
+    _test_base(f_checker, arg, *args, **kwargs)
+
+
+def _test_optional_list_expr(
+    arg: Optional[List[Expr]], *args: Optional[List[Expr]], **kwargs: Optional[List[Expr]]
+) -> None:
+    f_checker = lambda x: x is None or (
+        isinstance(x, list) and all([isinstance(arg, Expr) for arg in x])
+    )
+    _test_base(f_checker, arg, *args, **kwargs)
+
+
+prim_value = 1
+str_value = "value_to_be_convert"
+shape_value = (1, 1)
+tuple_value = (relax.const(1), (1, 1))
+placeholder = relax.const(0)
+
+test_cases = [prim_value, str_value, shape_value, tuple_value, placeholder]
+
+
+def test_args_to_expr():
+    for _f in [_test_expr, _test_optional_expr]:
+        f = args_converter.to_expr("arg", "args", "kwargs")(_f)
+        for x in test_cases:
+            f(
+                x,
+                x,  # the first argument in *args
+                x,  # the second argument in *args
+                test_kwargs=x,
+            )
+
+            if _f == _test_optional_expr:
+                f(None, None, x, test_kwargs=None)
+
+
+def test_args_to_list_expr():
+    for _f in [_test_list_expr, _test_optional_list_expr]:
+        f = args_converter.to_list_expr("arg", "args", "kwargs")(_f)
+        for x in test_cases:
+            f(
+                [x],
+                [x],  # the first argument in *args
+                [x, x],  # the second argument in *args
+                test_kwargs=[x, (x,)],
+            )
+
+            if _f == _test_optional_list_expr:
+                f(None, None, [x], test_kwargs=None)
+
+
+def test_error():
+    f = args_converter.to_list_expr("arg", "args", "kwargs")(_test_list_expr)
+    with pytest.raises(TypeError):
+        f(prim_value)  # fail to convert prim_value to `List[Expr]`
+
+
+def test_auto_convert():
+    for _f in [_test_expr, _test_optional_expr]:
+        f = args_converter.auto(_f)
+        for x in test_cases:
+            f(x, (x,), test_kwargs=x)
+
+            if _f == _test_optional_expr:
+                f(None, x, test_kwargs=None)
+
+    for _f in [_test_list_expr, _test_optional_list_expr]:
+        f = args_converter.auto(_f)
+        for x in test_cases:
+            f([x], [x, x], test_kwargs=[x, (x,)])
+
+            if _f == _test_optional_list_expr:
+                f(None, None, [x], test_kwargs=None)
+
+
+def test_auto_convert_skip():
+    def _test_expr_skip(arg: int, *args: Union[str, Expr], **kwargs: List[Optional[Expr]]) -> None:
+        f_checker = lambda x: not isinstance(x, Expr)
+        _test_base(f_checker, arg, *args, **kwargs)
+
+    f = args_converter.auto(_test_expr_skip)
+    f(1, "str", test_kwargs=[None])
+
+
+def test_empty_tuple():
+    def _test(arg: Expr):
+        assert isinstance(arg, relax.Tuple)
+
+    f = args_converter.auto(_test)
+    f(())
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -944,7 +944,7 @@ def test_vm_ops():
 def test_prim_value():
     @R.function
     def foo():
-        gv = R.call_packed("test", R.prim_value(1), type_args=R.Tensor((32, 32), "float32"))
+        gv = R.call_packed("test", 1, type_args=R.Tensor((32, 32), "float32"))
         return gv
 
     _check(foo, None)
@@ -953,7 +953,7 @@ def test_prim_value():
 def test_string_imm():
     @R.function
     def foo():
-        gv = R.call_packed("test", R.str("hello"), type_args=R.Tensor((32, 32), "float32"))
+        gv = R.call_packed("test", "hello", type_args=R.Tensor((32, 32), "float32"))
         return gv
 
     _check(foo, None)


### PR DESCRIPTION
This PR introduces a new decorator to automatically convert the arguments to the expr according to the Relax Expr, including:

1. convert `PrimExpr` to `relax.PrimValue`;
2. convert `tvm.String` or `str` to `relax.StringImm`;
3. convert tuple/list of `PrimExpr` to `relax.ShapeExpr`;
4. convert tuple/list of `Expr` to `relax.Tuple`.

cc @tqchen 