### PR TITLE
[Fix] Printer support for PrimValue, StringImm, DataTypeImm

### DIFF
--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -613,7 +613,10 @@ class TextPrinter {
                                   node->IsInstance<relax::BindingNode>() ||       //
                                   node->IsInstance<relax::BindingBlockNode>() ||  //
                                   node->IsInstance<relax::SeqExprNode>() ||       //
-                                  node->IsInstance<relax::ExternFuncNode>())) {
+                                  node->IsInstance<relax::ExternFuncNode>() ||    //
+                                  node->IsInstance<relax::PrimValueNode>() ||     //
+                                  node->IsInstance<relax::StringImmNode>() ||     //
+                                  node->IsInstance<relax::DataTypeImmNode>())) {
       doc << relax_text_printer_.Print(node);
     } else {
       doc << relay_text_printer_.PrintFinal(node);

--- a/tests/python/relax/test_printer.py
+++ b/tests/python/relax/test_printer.py
@@ -593,5 +593,20 @@ def test_extern_func_pretty_print():
     assert extern_func.__str__() == '"my_func"'
 
 
+def test_primvalue_pretty_print():
+    int_prim_value = relax.PrimValue(1)
+    assert int_prim_value.__str__() == "R.prim_value(1)"
+
+
+def test_stringimm_pretty_print():
+    strimm = relax.StringImm("test")
+    assert strimm.__str__() == 'R.str("test")'
+
+
+def test_dtypeimm_pretty_print():
+    dtypeimm = relax.DataTypeImm("float32")
+    assert dtypeimm.__str__() == 'R.dtype("float32")'
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR supports printing out PrimValue, StringImm, DataTypeImm using PrettyPrint, which will be used on Python side printing and sometimes C++ side printing.