### PR TITLE
[BYOC] Attach matched call nodes as attributes of composite functions

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -942,8 +942,10 @@ constexpr const char* kPrimitive = "Primitive";
  * When this is unset or set to "default", the default compilation pipeline will be used.
  */
 constexpr const char* kCodegen = "Codegen";
-/*! \brief Treat the function as a composite operator. */
+/*! \brief Treat the function as a composite function. */
 constexpr const char* kComposite = "Composite";
+/*! \brief Attach matched call nodes in a composite function. */
+constexpr const char* kMatchedCallNodes = "MatchedCallNodes";
 /*! \brief Indicate the function was created by the Pattern Partitioning Pass. */
 constexpr const char* kPartitionedFromPattern = "PartitionedFromPattern";
 }  // namespace attr

--- a/src/relax/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relax/backend/contrib/codegen_json/codegen_json.h
@@ -231,7 +231,7 @@ class JSONSerializer : public relax::MemoizedExprTranslator<NodeEntries> {
     return ret;
   }
 
-  void SetCallNodeAttribute(JSONGraphObjectPtr node, const CallNode* cn) {
+  void SetCallNodeAttribute(JSONGraphObjectPtr node, Call cn) {
     if (cn->op.as<OpNode>()) {
       OpAttrExtractor extractor(node);
       const Object* call_attr = cn->attrs.get();
@@ -246,6 +246,10 @@ class JSONSerializer : public relax::MemoizedExprTranslator<NodeEntries> {
       attr.emplace_back(values);
       node->SetAttr("PartitionedFromPattern", attr);
     }
+  }
+
+  void SetCallNodeAttribute(JSONGraphObjectPtr node, const CallNode* cn) {
+    SetCallNodeAttribute(node, GetRef<Call>(cn));
   }
 
   NodeEntries VisitBinding_(const MatchCastNode* binding) {

--- a/src/relax/backend/contrib/utils.h
+++ b/src/relax/backend/contrib/utils.h
@@ -89,37 +89,6 @@ inline std::string DType2String(const tvm::DataType dtype) {
   return os.str();
 }
 
-/*!
- * \brief Check if a call node is calling an op with the given name
- * \param call The call node whose callee we want to check
- * \param op_name The name of the op
- * \return true if the callee op matches with the op name
- */
-inline bool IsOp(const CallNode* call, const std::string& op_name) {
-  const auto* op_node = call->op.as<OpNode>();
-  if (!op_node) return false;
-  Op op = GetRef<Op>(op_node);
-  return op == Op::Get(op_name);
-}
-
-/*!
- * \brief Return a call node within the function which calls an op with the given name
- * The function must contain exactly one call to such op.
- * \param f The function to look for an op.
- * \param op_name The name of the op
- * \return A call node which calls an op with the given name
- */
-inline const CallNode* GetOpInFunction(Function f, const std::string& op_name) {
-  auto local_bindings = AnalyzeVar2Value(f);
-  for (const auto& entry : local_bindings) {
-    if (auto call = entry.second.as<CallNode>(); call && backend::IsOp(call, op_name)) {
-      return call;
-    }
-  }
-  LOG(FATAL) << op_name << " not found in the function:\n" << f;
-  return nullptr;
-}
-
 }  // namespace backend
 }  // namespace relax
 }  // namespace tvm

--- a/src/relay/backend/contrib/cutlass/codegen.cc
+++ b/src/relay/backend/contrib/cutlass/codegen.cc
@@ -586,7 +586,7 @@ GenerateBodyOutput GenerateBody(const std::string& func_name, const std::string&
   decl_stream << ");";
   if (func_name.find("dense") != std::string::npos) {
     ret.decl = DenseOp(ext_func_id, attribute_args, func_args);
-  } else if (func_name == "cutlass_batch_matmul") {
+  } else if (func_name.find("batch_matmul") != std::string::npos) {
     ret.decl = BatchMatmulOp(ext_func_id, attribute_args, func_args);
   } else if (IsConv2dResidualBlock(func_name)) {
     ret.decl = Conv2dOp(ext_func_id, attribute_args, func_args, true);


### PR DESCRIPTION
Introduce `attr::kMatchedCallNodes` attribute, a map between an op name and a list of pattern-matched call nodes whose callee is identified by the key op name. 

This is useful to find a call node of interest (usually an anchor op) in a composite function. So far we are using `GetOpInFunction` in codegen for that purpose, but if we can simply look up matched call nodes, that function is unnecessary. 

If there are multiple call nodes with the same op name in one match (e.g. attention), the codegen is responsible for figuring out which of them is needed in a given situation. 

cc @vinx13 @yelite 