### PR TITLE
[Fix][Pass] TIR op pattern kind analysis with int var in signature

### DIFF
--- a/src/relax/analysis/tir_op_pattern_kind.cc
+++ b/src/relax/analysis/tir_op_pattern_kind.cc
@@ -32,7 +32,10 @@ class PatternKindAnalyzer : public StmtExprVisitor {
  public:
   explicit PatternKindAnalyzer(const tir::PrimFunc& func) {
     for (const tir::Var& param : func->params) {
-      param_buffers_.insert(func->buffer_map.Get(param).value());
+      Optional<Buffer> param_buf = func->buffer_map.Get(param);
+      if (param_buf.defined()) {
+        param_buffers_.insert(param_buf.value());
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug in TIR pattern kind analyzer.

Previously the analyzer requires the input TIR function signature not to have any symbolic var other than Buffer var. This behavior will throw exception whenever the input TIR function signature contains integer var or other var, while the expected behavior is to ignore these vars instead of throwing error. This PR fixes this issue.