### PR TITLE
[Analysis] Memory usage estimation

### DIFF
--- a/python/tvm/relax/analysis/__init__.py
+++ b/python/tvm/relax/analysis/__init__.py
@@ -18,3 +18,4 @@
 """Relax IR analysis. """
 
 from .analysis import *
+from .estimate_memory_usage import estimate_memory_usage

--- a/python/tvm/relax/analysis/estimate_memory_usage.py
+++ b/python/tvm/relax/analysis/estimate_memory_usage.py
@@ -1,0 +1,164 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=abstract-method,unused-argument
+# pylint: disable=missing-function-docstring,missing-module-docstring
+from typing import Union
+import tvm
+from tvm.ir import Op
+from tvm.ir.module import IRModule
+
+from ..expr import Call, Expr, Function, ShapeExpr
+from ..expr_functor import visitor, PyExprVisitor
+
+
+def estimate_memory_usage(mod: Union[IRModule, Function]) -> str:
+    """Analysis function that estimates the memory usage of Relax functions
+    in an IRModule. The estimation includes the total memory size needed to
+    be allocated before and after memory planning.
+
+    The result might be over-estimated, as the estimation is static, which
+    does not consider control flows (such as "if" and cross-function calls).
+    It simply accumulates the size of every alloc_tensor and alloc_storage.
+
+    This analysis function is used to demonstrate the effect of memory
+    planning.
+
+    Parameters
+    ----------
+    mod : Union[IRModule, Function]
+        The input IRModule whose functions inside are to be analyzed.
+        If the input is a Function, we will wrap it with a IRModule, with
+        the function named "main".
+
+    Returns
+    -------
+    est : str
+        The estimation information, in the form of a string.
+
+    Notes
+    -----
+    We regards "relax.memory.alloc_tensor/storage" as the results produced by memory planning.
+    """
+
+    @visitor
+    class MemoryEstimator(PyExprVisitor):
+        """The IR visitor which estimates the memory usage of each Relax function.
+
+        Attributes
+        ----------
+        total_alloc_tensor_mem : int
+            The total memory size of alloc_tensor, in bytes.
+
+        total_const_size_tensor_num : int
+            The number of constant-size tensors.
+
+        total_dyn_size_tensor_num : int
+            The number of dynamic-size tensors.
+
+        planned_alloc_mem : int
+            The total memory size of memory.alloc_storage after memory planning, in bytes.
+
+        planned_mem_num : int
+            The number of memory.alloc_storages.
+        """
+
+        total_alloc_tensor_mem: int
+        total_const_size_tensor_num: int
+        total_dyn_size_tensor_num: int
+        planned_alloc_mem: int
+        planned_mem_num: int
+        builtin_alloc_tensor_op = Op.get("relax.builtin.alloc_tensor")
+        memory_alloc_tensor_op = Op.get("relax.memory.alloc_tensor")
+        memory_alloc_storage_op = Op.get("relax.memory.alloc_storage")
+
+        def estimate(self, mod: IRModule) -> str:
+            estimation: str = ""
+            for global_var, func in mod.functions.items():
+                if not isinstance(func, Function):
+                    continue
+
+                self.cleanup()
+                self.visit_expr(func)
+                estimation += self.generate_est_string(global_var.name_hint)
+
+            if estimation != "":
+                estimation = "Memory usage estimation:\n" + estimation
+            return estimation
+
+        def cleanup(self) -> None:
+            self.total_alloc_tensor_mem = 0
+            self.total_const_size_tensor_num = 0
+            self.total_dyn_size_tensor_num = 0
+            self.planned_alloc_mem = 0
+            self.planned_mem_num = 0
+
+        def visit_call_(self, call: Call) -> None:  # pylint: disable=arguments-differ
+            if call.op == self.builtin_alloc_tensor_op:
+                self.accumulate_tensor_alloc(shape=call.args[0], dtype_str=call.args[1].value)
+            elif call.op == self.memory_alloc_tensor_op:
+                self.accumulate_tensor_alloc(shape=call.args[2], dtype_str=call.args[3].value)
+            elif call.op == self.memory_alloc_storage_op:
+                self.accumulate_storage_alloc(size=call.args[0])
+
+        def accumulate_tensor_alloc(self, shape: Expr, dtype_str: str) -> None:
+            if not isinstance(shape, ShapeExpr):
+                raise TypeError(
+                    "The shape of relax.builtin.alloc_tensor and "
+                    "relax.memory.alloc_tensor is expected to be ShapeExpr"
+                )
+            size: int = 1
+            for dim_len in shape.values:
+                if not isinstance(dim_len, tvm.tir.IntImm):
+                    self.total_dyn_size_tensor_num += 1
+                    return
+                size *= dim_len.value
+
+            dtype = tvm.DataType(dtype_str)
+            self.total_const_size_tensor_num += 1
+            self.total_alloc_tensor_mem += (size * dtype.bits * dtype.lanes + 7) // 8
+
+        def accumulate_storage_alloc(self, size: Expr) -> None:
+            if not isinstance(size, ShapeExpr):
+                raise TypeError(
+                    "The size of relax.memory.alloc_storage is expected to be ShapeExpr"
+                )
+
+            self.planned_mem_num += 1
+            self.planned_alloc_mem += size.values[0].value
+
+        def generate_est_string(self, func_name: str) -> str:
+            est = (
+                f" * Without memory planning, there are {self.total_const_size_tensor_num} "
+                "constant-size memory allocation(s) with total size "
+                "{0:.4} GB".format(self.total_alloc_tensor_mem / 2**30)
+            )
+            if self.total_dyn_size_tensor_num > 0:
+                est += f", and {self.total_dyn_size_tensor_num} dynamic-size allocation(s)"
+            est += (
+                f".\n * With memory planning, there are {self.planned_mem_num} constant-size "
+                "memory allocation(s) with total size "
+                "{0:.4} GB.\n".format(self.planned_alloc_mem / 2**30)
+            )
+            est += " * Memory planning reduces constant memory size to " "{0:.1%}.".format(
+                self.planned_alloc_mem / self.total_alloc_tensor_mem
+            )
+            return "- Function " + func_name + ":\n" + est
+
+    if isinstance(mod, Function):
+        mod = tvm.IRModule({tvm.ir.GlobalVar("foo"): mod})
+
+    return MemoryEstimator().estimate(mod)

