### PR TITLE
[Debugging] Support `PrimValue`, `StringImm`, and `DataTypeImm` in the AST printer

### DIFF
--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -200,6 +200,15 @@ class ASTPrinter(ExprFunctor):
             false_branch=self.visit_expr(op.false_branch),
         )
 
+    def visit_prim_value_(self, op: relax.PrimValue) -> str:
+        return self.build_expr(op, "PrimValue", value=self.visit_prim_expr_(op.value))
+
+    def visit_string_imm_(self, op: relax.StringImm) -> str:
+        return self.build_expr(op, "StringImm", value=wrap_quotes(op.value))
+
+    def visit_data_type_imm_(self, op: relax.DataTypeImm) -> str:
+        return self.build_expr(op, "DataTypeImm", value=op.value)
+
     def visit_op_(self, op: tvm.ir.Op) -> str:
         # TODO: List other attributes?
         # op is not actually a Relax expr and does not have checked_type_
@@ -228,6 +237,8 @@ class ASTPrinter(ExprFunctor):
             return self.build_ast_node("ObjectType")
         if isinstance(type_node, relax.PackedFuncType):
             return self.build_ast_node("PackedFuncType")
+        if isinstance(type_node, tvm.ir.PrimType):
+            return self.build_ast_node("PrimType", dtype=type_node.dtype)
         if isinstance(type_node, relax.DynTensorType):
             fields = {}
             if type_node.ndim is not None:

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -586,5 +586,47 @@ def test_tuple_get_item():
     assert "index=0" in body_str
 
 
+def test_prim_value():
+    prim_value = rx.PrimValue(tir.IntImm("int64", 1))
+    prim_str = strip_whitespace(dump_ast(prim_value))
+    assert prim_str == strip_whitespace(
+        """
+        PrimValue(
+            value=PrimExpr(value=`1i64`),
+            struct_info=PrimStructInfo(dtype=int64),
+            checked_type_=PrimType(dtype=int64)
+        )
+    """
+    )
+
+
+def test_string_imm():
+    string_imm = rx.StringImm("test")
+    str_str = strip_whitespace(dump_ast(string_imm))
+    assert str_str == strip_whitespace(
+        """
+        StringImm(
+            value="test",
+            struct_info=ObjectStructInfo(),
+            checked_type_=ObjectType()
+        )
+    """
+    )
+
+
+def test_datatype_imm():
+    data_type_imm = rx.DataTypeImm("int32")
+    data_type_str = strip_whitespace(dump_ast(data_type_imm))
+    assert data_type_str == strip_whitespace(
+        """
+        DataTypeImm(
+            value=int32,
+            struct_info=ObjectStructInfo(),
+            checked_type_=ObjectType()
+        )
+    """
+    )
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR adds support for printing the newly added expressions `PrimValue`, `StringImm`, and `DataTypeImm` in the AST printer.