### PR TITLE
[BYOC] Fix MergeCompositeFunctions when some callees are not a composite function

### DIFF
--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -436,7 +436,7 @@ class FunctionCreator : public ExprMutator {
    * It will become the value of the kComposite attribute of the created function.
    * \note The created function won't be returned immediately. It's stored in the `function_` field.
    */
-  void CreateFunction(std::optional<std::string> composite_name) {
+  void CreateFunction(Map<String, ObjectRef> group_attrs) {
     // Step 1. Start constructing a new dataflow block.
     builder_->BeginDataflowBlock();
 
@@ -463,15 +463,11 @@ class FunctionCreator : public ExprMutator {
     Expr body = outputs.size() == 1 ? outputs[0] : Tuple(outputs);
     body = builder_->Normalize(body);
     body = builder_->Normalize(SeqExpr({new_block}, body));
-    Map<String, ObjectRef> attrs;
-    attrs.Set(tvm::relax::attr::kPrimitive, Integer(1));
-    if (composite_name) {
-      attrs.Set(tvm::relax::attr::kComposite, String(*composite_name));
-    }
+    group_attrs.Set(tvm::relax::attr::kPrimitive, Integer(1));
     function_ = Function(/*params=*/params_,           //
                          /*body=*/body,                //
                          /*ret_struct_info=*/NullOpt,  //
-                         /*attrs=*/DictAttrs(attrs));
+                         /*attrs=*/DictAttrs(group_attrs));
   }
 
   /*! \brief The original bindings of the function */
@@ -583,9 +579,8 @@ class OperatorFusor : public ExprMutator {
    * \param groups The grouped result of the group partition on the input indexed-forward graph.
    */
   OperatorFusor(IRModule mod, const IndexedForwardGraph& graph, const std::vector<Group*>& groups,
-                bool create_single_binding_function = false, bool lift_constant = true)
-      : OperatorFusor(mod, CreateGroupMap(graph, groups), create_single_binding_function,
-                      lift_constant) {}
+                bool lift_constant = true)
+      : OperatorFusor(mod, CreateGroupMap(graph, groups), lift_constant) {}
 
   /*!
    * \brief The main transformation on the IRModule
@@ -640,7 +635,7 @@ class OperatorFusor : public ExprMutator {
 
     // Step 3. Create the grouped function for each group.
     for (auto& [g, creator] : group2func_) {
-      creator.CreateFunction(g->composite_name);
+      creator.CreateFunction(g->attrs);
     }
 
     // Step 4. Start generating the new binding block.
@@ -665,7 +660,7 @@ class OperatorFusor : public ExprMutator {
       // Case 1. If the binding is the only binding in its group, recurse into it and emit the
       // transformed binding as usual.
       Group* group = GetGroupFromBinding(binding);
-      if (group->num_nodes == 1 && !create_single_binding_function_) {
+      if (group->num_nodes == 1 && group->attrs.empty()) {
         VisitBinding(binding);
         continue;
       }
@@ -734,7 +729,7 @@ class OperatorFusor : public ExprMutator {
     for (const Binding& binding : bindings) {
       // If the binding is the only binding in its group, there is no need to create a new function.
       Group* group = GetGroupFromBinding(binding);
-      if (group->num_nodes == 1 && !create_single_binding_function_) {
+      if (group->num_nodes == 1 && group->attrs.empty()) {
         continue;
       }
       // Add the binding to the grouped function it's in, and update the function information
@@ -874,8 +869,6 @@ class OperatorFusor : public ExprMutator {
   std::unordered_map<const VarNode*, int> tuple_get_indices_;
   /*! \brief A map from a group to its dependent groups, used to detect cyclic dependencies. */
   std::unordered_map<Group*, std::unordered_set<Group*>> group_deps_;
-  /*! \brief Whether or not a grouped function with a single binding should be created. */
-  bool create_single_binding_function_{false};
   /*! \brief Whether or not to lift bound constants to parameters of the grouped function. */
   bool lift_constants_{true};
 };
@@ -892,15 +885,13 @@ IRModule FuseOps(IRModule mod, int opt_level, size_t max_fuse_depth) {
 
   // Step 3. Transform the IRModule by fusing the operators in accordance with the graph partition
   // results.
-  return OperatorFusor(mod, graph, groups, /*create_single_binding_function*/ false,
-                       /*lift_constants*/ true)
-      .Transform();
+  return OperatorFusor(mod, graph, groups, /*lift_constants*/ true).Transform();
 }
 
 IRModule MakeGroupedFunctions(
     IRModule mod, const std::unordered_map<const Object*, GraphPartitioner::Group*>& partition,
-    bool create_single_binding_function, bool lift_constants) {
-  return OperatorFusor(mod, partition, create_single_binding_function, lift_constants).Transform();
+    bool lift_constants) {
+  return OperatorFusor(mod, partition, lift_constants).Transform();
 }
 
 static Map<Expr, Var> GetBindingInverse(const Map<Var, Expr>& binding) {
@@ -930,8 +921,7 @@ class PatternBasedPartitioner : ExprVisitor {
     return part.group_map_;
   }
 
-  PatternBasedPartitioner(const std::string& pattern_name, DFPattern pattern,
-                          const Map<Var, Expr>& bindings)
+  PatternBasedPartitioner(String pattern_name, DFPattern pattern, const Map<Var, Expr>& bindings)
       : pat_name_(pattern_name),
         pat_(pattern),
         bindings_(bindings),
@@ -955,7 +945,7 @@ class PatternBasedPartitioner : ExprVisitor {
       // parent_group corresponds to the group of "conv1" above.
       auto parent_group = GetGroupForBoundVar(GetRef<Call>(call));
       ICHECK(parent_group);
-      parent_group->composite_name = pat_name_;
+      parent_group->attrs.Set(attr::kComposite, pat_name_);
 
       for (const auto& [pat, match] : matches_opt.value()) {
         ICHECK(group_map_.count(match.get()));
@@ -992,7 +982,7 @@ class PatternBasedPartitioner : ExprVisitor {
     return group_map_[bound_var.get()]->FindRoot();
   }
 
-  std::string pat_name_;
+  String pat_name_;
   DFPattern pat_;
   Map<Var, Expr> bindings_;
   Map<Expr, Var> value_to_bound_var_;

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -561,12 +561,10 @@ class OperatorFusor : public ExprMutator {
   using Group = GraphPartitioner::Group;
   using GroupMap = std::unordered_map<const Object*, Group*>;
 
-  OperatorFusor(IRModule mod, const GroupMap& obj2group,
-                bool create_single_binding_function = false, bool lift_constants = true)
+  OperatorFusor(IRModule mod, const GroupMap& obj2group, bool lift_constants = true)
       : ExprMutator(mod),
         mod_(std::move(mod)),
         obj2group_(obj2group),
-        create_single_binding_function_(create_single_binding_function),
         lift_constants_(lift_constants) {}
 
   /*!
@@ -998,8 +996,7 @@ IRModule FuseOpsByPattern(const tvm::Array<String>& pattern_names,
       auto map = PatternBasedPartitioner::Run(pattern_names[i], patterns[i], entry.second, &arena);
       group_map.insert(map.begin(), map.end());
     }
-    mod = MakeGroupedFunctions(mod, group_map, /*create_single_binding_function*/ false,
-                               /*lift_constants*/ false);
+    mod = MakeGroupedFunctions(mod, group_map, /*lift_constants*/ false);
   }
   return mod;
 }

--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -107,7 +107,7 @@ class CodeGenRunner : ExprMutator {
     std::unordered_map<std::string, Array<Function>> target_functions;
 
     for (const auto& entry : mod->functions) {
-      PostOrderVisit(entry.second, [&target_functions, &target_options](Expr e) {
+      PostOrderVisit(entry.second, [&target_functions](Expr e) {
         if (e->IsInstance<FunctionNode>()) {
           auto f = Downcast<Function>(e);
           if (auto target_opt = f->GetAttr<String>(attr::kCodegen)) {

--- a/src/relax/transform/utils.h
+++ b/src/relax/transform/utils.h
@@ -107,16 +107,14 @@ inline std::string GetExtSymbol(const Function& func) {
  *
  * \param mod The input module.
  * \param partition A mapping from a subexpression to the containing group.
- * \param create_single_binding_function Whether or not to create a grouped function for a group
- *  containing a single binding.
- * \param create_single_binding_function Whether or not to lift bound constants to parameters of the
+ * \param lift_constants Whether or not to lift bound constants to parameters of the
  * grouped function.
  * \return A new module containing grouped functions.
  */
 IRModule MakeGroupedFunctions(
     IRModule mod,
     const std::unordered_map<const Object*, relay::GraphPartitioner::Group*>& partition,
-    bool create_single_binding_function = false, bool lift_constants = true);
+    bool lift_constants = true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relay/analysis/graph_partitioner.h
+++ b/src/relay/analysis/graph_partitioner.h
@@ -24,8 +24,6 @@
 
 #include <tvm/relay/op_attr_types.h>
 
-#include <optional>
-
 #include "../../support/arena.h"
 
 namespace tvm {
@@ -178,8 +176,8 @@ class GraphPartitioner {
      */
     uint32_t num_nodes{1};
 
-    /*! \brief The name to identify the pattern this group is created from, if any. */
-    std::optional<std::string> composite_name;
+    /*! \brief Optional attributes to annotate the grouped function. */
+    runtime::Map<runtime::String, ObjectRef> attrs;
     /*!
      * \brief Find the group root, perform path compression
      * \return The root type node.

--- a/tests/python/relax/test_codegen_dnnl.py
+++ b/tests/python/relax/test_codegen_dnnl.py
@@ -56,10 +56,10 @@ class Conv2dReLUx2:
     ):
         with R.dataflow():
             conv1 = relax.op.nn.relu(relax.op.nn.conv2d(data, weight1, padding=(1, 1)))
-            conv2d = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
-            R.output(conv2d)
+            conv2 = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(0, 0)))
+            R.output(conv2)
 
-        return conv2d
+        return conv2
 
 
 has_dnnl = tvm.get_global_func("relax.ext.dnnl", True)


### PR DESCRIPTION
The PR https://github.com/tlc-pack/relax/pull/372 was making a wrong assumption that all ops in a module are composite functions. So if the output of `FuseOpsByPattern` is like

```
lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(data, weight)
conv: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.relu(lv)  # <- not a composite function
``` 

`MergeCompositeFunctions` would try to create a grouped function for relu, which leads to an error since the grouped function for relu cannot be assigned the `kCodegen` attribute. But the function is still accidentally created due to the hacky `create_single_binding_function_` flag I added in https://github.com/tlc-pack/relax/pull/372. This flag was only meant for creating a grouped function for composite functions even if there is only one composite function in the group. But as a side-effect, we ended up creating a grouped function for a single op as well.

This PR removes the `create_single_binding_function_` flag, and instead adds attribute annotations to `Group`. By only annotating attributes for `Group` which corresponds to a composite function, we can skip creating a new function if the annotation is empty. The bug is fixed and overall the implementation is cleaner.

cc @sunggg 

 