### PR TITLE
[Transform] RewriteDataflowReshape to op and VMBuiltinLower handling

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -102,12 +102,16 @@ TVM_DLL Pass ToNonDataflow();
 TVM_DLL Pass CallTIRRewrite();
 
 /*!
- * \brief Convert all reshape-like call_tir to VM reshape operator call.
- * The VM reshape operator calls will be further lowered to a CreateView
- * operation at runtime, instead of doing real data copy.
+ * \brief Convert all reshape-like call_tir whose corresponding binding
+ * vars are DataflowVars to relax.reshape operator calls. The relax.reshape
+ * calls will be lowered an external builtin function call in a subsequent
+ * pass, where the external builtin function does a CreateView operation
+ * at runtime, instead of doing real data copy.
  * Here "reshape-like" includes reshape, expand_dims, flatten, etc.
  *
  * \return The Pass.
+ * \note The pass is applied at the first stage of Relax VM build, before
+ * rewriting call_tir, as this pass requires dataflow information.
  */
 TVM_DLL Pass RewriteDataflowReshape();
 

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -102,14 +102,22 @@ def CallTIRRewrite() -> tvm.ir.transform.Pass:
 
 
 def RewriteDataflowReshape() -> tvm.ir.transform.Pass:
-    """Convert all reshape-like call_tir to VM reshape operator call.
-    The VM reshape operator calls will be further lowered to a CreateView
-    operation at runtime, instead of doing real data copy.
+    """Convert all reshape-like call_tir whose corresponding binding
+    vars are DataflowVars to relax.reshape operator calls. The relax.reshape
+    calls will be lowered an external builtin function call in a subsequent
+    pass, where the external builtin function does a CreateView operation
+    at runtime, instead of doing real data copy.
+
     Here "reshape-like" includes reshape, expand_dims, flatten, etc.
 
     Returns
     -------
     ret : tvm.ir.transform.Pass
+
+    Notes
+    -----
+    The pass is applied at the first stage of Relax VM build, before
+    rewriting call_tir, as this pass requires dataflow information.
     """
     return _ffi_api.RewriteDataflowReshape()  # type: ignore
 

--- a/src/relax/transform/rewrite_dataflow_reshape.cc
+++ b/src/relax/transform/rewrite_dataflow_reshape.cc
@@ -18,7 +18,7 @@
  */
 /*!
  * \file src/relax/transform/rewrite_dataflow_reshape.cc
- * \brief Transform all reshape within dataflow block to a specialized reshape operator
+ * \brief Transform all reshape within dataflow block to a relax.reshape operator
  */
 #include <tvm/relax/analysis.h>
 #include <tvm/relax/expr_functor.h>
@@ -75,8 +75,11 @@ class DataflowReshapeRewriter : public ExprMutator {
     if (call->op != call_tir_op) {
       return false;
     }
-    GlobalVar gv = Downcast<GlobalVar>(call->args[0]);
-    const auto* func = mod_->functions.Get(gv).as<tir::PrimFuncNode>();
+    const auto* gv = call->args[0].as<GlobalVarNode>();
+    if (gv == nullptr) {
+      return false;
+    }
+    const auto* func = mod_->functions.Get(GetRef<GlobalVar>(gv)).as<tir::PrimFuncNode>();
     ICHECK_NOTNULL(func);
     return HasReshapePattern(GetRef<tir::PrimFunc>(func));
   }

--- a/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
+++ b/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
@@ -114,12 +114,7 @@ def test_reshape_expand_dims():
             x: R.Tensor((8, 3), dtype="float32")
         ) -> R.Tensor((2, 1, 4, 1, 3), dtype="float32"):
             with R.dataflow():
-                y = R.call_packed(
-                    "vm.builtin.reshape",
-                    x,
-                    (2, 4, 3),
-                    sinfo_args=R.Tensor((2, 4, 3), "float32"),
-                )
+                y: R.Tensor((2, 4, 3), "float32") = R.reshape(x, (2, 4, 3))
                 # Note: `z` is the output var of the dataflow block, and is thus
                 # not expected to be rewritten.
                 z = R.call_tir(


### PR DESCRIPTION
As discussed in https://github.com/tlc-pack/relax/pull/407#discussion_r1099586500, we update the behavior of pass RewriteDataflowReshape.

In short, prior to this PR, the pass transforms calls of reshape PrimFunc in dataflow blocks to direct calls of runtime packed func “vm.builtin.reshape.” The consequence of this behavior is that the memory planning pass has to check the reshape op by string comparison of `ExternFunc.global_symbol`, which is not ideal.

Therefore, this PR changes the RewriteDataflowReshape’s behavior, transforming calls of reshape PrimFunc to our high-level reshape op “relax.reshape,” and let the VMBuiltinLower pass to lowers the op to calls of “vm.builtin.reshape.”