### PR TITLE
Allow keeping bound constants in OperatorFusor (rather than lifting to parameters)

### DIFF
--- a/src/relax/transform/utils.h
+++ b/src/relax/transform/utils.h
@@ -109,12 +109,14 @@ inline std::string GetExtSymbol(const Function& func) {
  * \param partition A mapping from a subexpression to the containing group.
  * \param create_single_binding_function Whether or not to create a grouped function for a group
  *  containing a single binding.
+ * \param create_single_binding_function Whether or not to lift bound constants to parameters of the
+ * grouped function.
  * \return A new module containing grouped functions.
  */
 IRModule MakeGroupedFunctions(
     IRModule mod,
     const std::unordered_map<const Object*, relay::GraphPartitioner::Group*>& partition,
-    bool create_single_binding_function = false);
+    bool create_single_binding_function = false, bool lift_constants = true);
 
 }  // namespace relax
 }  // namespace tvm


### PR DESCRIPTION
While working on TensorRT BYOC, I found that the TensorRT runtime requires the weight tensor to be passed as a constant at compile time. So we need to use `BindParams` before partitioning, but currently it results in the following IR:
```
@tvm.script.ir_module
class Module:
    @R.function
    def main(data: R.Tensor((1, 64, 56, 56), dtype="float32")) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
        # block 0
        with R.dataflow():
            gv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu(data, metadata["relax.expr.Constant"][0])
            R.output(gv)
        return gv
        
    @R.function
    def fused_relax_nn_conv2d_relax_nn_relu(data1: R.Tensor((1, 64, 56, 56), dtype="float32"), param_0: R.Tensor((64, 64, 3, 3), dtype="float32")) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
      ...
```

Instead, what we need for BYOC is:
```
@tvm.script.ir_module
class Module:
    @R.function
    def main(data: R.Tensor((1, 64, 56, 56), dtype="float32")) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
        # block 0
        with R.dataflow():
            gv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu(data)
            R.output(gv)
        return gv
        
    @R.function
    def fused_relax_nn_conv2d_relax_nn_relu(data1: R.Tensor((1, 64, 56, 56), dtype="float32")) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
        # function attr dict
        R.func_attr({"Primitive": 1, "Composite": "dnnl.conv2d_relu"})
        # block 0
        with R.dataflow():
            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.conv2d(data1, metadata["relax.expr.Constant"][0], strides=[1, 1], padding=[1, 1, 1, 1], dilation=[1, 1], groups=1, data_layout="NCHW", kernel_layout="OIHW", out_layout="NCHW", out_dtype="")
            gv1: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.relu(lv)
            R.output(gv1)
```

This PR adds an option to `OperatorFusor`, to allow keeping bound constants in the original position rather than lifting them to parameters. This is used when `OperatorFusor` is used by the `FuseOpsByPattern` pass. 

@Hzfengsy @tqchen 