### PR TITLE
[Refactor][AST] `sinfo_args` A3: Well-formed check

### DIFF
--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -245,6 +245,10 @@ class WellFormedChecker : public relax::ExprVisitor,
       }
     }
 
+    for (const StructInfo& sinfo_arg : op->sinfo_args) {
+      this->VisitStructInfo(sinfo_arg);
+    }
+
     CheckStructInfo(op);
   }
 


### PR DESCRIPTION
This PR is the last part of the `sinfo_args` switch tracked by #377, which adds the StructInfo check in well-formed check, to ensure that the StructInfo in `sinfo_args` does not refer to any undefined symbolic variables.