### PR TITLE
[RUNTIME] Use Array to back Tuple

### DIFF
--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -203,14 +203,11 @@ def render_object(val: tvm.Object) -> str:
         return str(val)
     # no pretty-printer by default, so if we don't handle this,
     # then we can't look inside tuples
-    if isinstance(val, tvm.runtime.container.ADT):
-        # the fields array of an ADT cannot be directly accessed in Python
+    if isinstance(val, tvm.ir.Array):
+        # the fields array of an array cannot be directly accessed in Python
         # so we have to get the length and index into the fields separately
         fields = ", ".join([render_object(val[i]) for i in range(len(val))])
-        # special case: tag = 0 is a tuple
-        if val.tag == 0:
-            return f"({fields})"
-        return f"ADT(tag={val.tag}, fields=[{fields}])"
+        return f"({fields})"
     return str(val)
 
 

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -23,7 +23,7 @@ from tvm._ffi import base as _base
 import tvm
 from tvm import relax
 from tvm.ir.module import IRModule
-from tvm.runtime import Device, Module, PackedFunc, container
+from tvm.runtime import Device, Module, PackedFunc
 from tvm.runtime.object import Object
 from tvm.runtime.profiling import Report
 from tvm.tir.function import PrimFunc
@@ -232,7 +232,7 @@ class VirtualMachine(object):
             field_args: List[Any] = []
             for field in arg:
                 self._convert(field, field_args)
-            cargs.append(container.tuple_object(field_args))
+            cargs.append(tvm.runtime.convert(field_args))
         elif isinstance(arg, (_base.numeric_types, bool)):
             dtype = _gettype(arg)
             value = tvm.nd.array(np.array(arg, dtype=dtype), device=tvm.cpu(0))

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -269,7 +269,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
       args.push_back(this->VisitExpr(arg));
     }
     size_t dst_register = NewRegister();
-    builder_->EmitCall("runtime.Tuple", args, dst_register);
+    builder_->EmitCall("vm.builtin.make_tuple", args, dst_register);
 
     return Instruction::Arg::Register(dst_register);
   }

--- a/src/relax/backend/vm/codegen_vm_tir.cc
+++ b/src/relax/backend/vm/codegen_vm_tir.cc
@@ -309,7 +309,7 @@ class CodeGenVMTIR : public ExprFunctor<Optional<PrimExpr>(const Expr&)> {
       args.push_back(this->VisitExpr(arg).value());
     }
     int32_t dst_register = NewRegister();
-    this->EmitCallPacked("runtime.Tuple", args, dst_register);
+    this->EmitCallPacked("vm.builtin.make_tuple", args, dst_register);
     return RegListGet(dst_register);
   }
 

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -19,7 +19,6 @@
 /*!
  * \file src/runtime/relax_vm/builtin.cc
  */
-#include <tvm/runtime/container/adt.h>
 #include <tvm/runtime/container/shape_tuple.h>
 #include <tvm/runtime/data_type.h>
 #include <tvm/runtime/device_api.h>
@@ -214,14 +213,13 @@ TVM_REGISTER_GLOBAL("vm.builtin.check_shape_info").set_body_typed(CheckShapeInfo
  * \param err_ctx Additional context if error occurs.
  */
 void CheckTupleInfo(ObjectRef arg, int64_t size, Optional<String> err_ctx) {
-  using Tuple = runtime::ADT;
   // a function that lazily get context for error reporting
-  auto* ptr = arg.as<Tuple::ContainerType>();
+  auto* ptr = arg.as<runtime::ArrayNode>();
   CHECK(ptr != nullptr) << "TypeError: " << err_ctx.value_or("") << " expect a Tuple but get "
                         << arg->GetTypeKey();
-  CHECK(static_cast<int64_t>(ptr->size) == size)
+  CHECK(static_cast<int64_t>(ptr->size()) == size)
       << "ValueError: " << err_ctx.value_or("") << " expect a Tuple with " << size << " elements, "
-      << " but get a Tuple with " << ptr->size << " elements.";
+      << " but get a Tuple with " << ptr->size() << " elements.";
 }
 
 TVM_REGISTER_GLOBAL("vm.builtin.check_tuple_info").set_body_typed(CheckTupleInfo);
@@ -371,8 +369,15 @@ TVM_REGISTER_GLOBAL("vm.builtin.read_if_cond").set_body_typed(ReadIfCond);
 //-------------------------------------
 //  Data structure API
 //-------------------------------------
-TVM_REGISTER_GLOBAL("vm.builtin.tuple_getitem").set_body_typed([](runtime::ADT arr, int64_t index) {
-  return arr[index];
+TVM_REGISTER_GLOBAL("vm.builtin.tuple_getitem")
+    .set_body_typed([](runtime::Array<ObjectRef> arr, int64_t index) { return arr[index]; });
+
+TVM_REGISTER_GLOBAL("vm.builtin.make_tuple").set_body([](TVMArgs args, TVMRetValue* rv) {
+  runtime::Array<ObjectRef> arr;
+  for (int i = 0; i < args.num_args; ++i) {
+    arr.push_back(args[i].operator ObjectRef());
+  }
+  *rv = arr;
 });
 
 }  // namespace relax_vm

--- a/tests/python/relax/test_runtime_builtin.py
+++ b/tests/python/relax/test_runtime_builtin.py
@@ -114,7 +114,7 @@ def test_check_tensor_info():
 def test_check_tuple_info():
     check_tuple_info = tvm.get_global_func("vm.builtin.check_tuple_info")
     x = tvm.nd.array(np.zeros((2, 3)).astype("int32"))
-    t = tvm.runtime.container.tuple_object([x, x, x])
+    t = tvm.runtime.convert([x, x, x])
 
     check_tuple_info(t, 3, "")
 
@@ -143,7 +143,7 @@ def test_tuple_getitem():
     tuple_getitem = tvm.get_global_func("vm.builtin.tuple_getitem")
     x = tvm.nd.array(np.zeros((2, 3)).astype("int32"))
     y = tvm.nd.array(np.zeros((2, 3)).astype("int32"))
-    t = tvm.runtime.container.tuple_object([x, y])
+    t = tvm.runtime.convert([x, y])
 
     assert tuple_getitem(t, 0) == x
     assert tuple_getitem(t, 1) == y

--- a/tests/python/relax/test_vm_codegen_tir.py
+++ b/tests/python/relax/test_vm_codegen_tir.py
@@ -173,7 +173,7 @@ def test_const():
             T.anylist_setitem_call_packed(
                 r,
                 T.int32(2),
-                "runtime.Tuple",
+                "vm.builtin.make_tuple",
                 T.anylist_getitem(c, T.int32(0)),
                 T.anylist_getitem(c, T.int32(1)),
                 T.anylist_getitem(r, T.int32(0)),

--- a/tests/python/relax/test_vm_profiler.py
+++ b/tests/python/relax/test_vm_profiler.py
@@ -121,7 +121,7 @@ def test_tuple():
 
     def callback(vm, data):
         report = vm.profile("main", data)
-        assert "runtime.Tuple" in str(report)
+        assert "vm.builtin.make_tuple" in str(report)
 
     with_rpc(ex, callback, data_np)
 


### PR DESCRIPTION
This PR uses Array to back Tuple, doing so would enable uniform access of the relax interface and direct passing in python tuples.