### PR TITLE
[Fix][Util] Type comparison in auto arg converter

### DIFF
--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -249,9 +249,9 @@ class _ArgsConverter:
 
         for param in sig.parameters.values():
             anno = param.annotation
-            if anno is Expr or anno is Optional[Expr]:
+            if anno in (Expr, Optional[Expr]):
                 args_to_expr.append(param.name)
-            elif anno is List[Expr] or anno is Optional[List[Expr]]:
+            if anno in (List[Expr], Optional[List[Expr]]):
                 args_to_list_expr.append(param.name)
 
         return _ArgsConverter.convert(args_to_expr, args_to_list_expr)(func)


### PR DESCRIPTION
Previously when running all relax unit tests on my machine using `pytest test_*`, one auto argument converter tests always fail. (And when I only run that single test, it passes very well.)

After inspection, I noted that in the failed test, though `anno` is printed as `typing.Optional[tvm.ir.expr.RelayExpr]`, the comparison below `anno is Optional[Expr]` still results false.
https://github.com/tlc-pack/relax/blob/2e5e47962238be7385486241203d1a8146f38a0e/python/tvm/relax/utils.py#L252-L253

I tweaked the comparison to `in` and all tests seem to pass very successfully. I guess the issue might relate to some address issue (?) but I’m not 100% sure about this.

cc @Hzfengsy 