### PR TITLE
[BYOC] Update TensorRT backend for the new BYOC flow and offloading with constants

### DIFF
--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -592,9 +592,15 @@ def build(
     new_mod = seq(mod)
 
     # Extract external runtime modules if exist.
-    ext_libs = []
-    if mod.attrs and "external_mods" in mod.attrs:
-        ext_libs = mod.attrs["external_mods"]
+    attrs = dict(mod.attrs) if mod.attrs else {}
+
+    ext_libs = attrs.get("external_mods", [])
+    constants = attrs.get("const_name_to_constant", {})
+
+    if params is not None:
+        params.update(dict(constants))
+    else:
+        params = constants
 
     # builder collects the executable
     builder = relax.ExecBuilder()

--- a/src/relax/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relax/backend/contrib/codegen_json/codegen_json.h
@@ -153,10 +153,10 @@ class JSONSerializer : public relax::MemoizedExprTranslator<NodeEntries> {
 
   /*!
    * \brief Constructor
-   *
-   * \param constant_names TODO
+   * \param constant_names The names of all constants in the original module.
    */
-  explicit JSONSerializer(Map<Constant, String> constant_names) : constant_names_(constant_names) {}
+  explicit JSONSerializer(const Map<Constant, String>& constant_names)
+      : constant_names_(constant_names) {}
 
   void serialize(Function func) {
     // First we convert all the parameters into input nodes.
@@ -410,10 +410,10 @@ class JSONSerializer : public relax::MemoizedExprTranslator<NodeEntries> {
   std::vector<JSONGraphObjectPtr> nodes_;
   /*! \brief Output of the JSON graph. */
   NodeEntries heads_;
-  /*! \brief The list of required constants. */
+  /*! \brief The list of required constants, ordered. */
   Array<String> constants_used_;
-  /*! \brief TODO */
-  Map<Constant, String> constant_names_;
+  /*! \brief The names of all constants in the original module. */
+  const Map<Constant, String>& constant_names_;
 };
 
 }  // namespace contrib

--- a/src/relax/backend/contrib/cutlass/codegen.cc
+++ b/src/relax/backend/contrib/cutlass/codegen.cc
@@ -250,7 +250,7 @@ class CutlassModuleCodegen {
 };
 
 Array<runtime::Module> CUTLASSCompiler(Array<Function> functions, Map<String, ObjectRef> options,
-                                       Map<Constant, String> /*unsed*/) {
+                                       Map<Constant, String> /*unused*/) {
   const auto* tune_func = runtime::Registry::Get("contrib.cutlass.tune_relax_function");
   ICHECK(tune_func != nullptr)
       << "The packed function contrib.cutlass.tune_relax_function not found, "

--- a/src/relax/backend/contrib/cutlass/codegen.cc
+++ b/src/relax/backend/contrib/cutlass/codegen.cc
@@ -249,7 +249,8 @@ class CutlassModuleCodegen {
   Array<String> func_names_;
 };
 
-Array<runtime::Module> CUTLASSCompiler(Array<Function> functions, Map<String, ObjectRef> options) {
+Array<runtime::Module> CUTLASSCompiler(Array<Function> functions, Map<String, ObjectRef> options,
+                                       Map<Constant, String> /*unsed*/) {
   const auto* tune_func = runtime::Registry::Get("contrib.cutlass.tune_relax_function");
   ICHECK(tune_func != nullptr)
       << "The packed function contrib.cutlass.tune_relax_function not found, "

--- a/src/relax/backend/contrib/dnnl/codegen.cc
+++ b/src/relax/backend/contrib/dnnl/codegen.cc
@@ -39,7 +39,7 @@ using backend::contrib::NodeEntries;
 
 class DNNLJSONSerializer : public JSONSerializer {
  public:
-  DNNLJSONSerializer(Map<Var, Expr> bindings, Map<Constant, String> constant_names)
+  DNNLJSONSerializer(Map<Constant, String> constant_names, Map<Var, Expr> bindings)
       : JSONSerializer(constant_names), bindings_(bindings) {}
 
   using JSONSerializer::VisitExpr_;
@@ -85,7 +85,7 @@ Array<runtime::Module> DNNLCompiler(Array<Function> functions, Map<String, Objec
   Array<runtime::Module> compiled_functions;
 
   for (const auto& func : functions) {
-    DNNLJSONSerializer serializer(AnalyzeVar2Value(func), constant_names);
+    DNNLJSONSerializer serializer(constant_names, AnalyzeVar2Value(func));
     serializer.serialize(func);
     auto graph_json = serializer.GetJSON();
     auto constant_names = serializer.GetConstantNames();

--- a/src/relax/backend/contrib/tensorrt/codegen.cc
+++ b/src/relax/backend/contrib/tensorrt/codegen.cc
@@ -115,7 +115,7 @@ class CollectFromCompositeFunctionBody : public ExprVisitor {
  */
 class TensorRTJSONSerializer : public JSONSerializer {
  public:
-  explicit TensorRTJSONSerializer(Map<Var, Expr> bindings, Map<Constant, String> constant_names)
+  explicit TensorRTJSONSerializer(Map<Constant, String> constant_names, Map<Var, Expr> bindings)
       : JSONSerializer(constant_names), bindings_(bindings) {}
 
   using JSONSerializer::VisitExpr_;
@@ -218,7 +218,7 @@ Array<runtime::Module> TensorRTCompiler(Array<Function> functions,
   Array<runtime::Module> compiled_functions;
   for (const auto& func : functions) {
     VLOG(1) << "TensorRT partition:" << std::endl << PrettyPrint(func);
-    TensorRTJSONSerializer serializer(AnalyzeVar2Value(func), constant_names);
+    TensorRTJSONSerializer serializer(constant_names, AnalyzeVar2Value(func));
     serializer.serialize(func);
     std::string graph_json = serializer.GetJSON();
     VLOG(1) << "TensorRT JSON:" << std::endl << graph_json;

--- a/src/relax/backend/contrib/tensorrt/codegen.cc
+++ b/src/relax/backend/contrib/tensorrt/codegen.cc
@@ -91,107 +91,13 @@ class CollectFromCompositeFunctionBody : public ExprVisitor {
 
   void VisitExpr_(const ConstantNode* constant_node) final;
   void VisitExpr_(const CallNode* call_node) final;
-  /*
-    void SetPadNodeAttribute(const CallNode* call_node) {
-      const auto* pad_attr = call_node->attrs.as<PadAttrs>();
-      ICHECK(pad_attr);
-      auto p = pad_attr->pad_width;
-      const int dim_h = (p.size() == 5) ? 3 : 2;
-      const int dim_w = (p.size() == 5) ? 4 : 3;
-      std::vector<std::string> padding = {std::to_string(p[dim_h][0].as<IntImmNode>()->value),
-                                          std::to_string(p[dim_w][0].as<IntImmNode>()->value),
-                                          std::to_string(p[dim_h][1].as<IntImmNode>()->value),
-                                          std::to_string(p[dim_w][1].as<IntImmNode>()->value)};
-      std::vector<dmlc::any> padding_attr;
-      padding_attr.emplace_back(padding);
-      node_->SetAttr("padding", padding_attr);
-    }
 
-    void SetStridedSliceNodeAttribute(const CallNode* call_node) {
-      const auto* attrs = call_node->attrs.as<StridedSliceAttrs>();
-      ICHECK(attrs && attrs->begin && attrs->end && attrs->strides)
-          << "StridedSlice must have static begin, end, and strides.";
-      const bool default_strides =
-          !attrs->strides.value().defined() || attrs->strides.value().size() == 0;
-      auto ishape = backend::GetShape(call_node->args[0]->checked_type());
+  void SetGenericAttributes(const CallNode* call_node) {
+    OpAttrExtractor extractor(node_);
+    const Object* attr_obj = call_node->attrs.get();
+    extractor.Extract(const_cast<Object*>(attr_obj));
+  }
 
-      auto process_slice_index = [](Integer x, int default_value, int dim_value) {
-        if (!x.defined()) return default_value;
-        int value = x.as<IntImmNode>()->value;
-        if (value < 0) value += dim_value;
-        return value;
-      };
-
-      std::vector<std::string> start, size, strides;
-      for (size_t i = 0; i < attrs->begin.value().size(); ++i) {
-        const int begin_value = process_slice_index(attrs->begin.value()[i], 0, ishape[i]);
-        ICHECK_GE(begin_value, 0);
-        start.push_back(std::to_string(begin_value));
-        const int stride_value = (default_strides || i >= attrs->strides.value().size() ||
-                                  !attrs->strides.value()[i].defined())
-                                     ? 1
-                                     : attrs->strides.value()[i].as<IntImmNode>()->value;
-        ICHECK_GT(stride_value, 0);
-        strides.push_back(std::to_string(stride_value));
-        int size_value;
-        if (attrs->slice_mode == "end") {
-          const int end_value = process_slice_index(attrs->end.value()[i], ishape[i], ishape[i]);
-          size_value = (end_value - begin_value + stride_value - 1) / stride_value;
-        } else if (attrs->slice_mode == "size") {
-          // with slice_mode = "size", attrs->end_value mean the size of the slice
-          int end_value = attrs->end.value()[i].as<IntImmNode>()->value;
-          size_value = (end_value == -1) ? ishape[i] - begin_value : end_value;
-        } else {
-          LOG(FATAL) << "Unexpected slice_mode " << attrs->slice_mode << ", expected end or size";
-          throw;
-        }
-        ICHECK_GT(size_value, 0);
-        size.push_back(std::to_string(size_value));
-      }
-      std::vector<dmlc::any> start_attr, size_attr, strides_attr;
-      start_attr.emplace_back(start);
-      size_attr.emplace_back(size);
-      strides_attr.emplace_back(strides);
-      node_->SetAttr("start", start_attr);
-      node_->SetAttr("size", size_attr);
-      node_->SetAttr("strides", strides_attr);
-    }
-
-    void SetSplitNodeAttribute(const CallNode* call_node) {
-      const auto* split_attr = call_node->attrs.as<SplitAttrs>();
-      ICHECK(split_attr);
-
-      std::vector<std::string> indices_or_sections;
-      std::vector<std::string> mode;
-      std::vector<std::string> axis = {std::to_string(split_attr->axis)};
-      if (const auto* sections = split_attr->indices_or_sections.as<IntImmNode>()) {
-        mode.emplace_back("sections");
-        indices_or_sections.emplace_back(std::to_string(sections->value));
-      } else {
-        mode.emplace_back("indices");
-        auto indices = Downcast<tvm::Array<Integer>>(split_attr->indices_or_sections);
-        for (const auto& i : indices) {
-          indices_or_sections.emplace_back(std::to_string(i->value));
-        }
-      }
-
-      std::vector<dmlc::any> indices_or_sections_attr;
-      std::vector<dmlc::any> mode_attr;
-      std::vector<dmlc::any> axis_attr;
-      indices_or_sections_attr.emplace_back(indices_or_sections);
-      mode_attr.emplace_back(mode);
-      axis_attr.emplace_back(axis);
-      node_->SetAttr("indices_or_sections", indices_or_sections_attr);
-      node_->SetAttr("mode", mode_attr);
-      node_->SetAttr("axis", axis_attr);
-    }
-
-    void SetGenericAttributes(const CallNode* call_node) {
-      OpAttrExtractor extractor(node_);
-      const Object* attr_obj = call_node->attrs.get();
-      extractor.Extract(const_cast<Object*>(attr_obj));
-    }
-  */
   TensorRTJSONSerializer* serializer_;
   /*! \brief Accumulated translated arguments. */
   std::vector<JSONGraphNodeEntry> args_;
@@ -209,23 +115,24 @@ class CollectFromCompositeFunctionBody : public ExprVisitor {
  */
 class TensorRTJSONSerializer : public JSONSerializer {
  public:
-  explicit TensorRTJSONSerializer(const std::string& symbol) : JSONSerializer(symbol) {}
+  explicit TensorRTJSONSerializer(Map<Var, Expr> bindings, Map<Constant, String> constant_names)
+      : JSONSerializer(constant_names), bindings_(bindings) {}
 
   using JSONSerializer::VisitExpr_;
 
   std::vector<JSONGraphNodeEntry> VisitExpr_(const CallNode* call_node) final {
     // The call must be to an inline "Composite" function
-    const auto* function_node = call_node->op.as<FunctionNode>();
-    // ICHECK(function_node != nullptr);
-    if (!function_node) return JSONSerializer::VisitExpr_(call_node);
+    const auto* fn_var = call_node->op.as<VarNode>();
+    ICHECK(fn_var);
+    const auto fn = Downcast<Function>(bindings_[GetRef<Var>(fn_var)]);
 
-    auto opt_composite = function_node->GetAttr<String>(attr::kComposite);
+    auto opt_composite = fn->GetAttr<String>(attr::kComposite);
     ICHECK(opt_composite.defined());
     std::string name = opt_composite.value();
 
     // Collect the constants and attributes of all operator calls inside the composite body.
     CollectFromCompositeFunctionBody collector(this);
-    collector.VisitExpr(function_node->body);
+    collector.VisitExpr(fn->body);
 
     // Capture the args to the "Composite" function as inputs for this node.
     std::vector<JSONGraphNodeEntry> inputs;
@@ -238,9 +145,7 @@ class TensorRTJSONSerializer : public JSONSerializer {
     for (const auto& node : collector.args_) {
       inputs.emplace_back(node);
     }
-    // TODO(@sunggg): Revisit when we have op naming convention.
-    // Currently, simply remove "relax." prefix to make it work.
-    name = std::string("tensorrt.") + name.substr(6);
+
     // Create the final node.
     auto node = std::make_shared<JSONGraphNode>(name,
                                                 /*op_type=*/"kernel", inputs,
@@ -285,6 +190,10 @@ class TensorRTJSONSerializer : public JSONSerializer {
     node->SetAttr("use_fp16", use_fp16_attr);
     node->SetAttr("use_uint8", use_uint8_attr);
   }
+
+ private:
+  /*! \brief The bindings to look up composite functions. */
+  Map<Var, Expr> bindings_;
 };
 
 void CollectFromCompositeFunctionBody::VisitExpr_(const ConstantNode* constant_node) {
@@ -294,21 +203,7 @@ void CollectFromCompositeFunctionBody::VisitExpr_(const ConstantNode* constant_n
 }
 
 void CollectFromCompositeFunctionBody::VisitExpr_(const CallNode* call_node) {
-  const auto* op_node = call_node->op.as<OpNode>();
-  ICHECK(op_node != nullptr);
-  std::string name = op_node->name;
-  /*
-  // TODO(@sunggg): revisit when relax supports these ops.
-  if (name == "nn.pad") {
-    SetPadNodeAttribute(call_node);
-  } else if (name == "strided_slice") {
-    SetStridedSliceNodeAttribute(call_node);
-  } else if (name == "split") {
-    SetSplitNodeAttribute(call_node);
-  } else {
-    SetGenericAttributes(call_node);
-  }
-  */
+  SetGenericAttributes(call_node);
   ExprVisitor::VisitExpr_(call_node);
 }
 
@@ -318,20 +213,21 @@ void CollectFromCompositeFunctionBody::VisitExpr_(const CallNode* call_node) {
  * \return Runtime modules.
  */
 Array<runtime::Module> TensorRTCompiler(Array<Function> functions,
-                                        Map<String, ObjectRef> /*unused*/) {
+                                        Map<String, ObjectRef> /*unused*/,
+                                        Map<Constant, String> constant_names) {
   Array<runtime::Module> compiled_functions;
   for (const auto& func : functions) {
-    std::string func_name = GetExtSymbol(func);
     VLOG(1) << "TensorRT partition:" << std::endl << PrettyPrint(func);
-    TensorRTJSONSerializer serializer(func_name);
+    TensorRTJSONSerializer serializer(AnalyzeVar2Value(func), constant_names);
     serializer.serialize(func);
     std::string graph_json = serializer.GetJSON();
     VLOG(1) << "TensorRT JSON:" << std::endl << graph_json;
-    auto param_names = serializer.GetParams();
+    auto constant_names = serializer.GetConstantNames();
     const auto* pf = runtime::Registry::Get("runtime.tensorrt_runtime_create");
     ICHECK(pf != nullptr) << "Cannot find TensorRT runtime module create function.";
+    std::string func_name = GetExtSymbol(func);
     VLOG(1) << "Creating tensorrt runtime::Module for '" << func_name << "'";
-    compiled_functions.push_back((*pf)(func_name, graph_json, param_names));
+    compiled_functions.push_back((*pf)(func_name, graph_json, constant_names));
   }
   return compiled_functions;
 }

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -473,8 +473,8 @@ Module VMLink(ExecBuilder builder, Target target, Optional<Module> lib, Array<Mo
     lib = codegen::CSourceModuleCreate(";", "", Array<String>{});
   }
   std::unordered_map<std::string, runtime::NDArray> conv_params;
-  for (const auto& kv : params) {
-    conv_params[kv.first] = kv.second;
+  for (const auto& [name, param] : params) {
+    conv_params[name] = param;
   }
   Module combined_lib = codegen::CreateMetadataModule(
       conv_params, lib.value(), ext_libs, target,

--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -55,6 +55,7 @@ class CodeGenRunner : ExprMutator {
     }
 
     if (constant_names.size()) {
+      // Some backends (e.g. TensorRT) expect constants to be passed when they are instantiated
       Map<String, runtime::NDArray> constants;
       for (const auto& [constant, name] : constant_names) {
         ICHECK(!constants.count(name)) << "More than one constant with the name " << name;
@@ -109,6 +110,7 @@ class CodeGenRunner : ExprMutator {
       size_t count = 0;
       PostOrderVisit(func->body, [=, &count](Expr e) {
         if (e->IsInstance<ConstantNode>()) {
+          // Make sure to pick a unique name
           auto name = ext_symbol + "_" + opt_codegen.value() + "_const_" + std::to_string(count++);
           auto constant = Downcast<Constant>(e);
           constant_names.Set(constant, name);
@@ -153,7 +155,7 @@ class CodeGenRunner : ExprMutator {
     return ext_mods;
   }
 
-  /*! \brief TODO */
+  /*! \brief The names of all constants in the original module. */
   Map<Constant, String> constant_names;
 };
 

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -701,7 +701,6 @@ def test_conv2d():
 
     d_shape = (16, 16, 32, 32)
     w_shape = (32, 16, 3, 3)
-    padding = (1, 1)
     dyn_batch_shape = (relay.Any(),) + d_shape[1:]
 
     mod_nchw = get_conv2d_nchw(d_shape, w_shape, padding)
@@ -746,20 +745,18 @@ def test_conv2d():
         d_shape, w_shape, padding, out_dtype="int32", data_dtype="uint8", weight_dtype="int8"
     )
 
-    # TODO(masahi): The following test is broken if we use recent CUTLASS
-    # https://github.com/NVIDIA/cutlass/issues/799
-    # verify_conv2d(
-    #     mod_nchw,
-    #     mod_nchw,
-    #     d_shape,
-    #     w_shape,
-    #     sm=80,
-    #     atol=1e-5,
-    #     rtol=1e-5,
-    #     ref_target="llvm",
-    #     data_dtype="uint8",
-    #     weight_dtype="int8",
-    # )
+    verify_conv2d(
+        mod_nchw,
+        mod_nchw,
+        d_shape,
+        w_shape,
+        sm=80,
+        atol=1e-5,
+        rtol=1e-5,
+        ref_target="llvm",
+        data_dtype="uint8",
+        weight_dtype="int8",
+    )
 
 
 @tvm.testing.requires_cutlass

--- a/tests/python/relax/test_codegen_tensorrt.py
+++ b/tests/python/relax/test_codegen_tensorrt.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+import numpy as np
+import tvm
+import tvm.testing
+
+from tvm import relax, relay
+from tvm.script import relax as R
+from tvm.relax.dpl import make_fused_bias_activation_pattern, is_op, wildcard
+
+
+def get_relay_residual_block(d_shape, w_shape):
+    data = relay.var("data", shape=d_shape)
+    weight1 = relay.var("weight1", shape=w_shape)
+    weight2 = relay.var("weight2", shape=w_shape)
+    conv1 = relay.nn.relu(
+        relay.nn.conv2d(
+            data=data,
+            weight=weight1,
+            padding=(1, 1),
+        )
+    )
+    conv2d = relay.nn.relu(
+        relay.nn.conv2d(
+            data=conv1,
+            weight=weight2,
+            padding=(1, 1),
+        )
+    )
+    return conv2d + data
+
+
+@tvm.script.ir_module
+class Conv2dResidualBlock:
+    @R.function
+    def main(
+        data: R.Tensor((1, 64, 56, 56), "float32"),
+        weight1: R.Tensor((64, 64, 3, 3), "float32"),
+        weight2: R.Tensor((64, 64, 3, 3), "float32"),
+    ):
+        with R.dataflow():
+            conv1 = relax.op.nn.relu(relax.op.nn.conv2d(data, weight1, padding=(1, 1)))
+            conv2 = relax.op.nn.relu(relax.op.nn.conv2d(conv1, weight2, padding=(1, 1)))
+            out = relax.op.add(conv2, data)
+            R.output(out)
+
+        return out
+
+
+has_tensorrt = tvm.get_global_func("relax.ext.tensorrt", True)
+
+tensorrt_enabled = pytest.mark.skipif(
+    not has_tensorrt,
+    reason="TENSORRT note enabled.",
+)
+
+pytestmark = [tensorrt_enabled]
+
+
+def test_tensorrt_offload():
+    weight1_np = np.random.randn(64, 64, 3, 3).astype("float32")
+    weight2_np = np.random.randn(64, 64, 3, 3).astype("float32")
+
+    conv_pat = make_fused_bias_activation_pattern(
+        "relax.nn.conv2d", with_bias=False, activation=None
+    )
+    relu_pat = is_op("relax.nn.relu")(wildcard())
+    add_pat = is_op("relax.add")(wildcard(), wildcard())
+
+    patterns = [
+        ("tensorrt.nn.conv2d", conv_pat),
+        ("tensorrt.nn.relu", relu_pat),
+        ("tensorrt.add", add_pat),
+    ]
+
+    params_np = {"weight1": weight1_np, "weight2": weight2_np}
+
+    mod = tvm.transform.Sequential(
+        [
+            relax.transform.BindParams("main", params_np),
+            relax.transform.FuseOpsByPattern(patterns),
+            relax.transform.MergeCompositeFunctions(),
+            relax.transform.RunCodegen(),
+        ]
+    )(Conv2dResidualBlock)
+
+    target = "cuda"
+    dev = tvm.device(target, 0)
+    ex = relax.vm.build(mod, target)
+
+    vm = relax.VirtualMachine(ex, dev)
+    f = vm["main"]
+
+    data_np = np.random.randn(1, 64, 56, 56).astype("float32")
+    out = f(tvm.nd.array(data_np, dev)).numpy()
+
+    relay_mod = tvm.IRModule.from_expr(get_relay_residual_block(data_np.shape, weight1_np.shape))
+
+    ref = (
+        relay.create_executor("graph", mod=relay_mod, device=tvm.cpu(0), target="llvm")
+        .evaluate()(*[data_np, weight1_np, weight2_np])
+        .numpy()
+    )
+
+    tvm.testing.assert_allclose(out, ref, rtol=1e-3, atol=1e-3)
+
+
+if __name__ == "__main__":
+    test_tensorrt_offload()


### PR DESCRIPTION
A part of https://github.com/tlc-pack/relax/issues/364

Building on the two new passes, `FuseOpsByPattern` and `MergeCompositeFunctions`, this PR updates the existing TRT backend to have full support for the new BYOC flow. The attached test case demonstrates offloading a conv2d residual block, by having individual patterns for conv2d / relu / add, and merge their subgraphs via `MergeCompositeFunctions`. It is now possible to offload compute-intensive ops like conv2d, with its weight passed to the TRT engine at compile time (which is required by our TRT runtime) using `BindParams` pass. 

To enable offloading constants to BYOC, we need to update `RunCodegen` to
1. Name each constant used by extern functions
2. Maintain a mapping of constants to their names, and pass it to each BYOC backend. A BYOC backend would generate a json that references constants via their names.
3. Attach the name-to-constant mapping (the inverse of the mapping in 2) to the input mod, so that they can be passed to `CreateMetadataModule` in `VMLink` at the end of `vm.build(...)`.

@sunggg @tqchen @comaniac @mbaret @gigiblender @mikepapadim
          