### PR TITLE
[Tweak] Note that `PrimValue`, `DataTypeImm`, and `StringImm` are leaf nodes

### DIFF
--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -43,7 +43,7 @@
  *       (a) Expressions cannot contain nested complex expressions.
  *           Here are the expressions that may be nested inside other expressions:
  *           Var, DataflowVar, GlobalVar, Constant, ShapeExpr,
- *           Op, Tuple (we call these "leaf" expressions).
+ *           Op, PrimValue, StringImm, DataTypeImm, Tuple (we call these "leaf" expressions).
  *       (b) The right-hand side of a binding may contain a non-leaf expression
  *           (where all expressions nested in it are leaf expressions),
  *           other than SeqExprs (see rule 6)

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -79,8 +79,7 @@ bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank, bool permit_unkn
 
 bool IsLeafOrTuple(const Expr& expr) {
   return expr.as<LeafExprNode>() || expr.as<GlobalVarNode>() || expr.as<ExternFuncNode>() ||
-         expr.as<OpNode>() || expr.as<PrimExprNode>() || expr.as<StringImmNode>() ||
-         expr.as<DataTypeImmNode>() || expr.as<TupleNode>();
+         expr.as<OpNode>() || expr.as<TupleNode>();
 }
 
 class FunctionCopier : public ExprMutator {

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -79,7 +79,8 @@ bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank, bool permit_unkn
 
 bool IsLeafOrTuple(const Expr& expr) {
   return expr.as<LeafExprNode>() || expr.as<GlobalVarNode>() || expr.as<ExternFuncNode>() ||
-         expr.as<OpNode>() || expr.as<TupleNode>();
+         expr.as<OpNode>() || expr.as<PrimExprNode>() || expr.as<StringImmNode>() ||
+         expr.as<DataTypeImmNode>() || expr.as<TupleNode>();
 }
 
 class FunctionCopier : public ExprMutator {


### PR DESCRIPTION
Our comments in the well-formed pass did not mention `PrimValue`, `DataTypeImm`, and `StringImm` as leaf nodes. This PR updates the comment and adds a test case demonstrating this fact.