--- a/tests/python/relax/test_analysis_estimate_memory_usage.py
+++ b/tests/python/relax/test_analysis_estimate_memory_usage.py
@@ -1,0 +1,125 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+from tvm.script import relax as R, tir as T
+from tvm.relax.analysis import estimate_memory_usage
+
+
+def test_basic():
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def add(
+            rxplaceholder: T.Buffer[T.int64(8), "float32"],
+            rxplaceholder_1: T.Buffer[(), "float32"],
+            T_add: T.Buffer[T.int64(8), "float32"],
+        ):
+            T.evaluate(0)
+
+        @T.prim_func
+        def reshape(
+            rxplaceholder: T.Buffer[(T.int64(2), T.int64(4)), "float32"],
+            T_reshape: T.Buffer[T.int64(8), "float32"],
+        ):
+            T.evaluate(0)
+
+        @T.prim_func
+        def relu(
+            rxplaceholder: T.Buffer[T.int64(8), "float32"], compute: T.Buffer[T.int64(8), "float32"]
+        ):
+            T.evaluate(0)
+
+        @T.prim_func
+        def log(
+            rxplaceholder: T.Buffer[T.int64(10), "float32"],
+            compute: T.Buffer[T.int64(10), "float32"],
+        ):
+            T.evaluate(0)
+
+        @T.prim_func
+        def exp(
+            rxplaceholder: T.Buffer[(T.int64(2), T.int64(4)), "float32"],
+            compute: T.Buffer[(T.int64(2), T.int64(4)), "float32"],
+        ):
+            T.evaluate(0)
+
+        @T.prim_func
+        def pad(
+            rxplaceholder: T.Buffer[T.int64(8), "float32"],
+            PadInput: T.Buffer[T.int64(10), "float32"],
+        ):
+            T.evaluate(0)
+
+        @R.function
+        def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
+            storage: R.Object = R.memory.alloc_storage(
+                (32,), virtual_device_index=0, storage_scope="global", dtype="float32"
+            )
+            alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(
+                storage, offset=0, shape=(2, 4), dtype="float32"
+            )
+            _: R.Tuple() = exp(x, alloc)
+            lv: R.Tensor((2, 4), dtype="float32") = alloc
+            lv1: R.Tensor((8,), dtype="float32") = R.call_packed(
+                "vm.builtin.reshape", lv, (8,), sinfo_args=[R.Tensor((8,), dtype="float32")]
+            )
+            storage1: R.Object = R.memory.alloc_storage(
+                (40,), virtual_device_index=0, storage_scope="global", dtype="float32"
+            )
+            alloc1: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
+                storage1, offset=0, shape=(8,), dtype="float32"
+            )
+            _1: R.Tuple() = relu(lv1, alloc1)
+            _2: R.Tuple() = R.memory.kill_tensor(alloc)
+            _3: R.Tuple() = R.memory.kill_tensor(lv1)
+            lv2: R.Tensor((8,), dtype="float32") = alloc1
+            alloc2: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
+                storage, offset=0, shape=(8,), dtype="float32"
+            )
+            _4: R.Tuple() = add(lv2, R.const(1, "float32"), alloc2)
+            _5: R.Tuple() = R.memory.kill_tensor(alloc1)
+            lv3: R.Tensor((8,), dtype="float32") = alloc2
+            alloc3: R.Tensor((10,), dtype="float32") = R.memory.alloc_tensor(
+                storage1, offset=0, shape=(10,), dtype="float32"
+            )
+            _6: R.Tuple() = pad(lv3, alloc3)
+            _7: R.Tuple() = R.memory.kill_tensor(alloc2)
+            lv4: R.Tensor((10,), dtype="float32") = alloc3
+            alloc4: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor(
+                (10,), dtype="float32", runtime_device_index=0
+            )
+            _8: R.Tuple() = log(lv4, alloc4)
+            _9: R.Tuple() = R.memory.kill_tensor(alloc3)
+            gv5: R.Tensor((10,), dtype="float32") = alloc4
+            _11: R.Tuple() = R.memory.kill_storage(storage)
+            _10: R.Tuple() = R.memory.kill_storage(storage1)
+            return gv5
+
+    assert (
+        estimate_memory_usage(Module)
+        == r"""Memory usage estimation:
+- Function main:
+ * Without memory planning, there are 5 constant-size memory allocation(s) with total size 1.639e-07 GB.
+ * With memory planning, there are 2 constant-size memory allocation(s) with total size 6.706e-08 GB.
+ * Memory planning reduces constant memory size to 40.9%."""
+    )
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR brings an analysis function which estimates the memory usage of Relax functions, used for demonstrating the effect of memory planning.

The estimation will return the total memory size needed to be allocated before and after memory planning, as well as the number of tensors / memory blocks to be allocated before and after memory planning.

Note:
* The estimation is static -- it does not consider control flows (such as “if” and cross-function calls). It simply accumulates the size of every alloc_tensor and alloc_storage.
* We regards “`relax.memory.alloc_tensor/storage`” as the results produced by memory planning.