### PR TITLE
[Refactor][AST] `sinfo_args` A2: Remove VisitType

### DIFF
--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -48,7 +48,6 @@ from .expr import (
     StringImm,
     Tuple,
     TupleGetItem,
-    Type,
     Var,
     VarBinding,
 )
@@ -301,7 +300,6 @@ class _PyExprVisitor(Object):
         f_visit_var_def: Callable = None,
         f_visit_var_def_: Callable = None,
         f_visit_dataflow_var_def_: Callable = None,
-        f_visit_type: Callable = None,
         f_visit_span: Callable = None,
     ) -> None:
         """Constructor."""
@@ -334,7 +332,6 @@ class _PyExprVisitor(Object):
             f_visit_var_def,
             f_visit_var_def_,
             f_visit_dataflow_var_def_,
-            f_visit_type,
             f_visit_span,
         )
 
@@ -426,7 +423,6 @@ class PyExprVisitor:
             "visit_var_def",
             "visit_var_def_",
             "visit_dataflow_var_def_",
-            "visit_type",
             "visit_span",
         ],
     }
@@ -768,18 +764,6 @@ class PyExprVisitor:
         # Using self._outer() to ref _PyExprVisitor
         return _ffi_api.ExprVisitorVisitVarDef(self._outer(), var)  # type: ignore
 
-    def visit_type(self, t: Type) -> None:
-        """Visit Type.
-        Users can customized this function to overwrite VisitType(const Type& t) on the C++ side.
-
-        Parameters
-        ----------
-        t : Type
-            The Type to be visited.
-        """
-        # Using self._outer() to ref _PyExprVisitor
-        return _ffi_api.ExprVisitorVisitType(self._outer(), t)  # type: ignore
-
     def visit_span(self, span: Span) -> None:
         """Visit Span.
         Users can customized this function to overwrite VisitSpan(const Span& span) on the C++ side.
@@ -833,7 +817,6 @@ class _PyExprMutator(Object):
         f_visit_var_def: Callable = None,
         f_visit_var_def_: Callable = None,
         f_visit_dataflow_var_def_: Callable = None,
-        f_visit_type: Callable = None,
         f_visit_span: Callable = None,
     ) -> None:
         """Constructor."""
@@ -867,7 +850,6 @@ class _PyExprMutator(Object):
             f_visit_var_def,
             f_visit_var_def_,
             f_visit_dataflow_var_def_,
-            f_visit_type,
             f_visit_span,
         )
 
@@ -975,7 +957,6 @@ class PyExprMutator:
             "visit_var_def",
             "visit_var_def_",
             "visit_dataflow_var_def_",
-            "visit_type",
             "visit_span",
         ],
     }
@@ -1435,23 +1416,6 @@ class PyExprMutator:
         """
         # Using self._outer() to ref _PyExprMutator
         return _ffi_api.ExprMutatorVisitVarDef(self._outer(), var)  # type: ignore
-
-    def visit_type(self, t: Type) -> Type:
-        """Visit Type.
-        Users can customized this function to overwrite VisitType(const Type& t) on the C++ side.
-
-        Parameters
-        ----------
-        t : Type
-            The Type to be visited.
-
-        Returns
-        -------
-        result : Type
-            The type after transformation.
-        """
-        # Using self._outer() to ref _PyExprMutator
-        return _ffi_api.ExprMutatorVisitType(self._outer(), t)  # type: ignore
 
     def visit_span(self, span: Span) -> Span:
         """Visit Span.

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -232,8 +232,6 @@ void ExprVisitor::VisitExpr_(const StringImmNode* op) { this->VisitSpan(op->span
 
 void ExprVisitor::VisitExpr_(const DataTypeImmNode* op) { this->VisitSpan(op->span); }
 
-void ExprVisitor::VisitType(const Type& t) {}
-
 void ExprVisitor::VisitSpan(const Span& span) {}
 
 void ExprVisitor::VisitPrimExpr(const PrimExpr& expr) {}
@@ -542,8 +540,6 @@ BindingBlock ExprMutatorBase::VisitBindingBlock(const BindingBlock& block) {
   }
 }
 
-Type ExprMutatorBase::VisitType(const Type& t) { return t; }
-
 PrimExpr ExprMutatorBase::VisitPrimExpr(const PrimExpr& expr) { return expr; }
 
 // ==================
@@ -828,11 +824,6 @@ TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitVarDef")
       visitor->ExprVisitor::VisitVarDef(var);
     });
 
-TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitType")
-    .set_body_typed([](PyExprVisitor visitor, const Type& type) {
-      visitor->ExprVisitor::VisitType(type);
-    });
-
 TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitSpan")
     .set_body_typed([](PyExprVisitor visitor, const Span& span) {
       visitor->ExprVisitor::VisitSpan(span);
@@ -878,11 +869,6 @@ TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitBindingBlock")
 TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitVarDef")
     .set_body_typed([](PyExprMutator mutator, const Var& var) {
       return mutator->ExprMutator::VisitVarDef(var);
-    });
-
-TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitType")
-    .set_body_typed([](PyExprMutator mutator, const Type& type) {
-      return mutator->ExprMutator::VisitType(type);
     });
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitExprPostOrder")


### PR DESCRIPTION
This PR is part of the `sinfo_args` switch, as tracked by #377.

This PR removes VisitType from ExprFunctor in Relax, as Type is no longer a standalone construct in any Relax AST, with the switch of `sinfo_args` introduced by #379.