### PR TITLE
[BYOC] Refactor and bugfix on `run_codegen`

### DIFF
--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -117,9 +117,7 @@ class CodeGenRunner : ExprMutator {
           auto f = Downcast<Function>(e);
           if (auto target_opt = f->GetAttr<String>(attr::kCodegen)) {
             String target = target_opt.value();
-            if (target_options.empty() || target_options.count(target)) {
-              target_functions[target].push_back(f);
-            }
+            target_functions[target].push_back(f);
           }
         }
       });


### PR DESCRIPTION
This PR delivers the followings:
* Simplify the codegen behavior. For simplicity, run_codegen pass will now target any function with codegen annotation.
* Update test script to match with the latest TVMScript.
* Minor bug fix for test failure

cc. @masahi 