### PR TITLE
[Refactor][AST] `sinfo_args` A1: Update API of call_tir, call_packed, etc.

### DIFF
--- a/include/tvm/relax/dataflow_pattern.h
+++ b/include/tvm/relax/dataflow_pattern.h
@@ -379,6 +379,8 @@ class CallPatternNode : public DFPatternNode {
    */
   bool varg_default_wildcard; /*!< #args can be < #real args with the rest padded by Wildcard() */
 
+  // Todo(relax-team): Dataflow pattern for StructInfo, and match sinfo_args
+
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("op", &op);
     v->Visit("args", &args);
@@ -786,10 +788,10 @@ ExprPattern IsExpr(const Expr& expr);
 /*! \brief Syntatic Sugar for creating a ExprPattern base on an Op */
 ExprPattern IsOp(const String& op_name);
 /*! \brief Syntatic Sugar for call_tir (return a tensor) */
-CallPattern IsCallTIR(const String& name, Optional<TuplePattern> args = NullOpt,
-                      Optional<Array<PrimExpr>> oshape = NullOpt);
+// Todo(relax-team): Dataflow pattern for StructInfo, and match out_sinfo
+CallPattern IsCallTIR(const String& name, Optional<TuplePattern> args = NullOpt);
 /*! \brief Syntatic Sugar for call_tir (return a tuple of tensor) */
-CallPattern IsCallTIR(const String& name, TuplePattern var_args, Array<Array<PrimExpr>> oshapes);
+CallPattern IsCallTIR(const String& name, TuplePattern var_args);
 /*! \brief Syntatic Sugar for creating TuplePattern or UnorderedTuplePattern (unordered=true) */
 DFPattern IsTuple(const Array<DFPattern>& fields, bool unordered = false);
 /*! \brief Syntatic Sugar for creating a TupleGetItemPattern */

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -48,11 +48,6 @@ def get_static_type(sinfo: StructInfo) -> Type:
     return _ffi_api.GetStaticType(sinfo)  # type: ignore
 
 
-# Todo(ruihang): introduced to make call_packed work. To be removed in the followup PR.
-def struct_info_from_type(ty: Type):  # pylint: disable=invalid-name
-    return _ffi_api.StructInfoFromType(ty)  # type: ignore
-
-
 def erase_to_well_defined(
     sinfo: StructInfo,
     shape_var_map: Dict[tir.Var, tir.PrimExpr] = None,

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -34,7 +34,7 @@ from .expr import (
     BaseFunc,
     Binding,
 )
-from .struct_info import ShapeStructInfo, StructInfo, TensorStructInfo
+from .struct_info import ShapeStructInfo, StructInfo, TensorStructInfo, TupleStructInfo
 from .op.base import call_tir
 from . import _ffi_api
 
@@ -418,9 +418,6 @@ class BlockBuilder(Object):
             and all(isinstance(t, tvm.te.tensor.Tensor) for t in te_out)
         ), "only support te.tensor or tuple/list/Array of te.tensor as function output"
 
-        if isinstance(te_out, (tuple, list, tvm.ir.Array)) and len(te_out) == 1:
-            te_out = te_out[0]
-
         outs = [te_out] if isinstance(te_out, tvm.te.tensor.Tensor) else list(te_out)
         unbound_tir_vars = self._get_unbound_tir_vars(te_args + outs)
 
@@ -446,14 +443,13 @@ class BlockBuilder(Object):
         # Invert the TIR variable mapping, to convert the output shape back
         # with old set of variables.
         tir_var_inverse_map = {v: k for k, v in tir_var_map.items()}
-        output_shape = (
-            _shape_with_old_tir_var(outs[0].shape, tir_var_inverse_map)
-            if isinstance(te_out, tvm.te.tensor.Tensor)
-            else Tuple([_shape_with_old_tir_var(x.shape, tir_var_inverse_map) for x in outs])
-        )
 
-        output_dtype = (
-            te_out.dtype if isinstance(te_out, tvm.te.tensor.Tensor) else [x.dtype for x in outs]
+        out_sinfo_list = [
+            TensorStructInfo(_shape_with_old_tir_var(out.shape, tir_var_inverse_map), out.dtype)
+            for out in outs
+        ]
+        output_sinfo: Union[TensorStructInfo, TupleStructInfo] = (
+            out_sinfo_list[0] if len(out_sinfo_list) == 1 else TupleStructInfo(out_sinfo_list)
         )
 
         # add arguments for extra parameters from unbound var
@@ -461,12 +457,11 @@ class BlockBuilder(Object):
             call = call_tir(
                 gvar,
                 call_args,
-                output_shape,
-                output_dtype,
+                output_sinfo,
                 tir_vars=_shape_with_old_tir_var(unbound_tir_vars, tir_var_inverse_map),
             )
         else:
-            call = call_tir(gvar, call_args, output_shape, output_dtype)
+            call = call_tir(gvar, call_args, output_sinfo)
         return call
 
     def emit_te(self, func: Callable, *args: Any, **kwargs: Any) -> Var:
@@ -539,7 +534,7 @@ class BlockBuilder(Object):
                 @R.function
                 def rx_func(x: Tensor((n, m), "float32"), y: Tensor((n, m), "float32")) -> Tensor:
                     # block 0
-                    gv = relax.call_tir("te_func", (x, y), (128, 128), dtype="float32")
+                    gv = relax.call_tir("te_func", (x, y), R.Tensor((128, 128), "float32"))
                     return gv
 
         Example
@@ -584,7 +579,7 @@ class BlockBuilder(Object):
                 def rx_func(x: Tensor((n,), "float32"), y: Tensor(((n + 1),), "float32"))
                     -> Tensor(None, "float32", ndim=-1):
                     # block 0
-                    gv = relax.call_tir(te_func, (y,), ((n + 1),), (n,), dtype="float32")
+                    gv = relax.call_tir(te_func, (y,), R.Tensor((n + 1,), "float32"), (n,))
                     return gv
         """
         return self.emit(self.call_te(func, *args, **kwargs))

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -34,7 +34,7 @@ from .expr import (
     BaseFunc,
     Binding,
 )
-from .struct_info import ShapeStructInfo, StructInfo, TensorStructInfo, TupleStructInfo
+from .struct_info import ShapeStructInfo, StructInfo, TensorStructInfo
 from .op.base import call_tir
 from . import _ffi_api
 
@@ -444,13 +444,10 @@ class BlockBuilder(Object):
         # with old set of variables.
         tir_var_inverse_map = {v: k for k, v in tir_var_map.items()}
 
-        out_sinfo_list = [
+        output_sinfo = [
             TensorStructInfo(_shape_with_old_tir_var(out.shape, tir_var_inverse_map), out.dtype)
             for out in outs
         ]
-        output_sinfo: Union[TensorStructInfo, TupleStructInfo] = (
-            out_sinfo_list[0] if len(out_sinfo_list) == 1 else TupleStructInfo(out_sinfo_list)
-        )
 
         # add arguments for extra parameters from unbound var
         if len(unbound_tir_vars) > 0:

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -800,30 +800,23 @@ def is_shape(shape: List[tvm.ir.PrimExpr]) -> "PrimArrPattern":
     return PrimArrPattern(shape)
 
 
+# Todo(relax-team): Dataflow pattern for StructInfo, and match out_sinfo
 def _is_call_tir(
     func_pattern: DFPattern,
     args: Union[List, Tuple, TuplePattern] = None,
-    shape: Union[Tuple, List[tvm.ir.PrimExpr], DFPattern] = None,
 ) -> CallPattern:
     if args is None:
         args = wildcard()
     elif isinstance(args, (list, tuple)):
         args = TuplePattern(args)
 
-    if shape is None:
-        shape = wildcard()
-    elif isinstance(shape, (list, Array)):
-        shape = PrimArrPattern(shape)
-    elif isinstance(shape, (tuple)):
-        shape = is_tuple(shape)  # multiple shape patterns
-
-    return is_op("relax.call_tir")(func_pattern, args, shape)
+    return is_op("relax.call_tir")(func_pattern, args)
 
 
+# Todo(relax-team): Dataflow pattern for StructInfo, and match out_sinfo
 def is_call_tir(
     func_name: str,
     args: Union[List, Tuple, TuplePattern] = None,
-    shape: Union[Tuple, List[tvm.ir.PrimExpr], DFPattern] = None,
 ) -> CallPattern:
     """
     Syntax sugar for creating a CallPattern for call_tir that calls an function through global var.
@@ -834,8 +827,6 @@ def is_call_tir(
         Name of the CPS function to call.
     args : Union[List[DFPattern], Tuple[DFPattern]], optional
         Arguments in expected call_packed, by default None meaning arbitrary (number of) arguments
-    shape : Union[Tuple, List[tvm.ir.PrimExpr], DFPattern], optional
-        Shape (or shapes in a tuple) of the output, by default None meaning arbitrary shape(s)
 
     Returns
     -------
@@ -843,13 +834,12 @@ def is_call_tir(
         The resulting CallPattern
     """
     func_pattern = GlobalVarPattern(func_name)
-    return _is_call_tir(func_pattern, args, shape)
+    return _is_call_tir(func_pattern, args)
 
 
 def is_call_tir_extern(
     func_name: str,
     args: Union[List, Tuple, TuplePattern] = None,
-    shape: Union[Tuple, List[tvm.ir.PrimExpr], DFPattern] = None,
 ) -> CallPattern:
     """Syntax sugar for creating a CallPattern for call_tir that calls an extern function
 
@@ -859,8 +849,6 @@ def is_call_tir_extern(
         Name of the CPS function to call.
     args : Union[List[DFPattern], Tuple[DFPattern]], optional
         Arguments in expected call_packed, by default None meaning arbitrary (number of) arguments
-    shape : Union[Tuple, List[tvm.ir.PrimExpr], DFPattern], optional
-        Shape (or shapes in a tuple) of the output, by default None meaning arbitrary shape(s)
 
     Returns
     -------
@@ -868,7 +856,7 @@ def is_call_tir_extern(
         The resulting CallPattern
     """
     func_pattern = ExternFuncPattern(func_name)
-    return _is_call_tir(func_pattern, args, shape)
+    return _is_call_tir(func_pattern, args)
 
 
 def is_call_packed(

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -24,8 +24,8 @@ from tvm.runtime.object import Object
 from . import _ffi_api
 from ..expr import Expr, ShapeExpr, Call, ExternFunc
 from ..expr import Tuple as RxTuple
-from ..ty import DynTensorType, TupleType
-from ...ir import Array, Type, PrimExpr
+from ..struct_info import StructInfo, TensorStructInfo, TupleStructInfo
+from ...ir import PrimExpr
 from ..utils import args_converter
 
 
@@ -47,8 +47,7 @@ def null_value() -> Call:
 def call_tir(
     func: Union[str, Expr],
     args: Expr,
-    shape: Union[RxTuple, ShapeExpr, List[int]],
-    dtype: Union[str, List[str]],
+    out_sinfo: Union[TensorStructInfo, TupleStructInfo],
     tir_vars: Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]] = None,
 ) -> Call:
     """
@@ -62,11 +61,12 @@ def call_tir(
     args : Expr
         The input arguments.
 
-    shape: Union[RxTuple, ShapeExpr, List[int]]
-        The output shape. Tuple(ShapeExpr) if multiple outputs, ShapeExpr if single output.
-
-    dtype: Union[str, List[str]]
-        The output dtype. List[str] if multiple outputs, str if single output.
+    out_sinfo : Union[TensorStructInfo, TupleStructInfo]
+        The structure info of the call_tir output.
+        - It should either a single TensorStructInfo, indicating a single
+        returned tensor,
+        - or a TupleStructInfo with all fields TensorStructInfo, indicating
+        multiple returned tensors.
 
     tir_vars : Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]]
         ShapeExpr representing a tuple of integers to unpack when calling func. Is null if not used
@@ -79,52 +79,22 @@ def call_tir(
     if isinstance(func, str):
         func = ExternFunc(func)
 
-    def _create_shape(shape: List[Union[int, PrimExpr]]) -> ShapeExpr:
-        shape_array = []
-        for x in shape:
-            if isinstance(x, int):
-                shape_array.append(tvm.tir.IntImm("int64", x))
-            elif isinstance(x, tvm.tir.IntImm):
-                shape_array.append(x if x.dtype == "int64" else tvm.tir.IntImm("int64", x.value))
-            elif isinstance(x, PrimExpr):
-                if x.dtype != "int64":
-                    raise TypeError("Expect int64 dtype for shape")
-                shape_array.append(x)
-            else:
-                raise TypeError("Expect int or PrimExpr for shape")
-        return ShapeExpr(shape_array)
-
-    if isinstance(shape, (list, tuple, Array)):
-        if all([not isinstance(x, (list, tuple, Array, ShapeExpr)) for x in shape]):
-            shape = _create_shape(shape)  # type: ignore
-        elif all([isinstance(x, (list, tuple, Array, ShapeExpr)) for x in shape]):
-            shape = RxTuple(
-                [
-                    _create_shape(x) if not isinstance(x, ShapeExpr) else x  # type: ignore
-                    for x in shape
-                ]
-            )
-        else:
-            raise TypeError(
-                f"The shape is expected to be ShapeExpr or Tuple[ShapeExpr], bot got: f{shape}"
-            )
-
     if isinstance(args, Expr) and not isinstance(args, RxTuple):  # type: ignore
         args = RxTuple((args,))
 
-    if isinstance(dtype, str):
-        output_type = DynTensorType(len(shape), dtype)
-    elif isinstance(dtype, (list, tuple)):
-        if len(shape) != len(dtype):
-            raise ValueError("The number of output_shape and output_dtype of call_tir mismatch")
-        output_type = TupleType([DynTensorType(len(x), y) for x, y in zip(shape, dtype)])
-    else:
-        raise TypeError("Not supported dtype for call_tir: " + str(type(dtype)))
+    if isinstance(out_sinfo, TupleStructInfo) and not all(
+        [isinstance(field_sinfo, TensorStructInfo) for field_sinfo in out_sinfo.fields]
+    ):
+        raise TypeError(
+            f"The input out_sinfo is expected to be a TensorStructInfo or a "
+            "TupleStructInfo whose fields are all TensorStructInfo. However, "
+            "the given out_sinfo is {out_sinfo}."
+        )
 
     if isinstance(tir_vars, (list, tuple)):
         tir_vars = ShapeExpr(tir_vars)
 
-    return _ffi_api.call_tir(func, args, shape, output_type, tir_vars)  # type: ignore
+    return _ffi_api.call_tir(func, args, out_sinfo, tir_vars)  # type: ignore
 
 
 @args_converter.auto
@@ -132,7 +102,7 @@ def call_builtin(
     func: Union[str, Expr],
     args: Expr,
     *,
-    type_args: Optional[Union[Type, List[Type]]] = None,
+    sinfo_args: Optional[Union[StructInfo, List[StructInfo]]] = None,
     int_args: Optional[List[int]] = None,
     dtype_arg: Optional[str] = None,
     str_args: Optional[List[str]] = None,
@@ -148,8 +118,8 @@ def call_builtin(
     args : Expr
         The input arguments.
 
-    type_args: Optional[Union[Type, List[Type]]]
-        The type arguments to the call node.
+    sinfo_args: Optional[Union[StructInfo, List[StructInfo]]]
+        The struct info arguments to the call node.
 
     int_args: Optional[List[int]]
         List of additional int arguments passed to the builtin.
@@ -171,11 +141,11 @@ def call_builtin(
     if isinstance(func, str):
         func = ExternFunc(func)
 
-    if type_args is not None and not isinstance(type_args, (list, tuple)):
-        type_args = [type_args]
+    if sinfo_args is not None and not isinstance(sinfo_args, (list, tuple)):
+        sinfo_args = [sinfo_args]
 
     return _ffi_api.call_builtin(  # type: ignore
-        func, args, type_args, int_args, dtype_arg, str_args, require_ctx  # type: ignore
+        func, args, sinfo_args, int_args, dtype_arg, str_args, require_ctx  # type: ignore
     )
 
 
@@ -209,7 +179,7 @@ def make_closure(
 def invoke_closure(
     closure: Expr,
     args: Expr,
-    type_args: Union[List[Type], Type],
+    sinfo_args: Union[List[StructInfo], StructInfo],
 ) -> Object:
     """
     Invoke a closure.
@@ -222,8 +192,8 @@ def invoke_closure(
     args : Expr
         The input arguments.
 
-    type_args: Union[Tuple[Type], Type]
-        The type_args of the CallNode
+    type_args: Union[List[StructInfo], StructInfo]
+        The structure info arguments of the CallNode
 
     Returns
     -------
@@ -231,10 +201,10 @@ def invoke_closure(
         The result.
     """
 
-    if not isinstance(type_args, (list, tuple)):
-        type_args = (type_args,)
+    if not isinstance(sinfo_args, (list, tuple)):
+        sinfo_args = [sinfo_args]
 
-    return _ffi_api.invoke_closure(closure, args, type_args)  # type: ignore
+    return _ffi_api.invoke_closure(closure, args, sinfo_args)  # type: ignore
 
 
 def render_object(val: tvm.Object) -> str:

--- a/python/tvm/relax/testing/relay_translator.py
+++ b/python/tvm/relax/testing/relay_translator.py
@@ -169,7 +169,9 @@ def from_relay(
 
             if translate_op_with_tir and op_name in translate_op_with_tir:
                 tir_gvar = bb.add_func(translate_op_with_tir[op_name], op_name)
-                call = relax.call_tir(tir_gvar, new_args, out_type.shape, out_type.dtype)
+                call = relax.call_tir(
+                    tir_gvar, new_args, relax.TensorStructInfo(out_type.shape, out_type.dtype)
+                )
                 var = bb.emit(call)
             else:
                 with target:

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -92,32 +92,14 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::CallNode* op) {
   if (op->op == call_tir_op) {
     doc << "R.call_tir";
 
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 2; ++i) {
       args.push_back(Print(op->args[i]));
     }
     doc << "(" << Doc::Concat(args, Doc::Text(", "));
-
-    Type output_type = GetStaticType(op->sinfo_args[0]);
-    if (const auto* out_type = output_type.as<DynTensorTypeNode>()) {
-      doc << ", dtype=" << PrintDType(out_type->dtype);
-    } else if (const auto* out_type = output_type.as<TupleTypeNode>()) {
-      std::vector<Doc> dtypes;
-      for (auto field : out_type->fields) {
-        if (const auto* field_type = field.as<DynTensorTypeNode>()) {
-          Doc dtype;
-          dtype << PrintDType(field_type->dtype);
-          dtypes.push_back(dtype);
-        } else {
-          LOG(FATAL) << "TypeError: Invalid type: " << field_type->GetTypeKey();
-        }
-      }
-      doc << ", dtype=(" << Doc::Concat(dtypes, Doc::Text(", ")) << ")";
-    } else {
-      LOG(FATAL) << "TypeError: Invalid type: " << output_type->GetTypeKey();
-    }
-
-    if (op->args.size() == 4) {
-      doc << ", tir_vars=" << Print(op->args[3]);
+    ICHECK(op->sinfo_args.size() == 1);
+    doc << ", out_sinfo=" << Print(op->sinfo_args[0]);
+    if (op->args.size() == 3) {
+      doc << ", tir_vars=" << Print(op->args[2]);
     }
     doc << ")";
 
@@ -145,16 +127,14 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::CallNode* op) {
   }
 
   if (!op->sinfo_args.empty()) {
-    doc << ", type_args=";
-    Array<Type> type_args =
-        op->sinfo_args.Map([](StructInfo sinfo) { return GetStaticType(sinfo); });
-    std::vector<Doc> type_args_doc = PrintTypeArgs(type_args);
+    doc << ", sinfo_args=[";
 
-    if (type_args_doc.size() == 1) {
-      doc << "(" << type_args_doc[0] << " ,)";
-    } else {
-      doc << "(" << Doc::Concat(type_args_doc, Doc::Text(", ")) << ")";
+    std::vector<Doc> sinfo_args_docs;
+    sinfo_args_docs.reserve(op->sinfo_args.size());
+    for (const StructInfo& sinfo_arg : op->sinfo_args) {
+      sinfo_args_docs.push_back(Print(sinfo_arg));
     }
+    doc << Doc::Concat(sinfo_args_docs, Doc::Text(", ")) << "]";
   }
 
   doc << ")";
@@ -502,22 +482,6 @@ std::vector<Doc> RelaxScriptPrinter::PrintAttrs(const Attrs& attrs) {
     const_cast<BaseAttrsNode*>(attrs.operator->())->VisitAttrs(&attr_printer);
   }
   return kwargs;
-}
-
-std::vector<Doc> RelaxScriptPrinter::PrintTypeArgs(const Array<tvm::Type>& type_args) {
-  std::vector<Doc> type_args_doc;
-  if (!type_args.empty()) {
-    for (const auto& type : type_args) {
-      if (const auto* tensor = type.as<DynTensorTypeNode>()) {
-        Doc doc;
-        doc << "R.Tensor(ndim=" << tensor->ndim << ", dtype=" << PrintDType(tensor->dtype) << ")";
-        type_args_doc.push_back(doc);
-      } else {
-        type_args_doc.push_back(this->VisitType(type));
-      }
-    }
-  }
-  return type_args_doc;
 }
 
 Doc RelaxScriptPrinter::VisitAttrDefault_(const Object* op) {

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -312,7 +312,6 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
 
   Doc PrintAttr(const ObjectRef& attr);
   std::vector<Doc> PrintAttrs(const Attrs& attrs);
-  std::vector<Doc> PrintTypeArgs(const Array<tvm::Type>& type_args);
   Doc VisitAttrDefault_(const Object* op) override;
   Doc PrintExpr(const Expr& expr, bool meta, bool try_inline, bool optional_info = true);
   Doc VisitAttr_(const ArrayNode* op) override;

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -101,11 +101,6 @@ StructInfo StructInfoFromType(const Type& type) {
   }
 }
 
-// Todo(ruihang): introduced to make call_packed work. To be removed in the followup PR.
-TVM_REGISTER_GLOBAL("relax.analysis.StructInfoFromType").set_body_typed([](const Type& type) {
-  return StructInfoFromType(type);
-});
-
 //--------------------------
 // EraseToWellDefined
 //--------------------------

--- a/src/relax/backend/vm/vm_builtin_lower.cc
+++ b/src/relax/backend/vm/vm_builtin_lower.cc
@@ -75,9 +75,8 @@ class VMBuiltinLowerMutator : public ExprMutator {
     } else {
       auto attrs = DefaultBuiltinAttrs();
       attrs->dtype_arg = dtype;
-      // Todo(ruihang): reorganize in the followup PR
       return Call(call_builtin_op_, {builtin_compute_alloc_shape_, Tuple({shape})}, Attrs(attrs),
-                  {StructInfoFromType(GetStaticType(GetStructInfo(shape)))});
+                  {GetStructInfo(shape)});
     }
   }
 

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -81,7 +81,7 @@ class PrimExprSlotCollector : public ExprVisitor, public StructInfoVisitor {
     PrimExprSlotCollector collector;
     collector.slot_vec_ = slot_vec;
     collector.slot_map_ = slot_map;
-    // collect shape delcarations in func params
+    // collect shape declaration in func params
     for (auto param : func->params) {
       collector.VisitStructInfo(GetStructInfo(param));
       collector.VisitExpr(param);
@@ -283,7 +283,7 @@ class VMShapeLowerMutator
   }
 
   //-------------------------------------------------------
-  // PrimExpr slot hanlding
+  // PrimExpr slot handling
   //-------------------------------------------------------
   static DataType ShapeDType() { return DataType::Int(64); }
 
@@ -310,9 +310,9 @@ class VMShapeLowerMutator
   //-------------------------------------------------------
   // Helper functions to construct BuiltinFuncAttrs
   //-------------------------------------------------------
-  // Buildin attrs that contains extra int arguments.
+  // Builtin attrs that contains extra int arguments.
   Attrs ExtraIntArgs(std::vector<int64_t> int_args, Optional<String> err_ctx = NullOpt) {
-    // intiialize with default value
+    // initialize with default value
     auto n = make_object<BuiltinFuncAttrs>();
     Array<IntImm> arr;
     for (int64_t val : int_args) {
@@ -332,9 +332,9 @@ class VMShapeLowerMutator
     return Attrs(n);
   }
 
-  // Buildin attrs that contains extra int arguments.
+  // Builtin attrs that contains extra int arguments.
   Attrs ExtraTensorInfoArgs(int ndim, DataType dtype, String err_ctx) {
-    // intiialize with default value
+    // initialize with default value
     auto n = make_object<BuiltinFuncAttrs>();
     n->int_args = {IntImm(DataType::Int(64), ndim)};
     n->dtype_arg = dtype;
@@ -351,15 +351,14 @@ class VMShapeLowerMutator
     if (heap_size->value > 0) {
       TensorStructInfo heap_sinfo(ShapeDType(), 1);
       Var var("shape_heap", heap_sinfo);
-      // set up the buildin func.
+      // set up the builtin func.
       auto n = make_object<BuiltinFuncAttrs>();
       n->int_args = {heap_size};
       n->dtype_arg = DataType::Void();
       n->str_args = NullValue<Array<String>>();
       n->require_ctx = true;
-      // Todo(ruihang): reorganize in the followup PR
       Call call(call_builtin_op_, {builtin_alloc_shape_heap_, Tuple(Array<Expr>())}, Attrs(n),
-                {StructInfoFromType(GetStaticType(heap_sinfo))});
+                {heap_sinfo});
       UpdateStructInfo(call, heap_sinfo);
       return VarBinding(var, call);
     } else {
@@ -439,7 +438,7 @@ class VMShapeLowerMutator
   /*!
    * \brief Execute the match todo items.
    *
-   * This functoin can populate vars in the match items when seeing it for the first time.
+   * This function can populate vars in the match items when seeing it for the first time.
    * These new vars will be added to this->ready_vars_.
    *
    * If an item contains PrimExpr that are yet to be computed (but may be computable through
@@ -586,7 +585,7 @@ class VMShapeLowerMutator
    * \param struct_info The struct info to be matched.
    * \param value The input value.
    * \param always_check Whether we insert runtime check even if we can prove
-   *        that value's struct info already satisifies the condition.
+   *        that value's struct info already satisfies the condition.
    *        This option is necessary for argument checking per our calling convention.
    *
    * \param err_ctx Extra error context to bring more informative error reporting.

--- a/src/relax/ir/dataflow_pattern.cc
+++ b/src/relax/ir/dataflow_pattern.cc
@@ -548,8 +548,7 @@ ConstantPattern IsConst() { return ConstantPattern(make_object<ConstantPatternNo
 WildcardPattern Wildcard() { return WildcardPattern(make_object<WildcardPatternNode>()); }
 ExprPattern IsExpr(const Expr& expr) { return ExprPattern(expr); }
 ExprPattern IsOp(const String& op_name) { return IsExpr(Op::Get(op_name)); }
-CallPattern IsCallTIR(const String& name, Optional<TuplePattern> var_args,
-                      Optional<Array<PrimExpr>> oshape) {
+CallPattern IsCallTIR(const String& name, Optional<TuplePattern> var_args) {
   DFPattern arg_pattern;
   if (!var_args.defined()) {
     arg_pattern = Wildcard();
@@ -557,23 +556,11 @@ CallPattern IsCallTIR(const String& name, Optional<TuplePattern> var_args,
     arg_pattern = var_args.value();
   }
 
-  DFPattern shape_pattern;
-  if (!oshape.defined()) {
-    shape_pattern = Wildcard();
-  } else {
-    shape_pattern = PrimArrPattern(oshape.value());
-  }
-
-  return IsOp("relax.call_tir")(GlobalVarPattern(name), arg_pattern, shape_pattern);
+  return IsOp("relax.call_tir")(GlobalVarPattern(name), arg_pattern);
 }
 
-CallPattern IsCallTIR(const String& name, TuplePattern var_args, Array<Array<PrimExpr>> oshapes) {
-  Array<DFPattern> shape_patterns;
-  shape_patterns.reserve(oshapes.size());
-  for (auto shape : oshapes) shape_patterns.push_back(PrimArrPattern(std::move(shape)));
-
-  return IsOp("relax.call_tir")(GlobalVarPattern(name), var_args,
-                                IsTuple(std::move(shape_patterns)));
+CallPattern IsCallTIR(const String& name, TuplePattern var_args) {
+  return IsOp("relax.call_tir")(GlobalVarPattern(name), var_args);
 }
 
 DFPattern IsTuple(const Array<DFPattern>& fields, bool unordered) {

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -524,7 +524,6 @@ TVM_REGISTER_GLOBAL("relax.FunctionCreateEmpty")
 
 // Special opaque derivation function for ExternFunc
 // Take look at sinfo_args to figure out the return StructInfo.
-// TODO(relax-team): revisit sinfo_args related deduction.
 TVM_REGISTER_GLOBAL("tvm.relax.struct_info.infer_by_sinfo_args")
     .set_body_typed([](const Call& call, const BlockBuilder& ctx) -> StructInfo {
       ICHECK(call->sinfo_args.defined()) << "sinfo_args field of CallNode should always be defined";

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -71,55 +71,50 @@ StructInfo ReturnShapeStructInfo(const Call& call, const BlockBuilder& ctx) {
 
 // call_tir
 
-StructInfo CallTIRStructInfoFromShapeType(Expr shape, Type type) {
-  if (auto* tuple = shape.as<TupleNode>()) {
-    auto* ptr_type = type.as<TupleTypeNode>();
-    ICHECK(ptr_type != nullptr) << "Expect tuple type and shape to be consistent.";
-    ICHECK_EQ(ptr_type->fields.size(), tuple->fields.size());
-    Array<StructInfo> arr;
-    for (size_t i = 0; i < ptr_type->fields.size(); ++i) {
-      arr.push_back(CallTIRStructInfoFromShapeType(tuple->fields[i], ptr_type->fields[i]));
-    }
-    return TupleStructInfo(arr);
-  } else {
-    auto* ptr_type = type.as<DynTensorTypeNode>();
-    ICHECK(ptr_type != nullptr) << "Expect singleton shape to correspond to DynTensorType.";
-    return TensorStructInfo(shape, ptr_type->dtype);
-  }
-}
-
 StructInfo InferStructInfoCallTIR(const Call& call, const BlockBuilder& ctx) {
-  // Todo(ruihang): reorganize in the followup PR
-  Expr output_shape = call->args[2];
   if (call->sinfo_args.size() != 1) {
     ctx->ReportFatal(Diagnostic::Error(call)
                      << "sinfo_args should have exact 1 output struct info.");
   }
-  Type output_type = GetStaticType(call->sinfo_args[0]);
-  return CallTIRStructInfoFromShapeType(output_shape, output_type);
+  return call->sinfo_args[0];
 }
 
 RELAY_REGISTER_OP("relax.call_tir")
-    .set_num_inputs(4)
+    .set_num_inputs(3)
     .add_argument("func", "Expr", "The destination-passing-style function.")
     .add_argument("args", "Tuple", "The input arguments.")
-    .add_argument("output_shape", "Expr", "The output shape.")
     .add_argument("packed_ints", "Expr",
                   "ShapeExpr representing a tuple of ints to unpack during runtime. Omitted from "
                   "args if unused")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallTIR);
 
-Expr MakeCallTIR(Expr func, Tuple args, Expr output_shape, Type output_type,
-                 Optional<Expr> packed_ints) {
-  // Todo(ruihang): reorganize in the followup PR
+Expr MakeCallTIR(Expr func, Tuple args, StructInfo out_sinfo, Optional<Expr> packed_ints) {
+  auto f_check_shape = [](const TensorStructInfoNode* sinfo) {
+    const auto* shape = sinfo->shape.as<ShapeExprNode>();
+    CHECK(shape != nullptr) << "out_sinfo of call_tir should have defined ShapeExpr as shape";
+  };
+  if (const auto* tensor_sinfo = out_sinfo.as<TensorStructInfoNode>()) {
+    f_check_shape(tensor_sinfo);
+  } else if (const auto* tuple_sinfo = out_sinfo.as<TupleStructInfoNode>()) {
+    for (const StructInfo& field_sinfo : tuple_sinfo->fields) {
+      const auto* tensor_field = field_sinfo.as<TensorStructInfoNode>();
+      CHECK(tensor_field != nullptr)
+          << "out_sinfo of call_tir should be either TensorStructInfo or a TupleStructInfo whose "
+             "fields are all TensorStructInfo";
+      f_check_shape(tensor_field);
+    }
+  } else {
+    LOG(FATAL) << "out_sinfo of call_tir should be either TensorStructInfo or a TupleStructInfo "
+                  "whose fields are all TensorStructInfo";
+  }
+
   static const Op& op = Op::Get("relax.call_tir");
   Call call;
   if (!packed_ints) {
     // don't use additional optional argument
-    call = Call(op, {func, args, output_shape}, {}, {StructInfoFromType(output_type)});
+    call = Call(op, {func, args}, {}, {out_sinfo});
   } else {
-    call = Call(op, {func, args, output_shape, packed_ints.value()}, {},
-                {StructInfoFromType(output_type)});
+    call = Call(op, {func, args, packed_ints.value()}, {}, {out_sinfo});
   }
   return call;
 }
@@ -128,13 +123,12 @@ TVM_REGISTER_GLOBAL("relax.op.call_tir").set_body_typed(MakeCallTIR);
 
 // call builtin
 StructInfo InferStructInfoCallBuiltin(const Call& call, const BlockBuilder& ctx) {
-  // Todo(ruihang): reorganize in the followup PR
   if (call->sinfo_args.size() == 0) {
     // by default return void.
     return TupleStructInfo(Array<StructInfo>());
   } else {
-    ICHECK(call->sinfo_args[0].defined()) << call;
-    return StructInfoFromType(GetStaticType(call->sinfo_args[0]));
+    ICHECK_EQ(call->sinfo_args.size(), 1);
+    return call->sinfo_args[0];
   }
 }
 
@@ -144,11 +138,8 @@ TVM_REGISTER_OP("relax.call_builtin")
     .add_argument("args", "Tuple", "The input arguments.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallBuiltin);
 
-Expr MakeCallBuiltin(Expr func, Tuple args, Array<Type> type_args, Array<IntImm> int_args,
+Expr MakeCallBuiltin(Expr func, Tuple args, Array<StructInfo> sinfo_args, Array<IntImm> int_args,
                      DataType dtype_arg, Array<String> str_args, bool require_ctx) {
-  // Todo(ruihang): reorganize in the followup PR
-  Array<StructInfo> sinfo_args = type_args.Map([](Type type) { return StructInfoFromType(type); });
-
   auto attrs = make_object<BuiltinFuncAttrs>();
   attrs->int_args = int_args.Map([](IntImm value) {
     if (value->dtype != DataType::Int(64)) {
@@ -259,13 +250,12 @@ TVM_REGISTER_GLOBAL("relax.op.make_closure").set_body_typed(MakeClosure);
 // invoke_closure
 
 StructInfo InferStructInfoInvokeClosure(const Call& call, const BlockBuilder& ctx) {
-  // Todo(ruihang): reorganize in the followup PR
   if (call->sinfo_args.empty()) {
     return ObjectStructInfo();
   } else if (call->sinfo_args.size() == 1) {
-    return StructInfoFromType(GetStaticType(call->sinfo_args[0]));
+    return call->sinfo_args[0];
   } else {
-    return StructInfoFromType(GetStaticType(TupleStructInfo(call->sinfo_args)));
+    return TupleStructInfo(call->sinfo_args);
   }
 }
 
@@ -275,9 +265,7 @@ RELAY_REGISTER_OP("relax.invoke_closure")
     .add_argument("args", "Tuple", "The captured variables.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoInvokeClosure);
 
-Expr InvokeClosure(Expr closure, Tuple args, Array<Type> type_args) {
-  // Todo(ruihang): reorganize in the followup PR
-  Array<StructInfo> sinfo_args = type_args.Map([](Type type) { return StructInfoFromType(type); });
+Expr InvokeClosure(Expr closure, Tuple args, Array<StructInfo> sinfo_args) {
   static const Op& op = Op::Get("relax.invoke_closure");
   return Call(op, {closure, args}, {}, sinfo_args);
 }

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -99,11 +99,11 @@ class CallTIRMutator : public ExprMutator {
         args = Downcast<Tuple>(call->args[1])->fields;
         args.insert(args.end(), outs.begin(), outs.end());
 
-        if (call->args.size() == 3) {
+        if (call->args.size() == 2) {
           builder_->Emit(Call(call->args[0], args), "_");
         } else {
           // unpack semantics
-          args.push_back(call->args[3]);
+          args.push_back(call->args[2]);
           builder_->Emit(Call(call_tir_dyn_op, {call->args[0], Tuple(args)}), "_");
         }
       } else {

--- a/src/relax/transform/lambda_lift.cc
+++ b/src/relax/transform/lambda_lift.cc
@@ -58,7 +58,7 @@ class LambdaLifter : public ExprMutator {
           clo_arg = this->var_remap_.at(var->vid);
         }
         return Call(invoke_closure_op_, {clo_arg, Tuple(call_node->args)}, {},
-                    {StructInfoFromType(call_node->checked_type_)});
+                    {GetStructInfo(GetRef<Expr>(call_node))});
       }
     }
     if (auto global_var_node = call_node->op.as<GlobalVarNode>()) {

--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -69,12 +69,7 @@ class CodeGenRunner : ExprMutator {
       Expr new_op = VisitExpr(func);
       if (new_op->IsInstance<ExternFuncNode>()) {
         Array<Expr> new_args({new_op});
-        Array<Expr> tmp_args;
-        for (const auto& arg : call_node->args) {
-          tmp_args.push_back(VisitExpr(arg));
-        }
-        new_args.push_back(Tuple(tmp_args));
-        new_args.push_back(GetShapeOf(func->body));
+        new_args.push_back(Tuple(call_node->args.Map([this](Expr arg) { return VisitExpr(arg); })));
 
         static const Op& call_op = Op::Get("relax.call_tir");
 
@@ -86,8 +81,7 @@ class CodeGenRunner : ExprMutator {
         func = (*RemoveFuncAttrFunc)(func, attr::kCodegen);
         builder_->UpdateFunction(gvar, func);
 
-        return Call(call_op, new_args, tvm::Attrs(),
-                    {StructInfoFromType(GetStaticType(func->ret_struct_info))});
+        return Call(call_op, new_args, tvm::Attrs(), {func->ret_struct_info});
       }
     }
     Array<Expr> new_args;

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -109,8 +109,8 @@ def test_chained_remove_all_unused():
         def main(x: R.Tensor((32, 32), "float32")) -> R.Tensor:
             with R.dataflow():
                 lv0 = x
-                unused0 = R.call_tir("my_sigmoid", (x,), (32, 32), dtype="float32")
-                unused1 = R.call_tir("my_sigmoid", (unused0,), (32, 32), dtype="float32")
+                unused0 = R.call_tir("my_sigmoid", (x,), R.Tensor((32, 32), dtype="float32"))
+                unused1 = R.call_tir("my_sigmoid", (unused0,), R.Tensor((32, 32), dtype="float32"))
                 R.output(lv0)
             return lv0
 
@@ -135,10 +135,10 @@ def test_binding_block_remove_all_unused():
         def main(x: R.Tensor((32, 32), "float32")) -> R.Tensor:
             with R.dataflow():
                 lv0 = x
-                unused0 = R.call_tir("my_sigmoid", (x,), (32, 32), dtype="float32")
-                unused1 = R.call_tir("my_sigmoid", (unused0,), (32, 32), dtype="float32")
+                unused0 = R.call_tir("my_sigmoid", (x,), R.Tensor((32, 32), dtype="float32"))
+                unused1 = R.call_tir("my_sigmoid", (unused0,), R.Tensor((32, 32), dtype="float32"))
                 R.output(lv0)
-            z = R.call_packed("vm.builtin.copy", lv0, type_args=(R.Tensor((32, 32), "float32")))
+            z = R.call_packed("vm.builtin.copy", lv0, sinfo_args=(R.Tensor((32, 32), "float32")))
             return z
 
     optimized = remove_all_unused(IdentityUnused["main"])
@@ -150,7 +150,7 @@ def test_binding_block_remove_all_unused():
             with R.dataflow():
                 lv0 = x
                 R.output(lv0)
-            z = R.call_packed("vm.builtin.copy", lv0, type_args=(R.Tensor((32, 32), "float32")))
+            z = R.call_packed("vm.builtin.copy", lv0, sinfo_args=(R.Tensor((32, 32), "float32")))
             return z
 
     tvm.ir.assert_structural_equal(optimized, GroundTruth["main"])
@@ -164,7 +164,7 @@ def test_binding_block_fake_unused_remove_all_unused():
             with R.dataflow():
                 lv0 = x
                 R.output(lv0)
-            z = R.call_packed("vm.builtin.copy", lv0, type_args=(R.Tensor((32, 32), "float32")))
+            z = R.call_packed("vm.builtin.copy", lv0, sinfo_args=(R.Tensor((32, 32), "float32")))
             return lv0
 
     optimized = remove_all_unused(IdentityUnused["main"])
@@ -177,7 +177,7 @@ def test_binding_block_fake_unused_remove_all_unused():
                 lv0 = x
                 R.output(lv0)
             # This might bring side effect so cannot be removed.
-            z = R.call_packed("vm.builtin.copy", lv0, type_args=(R.Tensor((32, 32), "float32")))
+            z = R.call_packed("vm.builtin.copy", lv0, sinfo_args=(R.Tensor((32, 32), "float32")))
             return lv0
 
     tvm.ir.assert_structural_equal(optimized, GroundTruth["main"])
@@ -188,7 +188,7 @@ def test_edge_binding_block_fake_unused_remove_all_unused():
     class IdentityUnused:
         @R.function
         def main(x: R.Tensor((32, 32), "float32")) -> R.Tensor((32, 32), "float32"):
-            z = R.call_packed("vm.builtin.copy", x, type_args=(R.Tensor((32, 32), "float32")))
+            z = R.call_packed("vm.builtin.copy", x, sinfo_args=(R.Tensor((32, 32), "float32")))
             return x
 
     optimized = remove_all_unused(IdentityUnused["main"])

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -362,7 +362,7 @@ def test_call_packed():
         t = R.add(w, z)
         sh: R.Shape = R.shape_of(t)
         o: R.Object = R.call_packed(
-            "contrib.tensor_array_stack", x, y, type_args=R.Object(), test_attr=True
+            "contrib.tensor_array_stack", x, y, sinfo_args=R.Object(), test_attr=True
         )
         return o
 
@@ -425,7 +425,7 @@ def test_call_tir():
     @R.function
     def foo(x: R.Tensor(("m", "n"), "float32")):
         m, n = T.var("int64"), T.var("int64")
-        gv0 = R.call_tir("test.op.identity", (x,), (m, n), dtype="float32")
+        gv0 = R.call_tir("test.op.identity", (x,), R.Tensor((m, n), dtype="float32"))
         return gv0
 
     foo_str = strip_whitespace(
@@ -453,16 +453,17 @@ def test_call_tir():
             "op": 'Op(name="relax.call_tir")',
             "args": """[
                 ExternFunc(global_symbol="test.op.identity"),
-                Tuple(fields=[
-                    Var(name_hint="x")]),
-                    ShapeExpr(values=[PrimExpr(value=`m: int64`),
-                    PrimExpr(value=`n: int64`)
-                ])
+                Tuple(fields=[Var(name_hint="x")])
             ]""",
             "sinfo_args": """[
                 TensorStructInfo(
                     dtype=float32,
-                    ndim=2
+                    shape=ShapeExpr(
+                        values=[
+                            PrimExpr(value=`m: int64`),
+                            PrimExpr(value=`n: int64`)
+                        ]
+                    )
                 )
             ]""",
         },

--- a/tests/python/relax/test_autotir_integration.py
+++ b/tests/python/relax/test_autotir_integration.py
@@ -65,12 +65,12 @@ class InputModule:
     @R.function
     def main(x:R.Tensor((m,n), "float32"), w:R.Tensor((n,k), "float32")) -> R.Tensor:
         with R.dataflow():
-            sh = R.call_packed("vm.builtin.shape_of", x)
+            sh = R.call_packed("vm.builtin.shape_of", x, sinfo_args=R.Tensor)
             x0 = R.match_cast(sh, R.Tensor((m, n), "float32"))
-            sh1 = R.call_packed("vm.builtin.shape_of", w)
+            sh1 = R.call_packed("vm.builtin.shape_of", w, sinfo_args=R.Tensor)
             x1 = R.match_cast(sh1, R.Tensor((n, k), "float32"))
-            lv0 = R.call_tir(tir_matmul, (x, w), (m, k), dtype="float32")
-            lv1 = R.call_tir(tir_relu, (lv0), (m, k), dtype="float32)
+            lv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((m, k), dtype="float32"))
+            lv1 = R.call_tir(tir_relu, (lv0), R.Tensor((m, k), dtype="float32))
             R.output(lv1)
         return lv1
 """
@@ -110,8 +110,8 @@ def test_autotir(dev: str):
         @R.function
         def main(x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")) -> R.Tensor:
             with R.dataflow():
-                lv0 = R.call_tir(tir_matmul, (x, w), (32, 32), dtype="float32")
-                lv1 = R.call_tir(tir_relu, (lv0), (32, 32), dtype="float32")
+                lv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((32, 32), dtype="float32"))
+                lv1 = R.call_tir(tir_relu, (lv0), R.Tensor((32, 32), dtype="float32"))
                 R.output(lv1)
             return lv1
 
@@ -211,12 +211,12 @@ def test_meta_schedule_extract_tasks():
         @R.function
         def main(x: R.Tensor((128, 128), "float32")) -> R.Tensor(dtype="float32"):
             with R.dataflow():
-                lv0 = R.call_tir(add1, (x,), (128, 128), dtype="float32")
-                lv1 = R.call_tir(multiply1, (lv0,), (128, 128), dtype="float32")
-                lv2 = R.call_tir(add2, (lv1,), (128, 128), dtype="float32")
-                lv3 = R.call_tir(multiply1, (lv2,), (128, 128), dtype="float32")
-                lv4 = R.call_tir(add3, (lv3,), (128, 128), dtype="float32")
-                gv = R.call_tir(add1, (lv4,), (128, 128), dtype="float32")
+                lv0 = R.call_tir(add1, (x,), R.Tensor((128, 128), dtype="float32"))
+                lv1 = R.call_tir(multiply1, (lv0,), R.Tensor((128, 128), dtype="float32"))
+                lv2 = R.call_tir(add2, (lv1,), R.Tensor((128, 128), dtype="float32"))
+                lv3 = R.call_tir(multiply1, (lv2,), R.Tensor((128, 128), dtype="float32"))
+                lv4 = R.call_tir(add3, (lv3,), R.Tensor((128, 128), dtype="float32"))
+                gv = R.call_tir(add1, (lv4,), R.Tensor((128, 128), dtype="float32"))
                 R.output(gv)
             return gv
 

--- a/tests/python/relax/test_backend_transform_shape_lower.py
+++ b/tests/python/relax/test_backend_transform_shape_lower.py
@@ -117,7 +117,7 @@ def test_simple_symbolic_shape():
                 [],
                 int_args=[2],
                 require_ctx=True,
-                type_args=[R.Tensor(ndim=1, dtype="int64")],
+                sinfo_args=[R.Tensor(ndim=1, dtype="int64")],
             )
             _ = R.call_builtin(
                 "vm.builtin.check_tensor_info",
@@ -185,7 +185,7 @@ def test_symbolic_compute():
                 [],
                 int_args=[4],
                 require_ctx=True,
-                type_args=[R.Tensor(ndim=1, dtype="int64")],
+                sinfo_args=[R.Tensor(ndim=1, dtype="int64")],
             )
             _ = R.call_builtin(
                 "vm.builtin.check_tensor_info",
@@ -247,7 +247,7 @@ def test_symbolic_compute():
                     MK.USE_IMM,
                     2,
                 ],
-                type_args=[R.Shape(ndim=3)],
+                sinfo_args=[R.Shape(ndim=3)],
             )
             return s
 
@@ -286,7 +286,7 @@ def test_tuple_handling():
                 [],
                 int_args=[3],
                 require_ctx=True,
-                type_args=[R.Tensor(ndim=1, dtype="int64")],
+                sinfo_args=[R.Tensor(ndim=1, dtype="int64")],
             )
             # recursively unpack tuple for static info check
             _ = R.call_builtin("vm.builtin.check_tuple_info", [x], int_args=[2], str_args=[""])
@@ -360,7 +360,7 @@ def test_return_match_check():
                 [],
                 int_args=[2],
                 require_ctx=True,
-                type_args=[R.Tensor(ndim=1, dtype="int64")],
+                sinfo_args=[R.Tensor(ndim=1, dtype="int64")],
             )
             _ = R.call_builtin(
                 "vm.builtin.check_tensor_info",
@@ -377,7 +377,9 @@ def test_return_match_check():
             )
             _ = R.call_builtin("vm.builtin.check_tuple_info", [y], int_args=[1], str_args=[""])
             # emit runtime function call since y do not have the right type.
-            y1 = R.call_builtin("vm.builtin.tuple_getitem", [y], int_args=[0], type_args=[R.Object])
+            y1 = R.call_builtin(
+                "vm.builtin.tuple_getitem", [y], int_args=[0], sinfo_args=[R.Object]
+            )
             # run check
             _ = R.call_builtin(
                 "vm.builtin.check_tensor_info",

--- a/tests/python/relax/test_binding_rewrite.py
+++ b/tests/python/relax/test_binding_rewrite.py
@@ -228,8 +228,8 @@ def test_chained_rm_all_unused():
         def main(x: R.Tensor((32, 32), "float32")) -> R.Tensor:
             with R.dataflow():
                 lv0 = x
-                unused0 = R.call_tir("my_sigmoid", (x,), (32, 32), dtype="float32")
-                unused1 = R.call_tir("my_sigmoid", (unused0,), (32, 32), dtype="float32")
+                unused0 = R.call_tir("my_sigmoid", (x,), R.Tensor((32, 32), dtype="float32"))
+                unused1 = R.call_tir("my_sigmoid", (unused0,), R.Tensor((32, 32), dtype="float32"))
                 R.output(lv0)
             return lv0
 
@@ -263,19 +263,19 @@ def test_simple_replace_all_uses():
             #   lv4
             with R.dataflow():
                 lv0: R.Tensor((32, 32), "float32") = R.call_tir(
-                    "my_relu", (x,), (32, 32), dtype="float32"
+                    "my_relu", (x,), R.Tensor((32, 32), dtype="float32")
                 )
                 lv1: R.Tensor((32, 32), "float32") = R.call_tir(
-                    "my_sigmoid", (x,), (32, 32), dtype="float32"
+                    "my_sigmoid", (x,), R.Tensor((32, 32), dtype="float32")
                 )
                 lv2: R.Tensor((32, 32), "float32") = R.call_tir(
-                    "my_add", (x, lv0), (32, 32), dtype="float32"
+                    "my_add", (x, lv0), R.Tensor((32, 32), dtype="float32")
                 )
                 lv3: R.Tensor((32, 32), "float32") = R.call_tir(
-                    "my_mul", (x, lv0), (32, 32), dtype="float32"
+                    "my_mul", (x, lv0), R.Tensor((32, 32), dtype="float32")
                 )
                 lv4: R.Tensor((32, 32), "float32") = R.call_tir(
-                    "my_whatever", (lv2, lv3), (32, 32), dtype="float32"
+                    "my_whatever", (lv2, lv3), R.Tensor((32, 32), dtype="float32")
                 )
                 R.output(lv4)
             return lv4

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -666,9 +666,7 @@ def test_concat_mm_split():
                 lv2 = R.call_tir(
                     "my_split",
                     (lv1,),
-                    R.Tuple(
-                        R.Tensor((16, 32), dtype="float32"), R.Tensor((16, 32), dtype="float32")
-                    ),
+                    [R.Tensor((16, 32), dtype="float32"), R.Tensor((16, 32), dtype="float32")],
                 )
                 lv3 = R.TupleGetItem(lv2, 0)
                 lv4 = R.TupleGetItem(lv2, 1)

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -55,8 +55,8 @@ class Module:
     @R.function
     def main(x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")) -> R.Tensor:
         with R.dataflow():
-            lv0 = R.call_tir(tir_matmul, (x, w), (32, 32), dtype="float32")
-            lv1 = R.call_tir(tir_relu, (lv0), (32, 32), dtype="float32")
+            lv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir(tir_relu, (lv0), R.Tensor((32, 32), dtype="float32"))
             R.output(lv1)
         return lv1
 
@@ -294,7 +294,7 @@ def test_is_call_tir():
 def simple_call_packed(
     x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")
 ) -> R.Tensor:
-    gv0 = R.call_packed("test.vm.mul", x, w, type_args=(R.Tensor(ndim=2, dtype="float32")))
+    gv0 = R.call_packed("test.vm.mul", x, w, sinfo_args=(R.Tensor(ndim=2, dtype="float32")))
     return gv0
 
 
@@ -378,10 +378,10 @@ class Diamond:
             # relu  sigmoid
             #  \      /
             #    add
-            lv0 = R.call_tir("tir_matmul", (x, w), (32, 32), dtype="float32")
-            lv1 = R.call_tir("tir_relu", (lv0,), (32, 32), dtype="float32")
-            lv2 = R.call_tir("tir_sigmoid", (lv0), (32, 32), dtype="float32")
-            lv3 = R.call_tir("tir_add", (lv1, lv2), (32, 32), dtype="float32")
+            lv0 = R.call_tir("tir_matmul", (x, w), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir("tir_relu", (lv0,), R.Tensor((32, 32), dtype="float32"))
+            lv2 = R.call_tir("tir_sigmoid", (lv0), R.Tensor((32, 32), dtype="float32"))
+            lv3 = R.call_tir("tir_add", (lv1, lv2), R.Tensor((32, 32), dtype="float32"))
             R.output(lv3)
         return lv3
 
@@ -440,8 +440,8 @@ class SmallDiamond:
             #  /      \
             #  \      /
             #    add
-            lv0 = R.call_tir("my_relu", (x,), (32, 32), dtype="float32")
-            lv1 = R.call_tir("my_add", (lv0, lv0), (32, 32), dtype="float32")
+            lv0 = R.call_tir("my_relu", (x,), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir("my_add", (lv0, lv0), R.Tensor((32, 32), dtype="float32"))
             R.output(lv1)
         return lv1
 
@@ -454,9 +454,9 @@ class SmallParallel:
             # relu   relu
             #   \    /
             #    add
-            lv0 = R.call_tir("my_relu", (x,), (32, 32), dtype="float32")
-            lv1 = R.call_tir("my_relu", (x,), (32, 32), dtype="float32")
-            lv2 = R.call_tir("my_add", (lv0, lv1), (32, 32), dtype="float32")
+            lv0 = R.call_tir("my_relu", (x,), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir("my_relu", (x,), R.Tensor((32, 32), dtype="float32"))
+            lv2 = R.call_tir("my_add", (lv0, lv1), R.Tensor((32, 32), dtype="float32"))
             R.output(lv2)
         return lv2
 
@@ -507,13 +507,13 @@ class CBRx2:
         #     \   /
         #     concat
         with R.dataflow():
-            lv0 = R.call_tir("conv1x1", (x, w0), (32, 32), dtype="float32")
-            lv1 = R.call_tir("bias_add", (lv0, bias0), (32, 32), dtype="float32")
-            lv2 = R.call_tir("my_relu", (lv1), (32, 32), dtype="float32")
-            lv3 = R.call_tir("conv1x1", (x, w1), (32, 32), dtype="float32")
-            lv4 = R.call_tir("bias_add", (lv3, bias1), (32, 32), dtype="float32")
-            lv5 = R.call_tir("my_relu", (lv4), (32, 32), dtype="float32")
-            lv6 = R.call_tir("concat", (lv2, lv5), (32, 64), dtype="float32")
+            lv0 = R.call_tir("conv1x1", (x, w0), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir("bias_add", (lv0, bias0), R.Tensor((32, 32), dtype="float32"))
+            lv2 = R.call_tir("my_relu", (lv1), R.Tensor((32, 32), dtype="float32"))
+            lv3 = R.call_tir("conv1x1", (x, w1), R.Tensor((32, 32), dtype="float32"))
+            lv4 = R.call_tir("bias_add", (lv3, bias1), R.Tensor((32, 32), dtype="float32"))
+            lv5 = R.call_tir("my_relu", (lv4), R.Tensor((32, 32), dtype="float32"))
+            lv6 = R.call_tir("concat", (lv2, lv5), R.Tensor((32, 64), dtype="float32"))
             R.output(lv6)
         return lv6
 
@@ -626,8 +626,8 @@ def test_two_matmul():
             c: R.Tensor((48, 32), "float32"),
         ) -> R.Tensor:
             with R.dataflow():
-                lv0 = R.call_tir("matmul", (a, b), (32, 48), dtype="float32")
-                lv1 = R.call_tir("matmul", (lv0, c), (32, 32), dtype="float32")
+                lv0 = R.call_tir("matmul", (a, b), R.Tensor((32, 48), dtype="float32"))
+                lv1 = R.call_tir("matmul", (lv0, c), R.Tensor((32, 32), dtype="float32"))
                 R.output(lv1)
             return lv1
 
@@ -661,10 +661,14 @@ def test_concat_mm_split():
             c: R.Tensor((16, 32), "float32"),
         ) -> R.Tensor:
             with R.dataflow():
-                lv0 = R.call_tir("my_concat", (b, c), (32, 32), dtype="float32")
-                lv1 = R.call_tir("my_matmul", (a, lv0), (32, 32), dtype="float32")
+                lv0 = R.call_tir("my_concat", (b, c), R.Tensor((32, 32), dtype="float32"))
+                lv1 = R.call_tir("my_matmul", (a, lv0), R.Tensor((32, 32), dtype="float32"))
                 lv2 = R.call_tir(
-                    "my_split", (lv1,), ((16, 32), (16, 32)), dtype=("float32", "float32")
+                    "my_split",
+                    (lv1,),
+                    R.Tuple(
+                        R.Tensor((16, 32), dtype="float32"), R.Tensor((16, 32), dtype="float32")
+                    ),
                 )
                 lv3 = R.TupleGetItem(lv2, 0)
                 lv4 = R.TupleGetItem(lv2, 1)
@@ -709,18 +713,18 @@ def test_self_attention():
         ) -> R.Tensor:
             b, s, n, h = T.var("int64"), T.var("int64"), T.var("int64"), T.var("int64")
             with R.dataflow():
-                fcq = R.call_tir("my_fc", (x, wq), (b, s, n, h), dtype="float32")
-                tpq = R.call_tir("my_transpose", (fcq,), (b, s, h, n), dtype="float32")
+                fcq = R.call_tir("my_fc", (x, wq), R.Tensor((b, s, n, h), dtype="float32"))
+                tpq = R.call_tir("my_transpose", (fcq,), R.Tensor((b, s, h, n), dtype="float32"))
 
-                fck = R.call_tir("my_fc", (x, wk), (b, s, n, h), dtype="float32")
-                tpk = R.call_tir("my_transpose", (fck,), (b, s, h, n), dtype="float32")
+                fck = R.call_tir("my_fc", (x, wk), R.Tensor((b, s, n, h), dtype="float32"))
+                tpk = R.call_tir("my_transpose", (fck,), R.Tensor((b, s, h, n), dtype="float32"))
 
                 mul = R.multiply(tpq, tpk)
                 scale = R.multiply(mul, R.const(1.1, "float32"))
-                softmax = R.call_tir("softmax", (scale,), (b, s, n, h), dtype="float32")
+                softmax = R.call_tir("softmax", (scale,), R.Tensor((b, s, n, h), dtype="float32"))
 
-                fcv = R.call_tir("my_fc", (x, wv), (b, s, n, h), dtype="float32")
-                tpv = R.call_tir("my_transpose", (fcv,), (b, s, h, n), dtype="float32")
+                fcv = R.call_tir("my_fc", (x, wv), R.Tensor((b, s, n, h), dtype="float32"))
+                tpv = R.call_tir("my_transpose", (fcv,), R.Tensor((b, s, h, n), dtype="float32"))
 
                 out = R.multiply(softmax, tpv)
                 R.output(out)
@@ -750,14 +754,14 @@ def test_nested_diamond():
                 #      add5      add6
                 #          \    /
                 #           add7
-                lv0 = R.call_tir("tir_matmul", (x, w), (32, 32), dtype="float32")
-                lv1 = R.call_tir("tir_matmul", (x, w), (32, 32), dtype="float32")
-                lv2 = R.call_tir("tir_sigmoid", (lv0), (32, 32), dtype="float32")
-                lv3 = R.call_tir("tir_sigmoid", (lv1), (32, 32), dtype="float32")
-                lv4 = R.call_tir("tir_add", (lv0, lv1), (32, 32), dtype="float32")
-                lv5 = R.call_tir("tir_add", (lv2, lv4), (32, 32), dtype="float32")
-                lv6 = R.call_tir("tir_add", (lv3, lv4), (32, 32), dtype="float32")
-                lv7 = R.call_tir("tir_add", (lv5, lv6), (32, 32), dtype="float32")
+                lv0 = R.call_tir("tir_matmul", (x, w), R.Tensor((32, 32), dtype="float32"))
+                lv1 = R.call_tir("tir_matmul", (x, w), R.Tensor((32, 32), dtype="float32"))
+                lv2 = R.call_tir("tir_sigmoid", (lv0), R.Tensor((32, 32), dtype="float32"))
+                lv3 = R.call_tir("tir_sigmoid", (lv1), R.Tensor((32, 32), dtype="float32"))
+                lv4 = R.call_tir("tir_add", (lv0, lv1), R.Tensor((32, 32), dtype="float32"))
+                lv5 = R.call_tir("tir_add", (lv2, lv4), R.Tensor((32, 32), dtype="float32"))
+                lv6 = R.call_tir("tir_add", (lv3, lv4), R.Tensor((32, 32), dtype="float32"))
+                lv7 = R.call_tir("tir_add", (lv5, lv6), R.Tensor((32, 32), dtype="float32"))
                 R.output(lv7)
             return lv7
 
@@ -809,9 +813,9 @@ def test_incremental_solving():
     def simple_chain(x: R.Tensor((32, 32), "float32")) -> R.Tensor:
         with R.dataflow():
             # relu -> sigmoid -> neg
-            lv0 = R.call_tir("tir_relu", (x), (32, 32), dtype="float32")
-            lv1 = R.call_tir("tir_sigmoid", (lv0), (32, 32), dtype="float32")
-            lv2 = R.call_tir("tir_neg", (lv1), (32, 32), dtype="float32")
+            lv0 = R.call_tir("tir_relu", (x), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir("tir_sigmoid", (lv0), R.Tensor((32, 32), dtype="float32"))
+            lv2 = R.call_tir("tir_neg", (lv1), R.Tensor((32, 32), dtype="float32"))
             R.output(lv2)
         return lv2
 
@@ -838,8 +842,8 @@ def test_incremental_solving_counter():
     def simple_chain(x: R.Tensor((32, 32), "float32")) -> R.Tensor:
         with R.dataflow():
             # sigmoid -> neg
-            lv0 = R.call_tir("tir_sigmoid", (x), (32, 32), dtype="float32")
-            lv1 = R.call_tir("tir_neg", (lv0), (32, 32), dtype="float32")
+            lv0 = R.call_tir("tir_sigmoid", (x), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir("tir_neg", (lv0), R.Tensor((32, 32), dtype="float32"))
             R.output(lv1)
         return lv1
 

--- a/tests/python/relax/test_op.py
+++ b/tests/python/relax/test_op.py
@@ -39,8 +39,8 @@ def identity_tir(a: T.handle, b: T.handle) -> None:
 
 def test_call_tir() -> None:
     v0 = rx.Var("v0", R.Tensor([54, 96], "float32"))
-    v1 = rx.call_tir(rx.extern("test.op.identity"), [v0], [54, 96], "float32")
-    v1 = rx.call_tir(identity_tir, [v0], [54, 96], "float32")
+    v1 = rx.call_tir(rx.extern("test.op.identity"), [v0], R.Tensor((54, 96), "float32"))
+    v1 = rx.call_tir(identity_tir, [v0], R.Tensor((54, 96), "float32"))
 
 
 def test_implicit_op():

--- a/tests/python/relax/test_transform_attach_global_symbol.py
+++ b/tests/python/relax/test_transform_attach_global_symbol.py
@@ -45,7 +45,7 @@ class Before:
     @R.function
     def main(x: R.Tensor(("m", "n"), "float32"), w: R.Tensor(("n", "k"), "float32")) -> R.Tensor:
         m, n, k = T.var("int64"), T.var("int64"), T.var("int64")
-        gv0 = R.call_tir("tir_matmul", (x, w), (m, k), dtype="float32")
+        gv0 = R.call_tir("tir_matmul", (x, w), R.Tensor((m, k), dtype="float32"))
         return gv0
 
 
@@ -75,7 +75,7 @@ def test_basic():
         ) -> R.Tensor:
             R.func_attr({"global_symbol": "main"})
             m, n, k = T.var("int64"), T.var("int64"), T.var("int64")
-            gv0 = R.call_tir("tir_matmul", (x, w), (m, k), dtype="float32")
+            gv0 = R.call_tir("tir_matmul", (x, w), R.Tensor((m, k), dtype="float32"))
             return gv0
 
     before = Before

--- a/tests/python/relax/test_transform_bind_params.py
+++ b/tests/python/relax/test_transform_bind_params.py
@@ -48,7 +48,7 @@ def test_bind_params(use_np_array):
         def main(
             x: R.Tensor((16, 16), "float32"), w: R.Tensor((16, 16), "float32")
         ) -> R.Tensor((16, 16), "float32"):
-            gv0 = R.call_tir(tir_matmul, (x, w), (16, 16), dtype="float32")
+            gv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((16, 16), dtype="float32"))
             return gv0
 
     x_np = np.random.rand(16, 16).astype(np.float32)

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -67,7 +67,7 @@ def test_one_fold_addone():
 
         @R.function
         def before(c0: R.Tensor((16, 16), "float32")):
-            lv0 = relax.call_tir(addone, (c0,), (16, 16), dtype="float32")
+            lv0 = relax.call_tir(addone, (c0,), R.Tensor((16, 16), dtype="float32"))
             return lv0
 
         @R.function
@@ -97,7 +97,7 @@ def test_one_fold_transpose():
 
         @R.function
         def before(c0: R.Tensor((2, 3), "float32")):
-            lv0 = relax.call_tir(func, (c0,), (3, 2), dtype="float32")
+            lv0 = relax.call_tir(func, (c0,), R.Tensor((3, 2), dtype="float32"))
             return lv0
 
         @R.function
@@ -126,8 +126,8 @@ def test_two_hop_addone():
 
         @R.function
         def before(c0: R.Tensor((2, 2), "float32")):
-            lv0 = relax.call_tir(addone, (c0,), (2, 2), dtype="float32")
-            lv1 = relax.call_tir(addone, (lv0,), (2, 2), dtype="float32")
+            lv0 = relax.call_tir(addone, (c0,), R.Tensor((2, 2), dtype="float32"))
+            lv1 = relax.call_tir(addone, (lv0,), R.Tensor((2, 2), dtype="float32"))
             return lv1
 
         @R.function
@@ -159,7 +159,7 @@ def test_dataflow_fold():
         @R.function
         def before(c0: R.Tensor((16, 16), "float32")):
             with R.dataflow():
-                gv0 = relax.call_tir(identity, (c0,), (16, 16), dtype="float32")
+                gv0 = relax.call_tir(identity, (c0,), R.Tensor((16, 16), dtype="float32"))
                 R.output(gv0)
             return gv0
 
@@ -209,13 +209,13 @@ def test_fold_mixed_case():
             n, m = T.var("int64"), T.var("int64")
             x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             # this line cannot be folded because n is unknown
-            lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
+            lv0 = relax.call_tir(addone, (c0,), R.Tensor((n, 16), dtype="float32"))
             # this line can be folded
-            lv1 = relax.call_tir(addone, (c0,), (16, 16), dtype="float32")
+            lv1 = relax.call_tir(addone, (c0,), R.Tensor((16, 16), dtype="float32"))
             # this line can be folded because all inputs are const
-            lv2 = relax.call_tir(sub, (c0, lv1), (16, 16), dtype="float32")
+            lv2 = relax.call_tir(sub, (c0, lv1), R.Tensor((16, 16), dtype="float32"))
             # this line can not be folded because x's shape is unknown
-            lv3 = relax.call_tir(sub, (lv2, x), (16, 16), dtype="float32")
+            lv3 = relax.call_tir(sub, (lv2, x), R.Tensor((16, 16), dtype="float32"))
             return lv3
 
         @R.function
@@ -228,13 +228,13 @@ def test_fold_mixed_case():
             n, m = T.var("int64"), T.var("int64")
             x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             # this line cannot be folded because n is unknown
-            lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
+            lv0 = relax.call_tir(addone, (c0,), R.Tensor((n, 16), dtype="float32"))
             # this line can be folded
             lv1 = c1
             # this line can be folded because all inputs are const
             lv2 = c2
             # this line can not be folded because x's shape is unknown
-            lv3 = relax.call_tir(sub, (c2, x), (16, 16), dtype="float32")
+            lv3 = relax.call_tir(sub, (c2, x), R.Tensor((16, 16), dtype="float32"))
             return lv3
 
     c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
@@ -259,7 +259,7 @@ def test_int32_fold():
 
         @R.function
         def before(c0: R.Tensor((16, 16), "int32")):
-            lv0 = relax.call_tir(addone, (c0,), (16, 16), dtype="int32")
+            lv0 = relax.call_tir(addone, (c0,), R.Tensor((16, 16), dtype="int32"))
             return lv0
 
         @R.function

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -23,6 +23,9 @@ from tvm.script import relax as R
 
 def _check(mod_before, mod_expected):
     mod = relax.transform.FuseTIR()(mod_before)
+    print(mod.script())
+    print(mod_expected.script())
+    print(tvm.ir.base.get_first_structural_mismatch(mod, mod_expected))
     tvm.ir.assert_structural_equal(mod, mod_expected)
 
 

--- a/tests/python/relax/test_transform_lambda_lift.py
+++ b/tests/python/relax/test_transform_lambda_lift.py
@@ -94,7 +94,7 @@ def test_closure():
         ) -> R.Tensor((2, 3), "float32"):
             outer_func = lifted_func_0
             in_call = outer_func(x)
-            res = R.invoke_closure(in_call, (y,), type_args=(R.Tensor(ndim=2, dtype="float32")))
+            res = R.invoke_closure(in_call, (y,), sinfo_args=(R.Tensor((2, 3), dtype="float32")))
             return res
 
         @R.function
@@ -117,7 +117,7 @@ def test_closure():
             @R.function
             def outer_func(c1: R.Tensor((2, 3), "float32")):
                 @R.function
-                def inner_func(x1: R.Tensor((2, 3), "float32")):
+                def inner_func(x1: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
                     s: R.Tensor((2, 3), "float32") = R.add(x1, c1)
                     return s
 
@@ -144,7 +144,7 @@ def test_recursive():
             i: R.Tensor((), "int32"), s: R.Tensor((2, 3), "float32"), x: R.Tensor((2, 3), "float32")
         ) -> R.Tensor((2, 3), "float32"):
             cond: R.Tensor((), "bool") = R.call_packed(
-                "test.vm.less", i, R.const(10), type_args=(R.Tensor(ndim=0, dtype="bool"))
+                "test.vm.less", i, R.const(10), sinfo_args=(R.Tensor((), dtype="bool"))
             )
             c: R.Tensor((), "int32") = R.const(1, dtype="int32")
             if cond:
@@ -161,7 +161,7 @@ def test_recursive():
             gv = R.invoke_closure(
                 while_loop,
                 (relax.const(0), x),
-                type_args=(R.Tensor(ndim=2, dtype="float32")),
+                sinfo_args=(R.Tensor(ndim=2, dtype="float32")),
             )
             return gv
 
@@ -175,7 +175,7 @@ def test_recursive():
                 i: R.Tensor((), "int32"), s: R.Tensor((2, 3), "float32")
             ) -> R.Tensor((2, 3), "float32"):
                 cond: R.Tensor((), "bool") = R.call_packed(
-                    "test.vm.less", i, R.const(10), type_args=(R.Tensor(ndim=0, dtype="bool"))
+                    "test.vm.less", i, R.const(10), sinfo_args=(R.Tensor((), dtype="bool"))
                 )
                 c: R.Tensor((), "int32") = R.const(1, dtype="int32")
                 if cond:
@@ -290,7 +290,7 @@ def test_no_local_func():
 
         @R.function
         def before(c0: R.Tensor((16, 16), "float32"), x: R.Tensor(dtype="float32", ndim=2)):
-            s = R.call_tir(sub, (c0, x), (16, 16), dtype="float32")
+            s = R.call_tir(sub, (c0, x), R.Tensor((16, 16), dtype="float32"))
             return s
 
     before = Before

--- a/tests/python/relax/test_transform_meta_schedule_tuning.py
+++ b/tests/python/relax/test_transform_meta_schedule_tuning.py
@@ -61,8 +61,8 @@ class InputModule:
     @R.function
     def main(x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")) -> R.Tensor:
         with R.dataflow():
-            lv0 = R.call_tir(tir_matmul, (x, w), (32, 32), dtype="float32")
-            lv1 = R.call_tir(tir_relu, (lv0), (32, 32), dtype="float32")
+            lv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir(tir_relu, (lv0), R.Tensor((32, 32), dtype="float32"))
             R.output(lv1)
         return lv1
 

--- a/tests/python/relax/test_transform_normalize.py
+++ b/tests/python/relax/test_transform_normalize.py
@@ -124,8 +124,8 @@ def test_normalize_no_op():
         def foo(x: R.Tensor(("m", "n"), "float32")):
             m, n = T.var("int64"), T.var("int64")
             with R.dataflow():
-                lv0 = R.call_tir("test.op.identity", (x,), (m, n), dtype="float32")
-                gv0 = R.call_tir("test.op.identity", (lv0,), (m, n), dtype="float32")
+                lv0 = R.call_tir("test.op.identity", (x,), R.Tensor((m, n), dtype="float32"))
+                gv0 = R.call_tir("test.op.identity", (lv0,), R.Tensor((m, n), dtype="float32"))
                 R.output(gv0)
             return gv0
 

--- a/tests/python/relax/test_transform_remove_unused_funcs.py
+++ b/tests/python/relax/test_transform_remove_unused_funcs.py
@@ -51,7 +51,7 @@ def test_unused_relax_func():
         def main(
             x: R.Tensor((16, 16), "float32"), w: R.Tensor((16, 16), "float32")
         ) -> R.Tensor((16, 16), "float32"):
-            gv0 = R.call_tir(tir_add, (x, w), (16, 16), dtype="float32")
+            gv0 = R.call_tir(tir_add, (x, w), R.Tensor((16, 16), dtype="float32"))
             return gv0
 
     mod = InputModule
@@ -85,7 +85,7 @@ def test_unused_relax_func_custom_entry_func():
         def foo(
             x: R.Tensor((16, 16), "float32"), w: R.Tensor((16, 16), "float32")
         ) -> R.Tensor((16, 16), "float32"):
-            gv0 = R.call_tir(tir_add, (x, w), (16, 16), dtype="float32")
+            gv0 = R.call_tir(tir_add, (x, w), R.Tensor((16, 16), dtype="float32"))
             return gv0
 
     mod = InputModule
@@ -121,7 +121,7 @@ def test_unused_relax_func_symbolic_shape():
         @R.function
         def main(x: R.Tensor(("m", "n"), "float32"), w: R.Tensor(("n", "k"), "float32")):
             m, k = T.var("int64"), T.var("int64")
-            gv0 = R.call_tir(tir_add, (x, w), (m + 1, k), dtype="float32")
+            gv0 = R.call_tir(tir_add, (x, w), R.Tensor((m + 1, k), dtype="float32"))
             return gv0
 
     mod = InputModule

--- a/tests/python/relax/test_tuning_api.py
+++ b/tests/python/relax/test_tuning_api.py
@@ -57,7 +57,7 @@ class TestModule:
     # Input IRModule.
     @R.function
     def before(c0: R.Tensor((16, 16), "int32")):
-        lv0 = R.call_tir(addone, (c0,), (16, 16), dtype="int32")
+        lv0 = R.call_tir(addone, (c0,), R.Tensor((16, 16), dtype="int32"))
         return lv0
 
     # Expected IRModule after transformation.

--- a/tests/python/relax/test_vm_codegen_only.py
+++ b/tests/python/relax/test_vm_codegen_only.py
@@ -40,7 +40,7 @@ def test_vm_copy(exec_mode):
         @R.function
         def foo(x: R.Tensor((3, 4), "float32")):
             R.func_attr({"global_symbol": "foo"})
-            z = R.call_packed("vm.builtin.copy", x, type_args=(R.Tensor(ndim=2, dtype="float32")))
+            z = R.call_packed("vm.builtin.copy", x, sinfo_args=(R.Tensor((3, 4), dtype="float32")))
             return z
 
     mod = TestVMMove
@@ -81,7 +81,7 @@ def test_vm_exec_serialize_export_library(exec_mode):
         @R.function
         def foo(x: R.Tensor((3, 4), "float32")):
             R.func_attr({"global_symbol": "foo"})
-            z = R.call_packed("vm.builtin.copy", x, type_args=(R.Tensor(ndim=2, dtype="float32")))
+            z = R.call_packed("vm.builtin.copy", x, sinfo_args=(R.Tensor((3, 4), dtype="float32")))
             return z
 
     mod = TestVMMove
@@ -105,9 +105,9 @@ def test_if_cond(exec_mode):
         def ife(cond: R.Tensor((), "bool"), x: R.Tensor((3, 4), "float32")) -> R.Tensor:
             R.func_attr({"global_symbol": "ife"})
             if cond:
-                w = R.call_packed("test.vm.add", x, x, type_args=(R.Tensor))
+                w = R.call_packed("test.vm.add", x, x, sinfo_args=(R.Tensor))
             else:
-                w = R.call_packed("test.vm.mul", x, x, type_args=(R.Tensor))
+                w = R.call_packed("test.vm.mul", x, x, sinfo_args=(R.Tensor))
             return w
 
     mod = TestVMCompileIf
@@ -158,13 +158,13 @@ def test_vm_const_as_call_arg(exec_mode):
                 "test.vm.add",
                 relax.const([1, 2]),
                 relax.const([3, 4]),
-                type_args=(R.Tensor(ndim=2, dtype="float32")),
+                sinfo_args=(R.Tensor(ndim=2, dtype="float32")),
             )
             b = R.call_packed(
                 "test.vm.add",
                 a,
                 x,
-                type_args=(R.Tensor(ndim=2, dtype="float32")),
+                sinfo_args=(R.Tensor(ndim=2, dtype="float32")),
             )
             return b
 
@@ -197,7 +197,7 @@ def test_shape_check_builtin(exec_mode):
                 [],
                 int_args=[3],
                 require_ctx=True,
-                type_args=[R.Tensor(ndim=1, dtype="int64")],
+                sinfo_args=[R.Tensor(ndim=1, dtype="int64")],
             )
             _ = R.call_builtin(
                 "vm.builtin.check_tensor_info",
@@ -225,7 +225,7 @@ def test_shape_check_builtin(exec_mode):
                     MK.USE_IMM,
                     2,
                 ],
-                type_args=[R.Shape(ndim=3)],
+                sinfo_args=[R.Shape(ndim=3)],
             )
             return s
 

--- a/tests/python/relax/test_vm_codegen_tir.py
+++ b/tests/python/relax/test_vm_codegen_tir.py
@@ -37,7 +37,7 @@ def test_add():
         @R.function
         def foo(x: R.Tensor):
             R.func_attr({"global_symbol": "foo"})
-            z = R.call_packed("test.vm.add", x, x, type_args=(R.Tensor))
+            z = R.call_packed("test.vm.add", x, x, sinfo_args=(R.Tensor))
             return z
 
     @tvm.script.ir_module
@@ -108,9 +108,9 @@ def test_if_cond():
         def ife(cond: R.Tensor((), "bool"), x: R.Tensor) -> R.Tensor:
             R.func_attr({"global_symbol": "ife"})
             if cond:
-                w = R.call_packed("test.vm.add", x, x, type_args=(R.Tensor))
+                w = R.call_packed("test.vm.add", x, x, sinfo_args=(R.Tensor))
             else:
-                w = R.call_packed("test.vm.mul", x, x, type_args=(R.Tensor))
+                w = R.call_packed("test.vm.mul", x, x, sinfo_args=(R.Tensor))
             return w
 
     @tvm.script.ir_module
@@ -195,7 +195,7 @@ def test_const_call():
         def main(x: R.Tensor):
             R.func_attr({"global_symbol": "main"})
             y = R.const([1, 2])
-            z = R.call_packed("test.vm.add", x, y, type_args=(R.Tensor))
+            z = R.call_packed("test.vm.add", x, y, sinfo_args=(R.Tensor))
             return z
 
     @tvm.script.ir_module


### PR DESCRIPTION
Following #377 and #379, this PR followups to update the API of `call_tir`, `call_packed`, `call_builtin` and `invoke_closure`.

* The API of `call_tir` is changed to
  ```python
  def call_tir(
      func: Union[str, Expr],
      args: Expr,
      out_sinfo: Union[TensorStructInfo, List[TensorStructInfo]],
      tir_vars: Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]] = None,
  ) -> Call:
      ...
  ```
  where we combine the `shape` and `dtype` parameters into `out_sinfo`. In the concrete CallNode of `call_tir`, the output shape is no longer passed as an CallNode argument and passed in the `sinfo_args` instead.
* For `call_packed`, `call_builtin` and `invoke_closure`, we change the `type_args` parameter to `sinfo_args`. For example, the API of `call_packed` is updated to
  ```python
  def call_packed(
      func: str,
      *args: Expr,
      sinfo_args: Union[StructInfo, List[StructInfo]],
      **kwargs: Any,
  ) -> Call:
      ...
  ```

---

One thing specific to note is about our existing dataflow pattern language. Previously we have a sugar function for `call_tir`:
```python
def is_call_tir(
    func_name: str,
    args: Union[List, Tuple, TuplePattern] = None,
    shape: Union[Tuple, List[tvm.ir.PrimExpr], DFPattern] = None,
) -> CallPattern:
    ...
```
Since we changed the API of `call_tir` - the CallNode does not contain the shape as one argument, - together with the fact that the dataflow pattern language does not yet support matching StructInfo, we have no approach to match the shape anymore. Therefore, the `shape` parameter is removed from `is_call_tir`. I left some Todo items there for future `sinfo_args` matching support.

---

cc @Hzfengsy @tqchen @slyubomirsky @spectrometerHBH 