### PR TITLE
Replace CopyWithNewParams with CopyWithNewVars

### DIFF
--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -141,13 +141,16 @@ TVM_DLL bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank = true,
 TVM_DLL bool IsLeafOrTuple(const Expr& expr);
 
 /*!
- * \brief Copy the given function. The parameters of the original function would be copied to
- * satisfy the restriction in the well-formed check: any two functions cannot share the same
- * parameter variable.
+ * \brief Copy the given function. All variables that are bound inside the original function
+ *  would be copied to satisfy the restriction in the well-formed check: Variables in
+ *  Relax must be bound exactly once. This also ensures that both the function and its copy
+ *  can be inserted into the same IRModule, and be asserted on the structural equality
+ *  agaisnt IRModule created by TVMScript.
+ *
  * \param func The relax function to copy.
  * \return The copied function.
  */
-TVM_DLL Function CopyWithNewParams(Function func);
+TVM_DLL Function CopyWithNewVars(Function func);
 
 }  // namespace relax
 }  // namespace tvm

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -260,10 +260,12 @@ class _ArgsConverter:
 args_converter = _ArgsConverter()  # pylint: disable=invalid-name
 
 
-def copy_with_new_params(func: Function) -> Function:
-    """Copy the given function. The parameters of the original function would be copied to
-    satisfy the restriction in the well-formed check: any two functions cannot share the same
-    parameter variable.
+def copy_with_new_vars(func: Function) -> Function:
+    """Copy the given function. All variables that are bound inside the original function
+    would be copied to satisfy the restriction in the well-formed check: Variables in
+    Relax must be bound exactly once. This also ensures that both the function and its copy
+    can be inserted into the same IRModule, and be asserted on the structural equality
+    agaisnt IRModule created by TVMScript.
 
     Parameters
     ----------
@@ -275,4 +277,4 @@ def copy_with_new_params(func: Function) -> Function:
     ret : Function
         The copied function.
     """
-    return _ffi_api.CopyWithNewParams(func)  # type: ignore
+    return _ffi_api.CopyWithNewVars(func)  # type: ignore

--- a/src/relax/transform/merge_composite_functions.cc
+++ b/src/relax/transform/merge_composite_functions.cc
@@ -266,7 +266,7 @@ class CompositeInliner : public ExprMutator {
   Expr VisitExpr_(const CallNode* call) {
     if (call->op->IsInstance<GlobalVarNode>()) {
       auto gvar = Downcast<GlobalVar>(call->op);
-      auto func = CopyWithNewParams(Downcast<Function>(mod_->Lookup(gvar)));
+      auto func = CopyWithNewVars(Downcast<Function>(mod_->Lookup(gvar)));
       if (func->GetAttr<String>(attr::kComposite)) {
         return Call(func, call->args);
       }


### PR DESCRIPTION
This PR adds a `CopyWithNewVars` function to replace `CopyWithNewParams`. `CopyWithNewVars` will copy all variables defined in a function, rather than just copy function parameters like what `CopyWithNewParams` does.

When the copy of a function needs to be added to the same IRModule of original function, it's important that the copy doesn't use the same variable as the original function does. Otherwise it's not possible to assert structural equal between the result and an IRModule created through TVMScript, which is a common pattern used in tests.