### PR TITLE
[Pass] Rewrite dataflow reshape

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -288,6 +288,21 @@ TVM_DLL bool WellFormed(IRModule m, bool check_struct_info = true);
 TVM_DLL relay::OpPatternKind AnalyzeOpPatternKind(const tir::PrimFunc& func);
 
 /*!
+ * \brief Check if the given PrimFunc is essentially doing a reshape operation.
+ * The reshape operation also includes expand_dims, squeeze, flatten, etc.
+ * \details Here the allowed reshape pattern is: for example, assume the operation is
+ *  `B[l_0, l_1, ..., l_b] = A[r_0, r_1, ..., r_a]`, we check if we can prove that the flattened
+ * index of l_0, ..., l_b under buffer B equals to the flattened index of r_0, ..., r_a under
+ * buffer A.
+ * \param func The function to be examined.
+ * \return A boolean indicating if the given PrimFunc is doing a reshape.
+ * \note According to the description above, the returned result can only be false-negative and
+ * cannot be false-positive, since whenever we cannot prove the equality, we return false. This
+ * property guarantees the safety of this function.
+ */
+TVM_DLL bool HasReshapePattern(const tir::PrimFunc& func);
+
+/*!
  * \brief Gather all shape variables from expression expr.
  *
  * This analysis is intended to be called on shape expressions (those set as the shape_ of another

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -102,6 +102,16 @@ TVM_DLL Pass ToNonDataflow();
 TVM_DLL Pass CallTIRRewrite();
 
 /*!
+ * \brief Convert all reshape-like call_tir to VM reshape operator call.
+ * The VM reshape operator calls will be further lowered to a CreateView
+ * operation at runtime, instead of doing real data copy.
+ * Here "reshape-like" includes reshape, expand_dims, flatten, etc.
+ *
+ * \return The Pass.
+ */
+TVM_DLL Pass RewriteDataflowReshape();
+
+/*!
  * \brief Attach global_symbol to Relax functions and TIR Primfuncs for codegen.
  *
  * \return The Pass.

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -207,6 +207,35 @@ def well_formed(mod: tvm.IRModule, check_struct_info: bool = True) -> bool:
     return _ffi_api.well_formed(mod, check_struct_info)  # type: ignore
 
 
+def has_reshape_pattern(func: tir.PrimFunc) -> bool:
+    """Check if the given PrimFunc is essentially doing a reshape operation.
+    The reshape operation also includes expand_dims, squeeze, flatten, etc.
+
+    Here the allowed reshape pattern is: for example, assume the operation is
+    `B[l_0, l_1, ..., l_b] = A[r_0, r_1, ..., r_a]`, we check if we can prove
+    that the flattened index of l_0, ..., l_b under buffer B equals to the
+    flattened index of r_0, ..., r_a under buffer A.
+
+    Parameters
+    ----------
+    func : tir.PrimFunc
+        The function to be examined.
+
+    Returns
+    -------
+    ret : bool
+        A boolean indicating if the given PrimFunc is doing a reshape.
+
+    Notes
+    -----
+    According to the description above, the returned result can only be
+    false-negative and cannot be false-positive, since whenever we cannot
+    prove the equality, we return false. This property guarantees the safety
+    of this function.
+    """
+    return _ffi_api.has_reshape_pattern(func)  # type: ignore
+
+
 def get_var2val(func: Function) -> Dict[Var, Expr]:
     """
     Get a mapping from Var to Expr for each variable in the function.

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -101,6 +101,19 @@ def CallTIRRewrite() -> tvm.ir.transform.Pass:
     return _ffi_api.CallTIRRewrite()  # type: ignore
 
 
+def RewriteDataflowReshape() -> tvm.ir.transform.Pass:
+    """Convert all reshape-like call_tir to VM reshape operator call.
+    The VM reshape operator calls will be further lowered to a CreateView
+    operation at runtime, instead of doing real data copy.
+    Here "reshape-like" includes reshape, expand_dims, flatten, etc.
+
+    Returns
+    -------
+    ret : tvm.ir.transform.Pass
+    """
+    return _ffi_api.RewriteDataflowReshape()  # type: ignore
+
+
 def VMBuiltinLower() -> tvm.ir.transform.Pass:
     """Lowering generic intrinsic to VM intrinsics.
 

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -581,7 +581,9 @@ def build(
     if isinstance(target, str):
         target = tvm.target.Target(target)
 
-    passes = [relax.transform.ToNonDataflow()]
+    passes = []
+    passes.append(relax.transform.RewriteDataflowReshape())
+    passes.append(relax.transform.ToNonDataflow())
     passes.append(relax.transform.CallTIRRewrite())
     passes.append(relax.transform.VMBuiltinLower())
     passes.append(relax.transform.VMShapeLower())

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -129,6 +129,10 @@ bool Analyzer::CanProve(const PrimExpr& expr) {
 PrimExpr Analyzer::Simplify(const PrimExpr& expr, int steps) {
   PrimExpr res = expr;
 
+  // Always starts with a canonical simplification, as some structural property
+  // of an expression might be destroyed by rewrite simplification.
+  res = this->canonical_simplify(res);
+
   for (int i = 0; i < steps; ++i) {
     if (tir::is_const_int(res)) {
       return res;

--- a/src/relax/transform/rewrite_dataflow_reshape.cc
+++ b/src/relax/transform/rewrite_dataflow_reshape.cc
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file src/relax/transform/rewrite_dataflow_reshape.cc
+ * \brief Transform all reshape within dataflow block to a specialized reshape operator
+ */
+#include <tvm/relax/analysis.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+
+namespace tvm {
+namespace relax {
+
+class DataflowReshapeRewriter : public ExprMutator {
+ public:
+  explicit DataflowReshapeRewriter(const IRModule& mod) : mod_(mod) {}
+
+ private:
+  BindingBlock VisitBindingBlock(const BindingBlock& block) final {
+    // We only rewrite the bindings inside dataflow blocks.
+    if (const auto* dataflow_block = block.as<DataflowBlockNode>()) {
+      return VisitBindingBlock_(dataflow_block);
+    } else {
+      return block;
+    }
+  }
+
+  void VisitBinding_(const VarBindingNode* binding) final {
+    // We only rewrite the bindings that are not dataflow output (which means they are not
+    // externally referenced)
+    if (!binding->var->IsInstance<DataflowVarNode>()) {
+      this->builder_->EmitNormalized(GetRef<VarBinding>(binding));
+    } else {
+      ExprMutator::VisitBinding_(binding);
+    }
+  }
+
+  Expr VisitExpr_(const CallNode* call) final {
+    if (!IsCallingTIRReshape(call)) {
+      return GetRef<Call>(call);
+    }
+    static const ExternFunc& vm_builtin_reshape = ExternFunc("vm.builtin.reshape");
+    Array<Expr> args = Downcast<Tuple>(call->args[1])->fields;
+    ICHECK_EQ(args.size(), 1);
+    TensorStructInfo res_sinfo = Downcast<TensorStructInfo>(call->struct_info_);
+    ShapeExpr new_shape = Downcast<ShapeExpr>(res_sinfo->shape);
+    return Call(vm_builtin_reshape, {args[0], new_shape}, Attrs(), {res_sinfo});
+  }
+
+  bool IsCallingTIRReshape(const CallNode* call) {
+    static const Op& call_tir_op = Op::Get("relax.call_tir");
+    if (call->op != call_tir_op) {
+      return false;
+    }
+    GlobalVar gv = Downcast<GlobalVar>(call->args[0]);
+    const auto* func = mod_->functions.Get(gv).as<tir::PrimFuncNode>();
+    ICHECK_NOTNULL(func);
+    return HasReshapePattern(GetRef<tir::PrimFunc>(func));
+  }
+
+  const IRModule& mod_;
+};
+
+Expr RewriteDataflowReshape(const Function& f, const IRModule& mod) {
+  return DataflowReshapeRewriter(mod)(f);
+}
+
+namespace transform {
+
+Pass RewriteDataflowReshape() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
+      [=](Function f, IRModule m, PassContext pc) {
+        return Downcast<Function>(RewriteDataflowReshape(f, m));
+      };
+  return CreateFunctionPass(pass_func, 0, "RewriteDataflowReshape", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.RewriteDataflowReshape")
+    .set_body_typed(RewriteDataflowReshape);
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -321,6 +321,10 @@ TVM_REGISTER_GLOBAL("vm.builtin.copy").set_body([](TVMArgs args, TVMRetValue* rv
   *rv = args[0];
 });
 
+TVM_REGISTER_GLOBAL("vm.builtin.reshape").set_body_typed([](NDArray data, ShapeTuple new_shape) {
+  return data.CreateView(new_shape, data->dtype);
+});
+
 /*!
  * \brief Load the scalar value in cond and return the result value.
  * \param cond The condition

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -16,23 +16,24 @@
 # under the License.
 
 from typing import List, Set, Union
-import pytest
 
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm import relax as rx
 from tvm.relax.analysis import (
-    udchain,
-    remove_all_unused,
-    name_to_binding,
-    shape_vars,
-    all_vars,
-    free_vars,
-    bound_vars,
     all_global_vars,
+    all_vars,
+    bound_vars,
     called_global_vars,
+    free_vars,
+    has_reshape_pattern,
+    name_to_binding,
+    remove_all_unused,
+    shape_vars,
+    udchain,
 )
-from tvm.script import relax as R
+from tvm.script import relax as R, tir as T
 
 
 def var_name_set(vars: List[Union[rx.Var, rx.GlobalVar]]) -> Set[str]:
@@ -369,5 +370,148 @@ def test_called_global_vars():
     assert call_vars[0].name_hint == "gv1"
 
 
+def test_reshape_pattern_reshape():
+    @T.prim_func
+    def reshape(
+        rxplaceholder: T.Buffer[(1, 2, 3, 4), "float32"],
+        T_reshape: T.Buffer[(8, 3), "float32"],
+    ):
+        for i0, i1 in T.grid(8, 3):
+            with T.block("T_reshape"):
+                ax0, ax1 = T.axis.remap("SS", [i0, i1])
+                T.reads(
+                    rxplaceholder[
+                        (ax0 * 3 + ax1) // 24,
+                        (ax0 * 3 + ax1) % 24 // 12,
+                        (ax0 * 3 + ax1) % 12 // 4,
+                        (ax0 * 3 + ax1) % 4,
+                    ]
+                )
+                T.writes(T_reshape[ax0, ax1])
+                T_reshape[ax0, ax1] = rxplaceholder[
+                    (ax0 * 3 + ax1) // 24,
+                    (ax0 * 3 + ax1) % 24 // 12,
+                    (ax0 * 3 + ax1) % 12 // 4,
+                    (ax0 * 3 + ax1) % 4,
+                ]
+
+    assert has_reshape_pattern(reshape)
+
+
+def test_reshape_pattern_reshape_scheduled():
+    @T.prim_func
+    def reshape_scheduled(
+        rxplaceholder: T.Buffer[(1, 2, 3, 4), "float32"],
+        T_reshape: T.Buffer[(8, 3), "float32"],
+    ):
+        for i0_i1_fused_0 in T.thread_binding(1, thread="blockIdx.x"):
+            for i0_i1_fused_1 in T.thread_binding(24, thread="threadIdx.x"):
+                with T.block("T_reshape"):
+                    ax0 = T.axis.spatial(8, (i0_i1_fused_0 * 24 + i0_i1_fused_1) // 3)
+                    ax1 = T.axis.spatial(3, (i0_i1_fused_0 * 24 + i0_i1_fused_1) % 3)
+                    T.reads(
+                        rxplaceholder[
+                            (ax0 * 3 + ax1) // 24,
+                            (ax0 * 3 + ax1) % 24 // 12,
+                            (ax0 * 3 + ax1) % 12 // 4,
+                            (ax0 * 3 + ax1) % 4,
+                        ]
+                    )
+                    T.writes(T_reshape[ax0, ax1])
+                    T_reshape[ax0, ax1] = rxplaceholder[
+                        (ax0 * 3 + ax1) // 24,
+                        (ax0 * 3 + ax1) % 24 // 12,
+                        (ax0 * 3 + ax1) % 12 // 4,
+                        (ax0 * 3 + ax1) % 4,
+                    ]
+
+    assert has_reshape_pattern(reshape_scheduled)
+
+
+def test_reshape_pattern_expand_dims():
+    @T.prim_func
+    def expand_dims(
+        rxplaceholder: T.Buffer[(2, 3, 4), "float32"],
+        expand_dims: T.Buffer[(2, 1, 1, 1, 3, 1, 4, 1), "float32"],
+    ):
+        T.func_attr({"tir.noalias": True})
+        for i0, i1, i2, i3, i4, i5, i6, i7 in T.grid(2, 1, 1, 1, 3, 1, 4, 1):
+            with T.block("expand_dims"):
+                i0_1, i1_1, i2_1, i3_1, i4_1, i5_1, i6_1, i7_1 = T.axis.remap(
+                    "SSSSSSSS", [i0, i1, i2, i3, i4, i5, i6, i7]
+                )
+                T.reads(rxplaceholder[i0_1, i4_1, i6_1])
+                T.writes(expand_dims[i0_1, i1_1, i2_1, i3_1, i4_1, i5_1, i6_1, i7_1])
+                expand_dims[i0_1, i1_1, i2_1, i3_1, i4_1, i5_1, i6_1, i7_1] = rxplaceholder[
+                    i0_1, i4_1, i6_1
+                ]
+
+    assert has_reshape_pattern(expand_dims)
+
+
+def test_reshape_pattern_with_raggedness():
+    @T.prim_func
+    def reshape_raggedness(
+        A: T.Buffer[(100, 768), "float32"],
+        src_indptr: T.Buffer[(9,), "int32"],
+        B: T.Buffer[(100, 12, 64), "float32"],
+    ):
+        for b in T.serial(8):
+            with T.block("block0"):
+                vb = T.axis.spatial(8, b)
+                for i in T.serial(src_indptr[vb + 1] - src_indptr[vb]):
+                    for h in T.serial(12):
+                        for f in T.serial(64):
+                            with T.block("block1"):
+                                vi, vh, vf = T.axis.remap("SSS", [i, h, f])
+                                B[src_indptr[vb] + vi, vh, vf] = A[
+                                    src_indptr[vb] + vi, vh * 64 + vf
+                                ]
+
+    assert has_reshape_pattern(reshape_raggedness)
+
+
+def test_reshape_pattern_reject_seqstmt():
+    @T.prim_func
+    def identity_bias(A: T.Buffer[(4, 4), "float32"], B: T.Buffer[(4, 4), "float32"]):
+        C = T.alloc_buffer((128, 128), "float32")
+        for i0, i1 in T.grid(4, 4):
+            with T.block("identity"):
+                vi0, vi1 = T.axis.remap("SS", [i0, i1])
+                C[vi0, vi1] = A[vi0, vi1]
+        for i0, i1 in T.grid(4, 4):
+            with T.block("identity"):
+                vi0, vi1 = T.axis.remap("SS", [i0, i1])
+                B[vi0, vi1] = C[vi0, vi1] + T.float32(1)
+
+    @T.prim_func
+    def identity_identity(A: T.Buffer[(4, 4), "float32"], B: T.Buffer[(4, 4), "float32"]):
+        C = T.alloc_buffer((128, 128), "float32")
+        for i0, i1 in T.grid(4, 4):
+            with T.block("identity"):
+                vi0, vi1 = T.axis.remap("SS", [i0, i1])
+                C[vi0, vi1] = A[vi0, vi1]
+        for i0, i1 in T.grid(4, 4):
+            with T.block("identity"):
+                vi0, vi1 = T.axis.remap("SS", [i0, i1])
+                B[vi0, vi1] = C[vi0, vi1]
+
+    assert not has_reshape_pattern(identity_bias)
+    assert not has_reshape_pattern(identity_identity)
+
+
+def test_reshape_pattern_reject_reduction():
+    @T.prim_func
+    def reduction(A: T.Buffer[(4, 4), "float32"], B: T.Buffer[(4,), "float32"]):
+        for i0, i1 in T.grid(4, 4):
+            with T.block("identity"):
+                vi0, vi1 = T.axis.remap("SR", [i0, i1])
+                with T.init():
+                    B[vi0] = T.float32(0)
+                B[vi0] = B[vi0] + A[vi0, vi1]
+
+    assert not has_reshape_pattern(reduction)
+
+
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
+++ b/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
@@ -1,0 +1,171 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+from tvm import relax
+from tvm.script import relax as R, tir as T
+
+
+def test_reshape_expand_dims():
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def reshape(
+            rxplaceholder: T.Buffer[(T.int64(8), T.int64(3)), "float32"],
+            T_reshape: T.Buffer[(T.int64(2), T.int64(4), T.int64(3)), "float32"],
+        ):
+            for ax0, ax1, ax2 in T.grid(T.int64(2), T.int64(4), T.int64(3)):
+                with T.block("T_reshape"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        rxplaceholder[
+                            (v_ax0 * 12 + v_ax1 * 3 + v_ax2) // T.int64(3),
+                            (v_ax1 * 12 + v_ax2 * 3 + v_ax2) % T.int64(3),
+                        ]
+                    )
+                    T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+                    T_reshape[v_ax0, v_ax1, v_ax2] = rxplaceholder[
+                        (v_ax0 * 12 + v_ax1 * 3 + v_ax2) // T.int64(3),
+                        (v_ax1 * 12 + v_ax2 * 3 + v_ax2) % T.int64(3),
+                    ]
+
+        @T.prim_func
+        def expand_dims(
+            rxplaceholder: T.Buffer[(T.int64(2), T.int64(4), T.int64(3)), "float32"],
+            expand_dims: T.Buffer[
+                (T.int64(2), T.int64(1), T.int64(4), T.int64(1), T.int64(3)),
+                "float32",
+            ],
+        ):
+            for i0, i1, i2, i3, i4 in T.grid(
+                T.int64(2), T.int64(1), T.int64(4), T.int64(1), T.int64(3)
+            ):
+                with T.block("expand_dims"):
+                    i0_1, i1_1, i2_1, i3_1, i4_1 = T.axis.remap("SSSSS", [i0, i1, i2, i3, i4])
+                    T.reads(rxplaceholder[i0_1, i2_1, i4_1])
+                    T.writes(expand_dims[i0_1, i1_1, i2_1, i3_1, i4_1])
+                    expand_dims[i0_1, i1_1, i2_1, i3_1, i4_1] = rxplaceholder[i0_1, i2_1, i4_1]
+
+        @R.function
+        def main(
+            x: R.Tensor((8, 3), dtype="float32")
+        ) -> R.Tensor((2, 1, 4, 1, 3), dtype="float32"):
+            with R.dataflow():
+                y = R.call_tir(reshape, (x,), out_sinfo=R.Tensor((2, 4, 3), dtype="float32"))
+                z = R.call_tir(expand_dims, (y,), out_sinfo=R.Tensor((2, 1, 4, 1, 3), "float32"))
+                R.output(z)
+            return z
+
+    @tvm.script.ir_module
+    class Expected:
+        @T.prim_func
+        def reshape(
+            rxplaceholder: T.Buffer[(T.int64(8), T.int64(3)), "float32"],
+            T_reshape: T.Buffer[(T.int64(2), T.int64(4), T.int64(3)), "float32"],
+        ):
+            for ax0, ax1, ax2 in T.grid(T.int64(2), T.int64(4), T.int64(3)):
+                with T.block("T_reshape"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        rxplaceholder[
+                            (v_ax0 * T.int64(12) + v_ax1 * T.int64(3) + v_ax2) // T.int64(3),
+                            (v_ax1 * T.int64(12) + v_ax2 * T.int64(3) + v_ax2) % T.int64(3),
+                        ]
+                    )
+                    T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+                    T_reshape[v_ax0, v_ax1, v_ax2] = rxplaceholder[
+                        (v_ax0 * T.int64(12) + v_ax1 * T.int64(3) + v_ax2) // T.int64(3),
+                        (v_ax1 * T.int64(12) + v_ax2 * T.int64(3) + v_ax2) % T.int64(3),
+                    ]
+
+        @T.prim_func
+        def expand_dims(
+            rxplaceholder: T.Buffer[(T.int64(2), T.int64(4), T.int64(3)), "float32"],
+            expand_dims: T.Buffer[
+                (T.int64(2), T.int64(1), T.int64(4), T.int64(1), T.int64(3)), "float32"
+            ],
+        ):
+            for i0, i1, i2, i3, i4 in T.grid(
+                T.int64(2), T.int64(1), T.int64(4), T.int64(1), T.int64(3)
+            ):
+                with T.block("expand_dims"):
+                    i0_1, i1_1, i2_1, i3_1, i4_1 = T.axis.remap("SSSSS", [i0, i1, i2, i3, i4])
+                    T.reads(rxplaceholder[i0_1, i2_1, i4_1])
+                    T.writes(expand_dims[i0_1, i1_1, i2_1, i3_1, i4_1])
+                    expand_dims[i0_1, i1_1, i2_1, i3_1, i4_1] = rxplaceholder[i0_1, i2_1, i4_1]
+
+        @R.function
+        def main(
+            x: R.Tensor((8, 3), dtype="float32")
+        ) -> R.Tensor((2, 1, 4, 1, 3), dtype="float32"):
+            with R.dataflow():
+                y = R.call_packed(
+                    "vm.builtin.reshape",
+                    x,
+                    (2, 4, 3),
+                    sinfo_args=R.Tensor((2, 4, 3), "float32"),
+                )
+                # Note: `z` is the output var of the dataflow block, and is thus
+                # not expected to be rewritten.
+                z = R.call_tir(
+                    expand_dims, (y,), out_sinfo=R.Tensor((2, 1, 4, 1, 3), dtype="float32")
+                )
+                R.output(z)
+            return z
+
+    assert relax.analysis.has_reshape_pattern(Module["expand_dims"])
+    mod = relax.transform.RewriteDataflowReshape()(Module)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_reshape_non_dataflow():
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def reshape(
+            rxplaceholder: T.Buffer[(T.int64(8), T.int64(3)), "float32"],
+            T_reshape: T.Buffer[(T.int64(2), T.int64(4), T.int64(3)), "float32"],
+        ):
+            for ax0, ax1, ax2 in T.grid(T.int64(2), T.int64(4), T.int64(3)):
+                with T.block("T_reshape"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        rxplaceholder[
+                            (v_ax0 * 12 + v_ax1 * 3 + v_ax2) // T.int64(3),
+                            (v_ax1 * 12 + v_ax2 * 3 + v_ax2) % T.int64(3),
+                        ]
+                    )
+                    T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+                    T_reshape[v_ax0, v_ax1, v_ax2] = rxplaceholder[
+                        (v_ax0 * 12 + v_ax1 * 3 + v_ax2) // T.int64(3),
+                        (v_ax1 * 12 + v_ax2 * 3 + v_ax2) % T.int64(3),
+                    ]
+
+        @R.function
+        def main(x: R.Tensor((8, 3), dtype="float32")) -> R.Tensor((2, 4, 3), dtype="float32"):
+            y = R.call_tir(reshape, (x,), out_sinfo=R.Tensor((2, 4, 3), dtype="float32"))
+            return y
+
+    assert relax.analysis.has_reshape_pattern(Module["reshape"])
+    # The binding var of the call_tir is not a DataflowVar. So the pass does no change.
+    mod = relax.transform.RewriteDataflowReshape()(Module)
+    tvm.ir.assert_structural_equal(mod, Module)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR introduces the dataflow reshape rewrite pass, which transform all dataflow TIR reshape bindings inside a Relax function into a call of runtime packed function `relax.vm.builtin.reshape`. Here “dataflow TIR reshape bindings” means
1. the binding value is a `call_tir` of any PrimFunc that is essentially doing a reshape operation,
2. the binding var is a DataflowVar, or in other words, the binding is inside a DataflowBlock and the binding var is not a block output var.

The `relax.vm.builtin.reshape` packed function creates a view of the input NDArray with the target shape, instead of doing data copy.

In order to fulfill this pass, this PR contains the following parts.
1. An analysis function that detects the reshape pattern of PrimFuncs.
2. The dataflow reshape rewrite pass itself.
3. The implementation of `relax.vm.builtin.reshape` as a PackedFunc.

This PR contains unit tests for each part.