### PR TITLE
[TVMScript] Use explicit `R.shape` in TVMScript

### DIFF
--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -23,7 +23,7 @@ from .. import tir
 from ..runtime import String, convert_to_object
 from ..tir import PrimExpr
 from . import _ffi_api
-from .expr import Expr, Function, PrimValue, ShapeExpr, StringImm
+from .expr import Expr, Function, PrimValue, StringImm
 from .expr import Tuple as rx_Tuple
 
 

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -74,14 +74,12 @@ def convert_to_expr(value: Any) -> Expr:
     1. Return the input itself if it's already a `relax.Expr`;
     2. Return `relax.PrimValue` if the input is a `PrimExpr`;
     3. Return `relax.StringImm` if the input is `tvm.String` or `str`;
-    4. Return `relax.ShapeExpr` if the input is a tuple/list of `PrimExpr` w/ int dtype;
-    5. Return `relax.Tuple` if the input is a tuple/list of `Expr`.
+    4. Return `relax.Tuple` if the input is a tuple/list of `Expr`.
 
     Notes
     -----
     1. `tvm.tir.StringImm` is not allowed because of ambiguity,
        which can be either `relax.StringImm` or `relax.PrimValue`.
-    2. We regard empty tuple/list as `relax.Tuple` instead of `relax.ShapeExpr`
     """
     if isinstance(value, int):
         return PrimValue(tir.IntImm("int64", value))
@@ -102,16 +100,8 @@ def convert_to_expr(value: Any) -> Expr:
     # Case 3
     if isinstance(tvm_value, String):
         return StringImm(value)
-    # Case 4 & 5
+    # Case 4
     if isinstance(value, (tuple, list)):
-        # Note 2
-        if len(value) == 0:
-            return rx_Tuple([])
-        # Case 4
-        opt_prim_value = [convert_to_object(v) for v in value]
-        if all([isinstance(v, PrimExpr) and v.dtype.startswith("int") for v in opt_prim_value]):
-            return ShapeExpr(value)
-        # Case 5
         # `convert_to_expr` ensures that all elements are `Expr` if no exception raises
         return rx_Tuple([convert_to_expr(v) for v in value])
     raise TypeError(f"Cannot convert {value} with type {type(value)} to `relax.Expr`")

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -382,11 +382,11 @@ def Else() -> frame.ElseFrame:  # pylint: disable=invalid-name
 ############################### R.tuple ################################
 
 
-def tuple(*fields: List[Expr]) -> Expr:
+def tuple(*fields: Expr) -> Expr:
     """Create a tuple expression.
     Parameters
     ----------
-    fields : List[Expr]
+    *fields : Expr
         The fields of the tuple.
     Returns
     -------
@@ -397,6 +397,23 @@ def tuple(*fields: List[Expr]) -> Expr:
         fields = []
 
     return relax.Tuple(fields)  # pylint: disable=no-member # type: ignore
+
+
+############################### R.shape ################################
+
+
+def shape(value: List[PrimExpr]) -> Expr:
+    """Create a ShapeExpr.
+    Parameters
+    ----------
+    value : List[PrimExpr]
+        The fields of the tuple.
+    Returns
+    -------
+    res : Expr
+        The result tuple.
+    """
+    return relax.ShapeExpr(value)  # pylint: disable=no-member # type: ignore
 
 
 ############################### PrimValue ##############################
@@ -524,6 +541,7 @@ __all__ = [
     "prod",
     "reshape",
     "round",
+    "shape",
     "shape_of",
     "sigmoid",
     "sign",

--- a/src/script/printer/relax/expr.cc
+++ b/src/script/printer/relax/expr.cc
@@ -71,7 +71,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           for (int i = 0, l = n->values.size(); i < l; ++i) {
             values_doc.push_back(PrintShapeVar(n->values[i], values_p->ArrayIndex(i), d));
           }
-          return TupleDoc(values_doc);
+          return Relax(d, "shape")->Call({ListDoc(values_doc)});
         });
 
 Optional<ExprDoc> SpecialScalar(const runtime::NDArray& n, const ObjectPath& p) {

--- a/tests/python/relax/test_analysis_estimate_memory_usage.py
+++ b/tests/python/relax/test_analysis_estimate_memory_usage.py
@@ -69,40 +69,40 @@ def test_basic():
         @R.function
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
             storage: R.Object = R.memory.alloc_storage(
-                (32,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([32]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(
-                storage, offset=0, shape=(2, 4), dtype="float32"
+                storage, offset=0, shape=R.shape([2, 4]), dtype="float32"
             )
             _: R.Tuple() = exp(x, alloc)
             lv: R.Tensor((2, 4), dtype="float32") = alloc
             lv1: R.Tensor((8,), dtype="float32") = R.call_packed(
-                "vm.builtin.reshape", lv, (8,), sinfo_args=[R.Tensor((8,), dtype="float32")]
+                "vm.builtin.reshape", lv, R.shape([8]), sinfo_args=[R.Tensor((8,), dtype="float32")]
             )
             storage1: R.Object = R.memory.alloc_storage(
-                (40,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([40]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc1: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
-                storage1, offset=0, shape=(8,), dtype="float32"
+                storage1, offset=0, shape=R.shape([8]), dtype="float32"
             )
             _1: R.Tuple() = relu(lv1, alloc1)
             _2: R.Tuple() = R.memory.kill_tensor(alloc)
             _3: R.Tuple() = R.memory.kill_tensor(lv1)
             lv2: R.Tensor((8,), dtype="float32") = alloc1
             alloc2: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
-                storage, offset=0, shape=(8,), dtype="float32"
+                storage, offset=0, shape=R.shape([8]), dtype="float32"
             )
             _4: R.Tuple() = add(lv2, R.const(1, "float32"), alloc2)
             _5: R.Tuple() = R.memory.kill_tensor(alloc1)
             lv3: R.Tensor((8,), dtype="float32") = alloc2
             alloc3: R.Tensor((10,), dtype="float32") = R.memory.alloc_tensor(
-                storage1, offset=0, shape=(10,), dtype="float32"
+                storage1, offset=0, shape=R.shape([10]), dtype="float32"
             )
             _6: R.Tuple() = pad(lv3, alloc3)
             _7: R.Tuple() = R.memory.kill_tensor(alloc2)
             lv4: R.Tensor((10,), dtype="float32") = alloc3
             alloc4: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor(
-                (10,), dtype="float32", runtime_device_index=0
+                R.shape([10]), dtype="float32", runtime_device_index=0
             )
             _8: R.Tuple() = log(lv4, alloc4)
             _9: R.Tuple() = R.memory.kill_tensor(alloc3)

--- a/tests/python/relax/test_backend_transform_shape_lower.py
+++ b/tests/python/relax/test_backend_transform_shape_lower.py
@@ -167,7 +167,7 @@ def test_symbolic_compute():
             n = T.Var("n", "int64")
             k = T.Var("k", "int64")
             z = R.match_cast(y, R.Tensor([k, m, k + 1], dtype=None))
-            return (k + 1, m, 2)
+            return R.shape([k + 1, m, 2])
 
     # slot assignment:
     # 0: n, 1: m, 2:k, 3: k+1

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -1041,7 +1041,7 @@ def test_size():
         def main(input_1: R.Tensor((1, 3, 10, 10), dtype="float32")) -> R.Shape([1, 3, 10, 10]):
             # block 0
             with R.dataflow():
-                gv: R.Shape([1, 3, 10, 10]) = (1, 3, 10, 10)
+                gv: R.Shape([1, 3, 10, 10]) = R.shape([1, 3, 10, 10])
                 R.output(gv)
             return gv
 
@@ -1116,7 +1116,7 @@ def test_getattr():
         def main(input_1: R.Tensor((1, 3, 10, 10), dtype="float32")) -> R.Shape([1, 3, 10, 10]):
             # block 0
             with R.dataflow():
-                gv: R.Shape([1, 3, 10, 10]) = (1, 3, 10, 10)
+                gv: R.Shape([1, 3, 10, 10]) = R.shape([1, 3, 10, 10])
                 R.output(gv)
             return gv
 

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -624,7 +624,7 @@ def test_primexpr_arithmetic():
         z: R.Tensor((n * m,), "float32") = R.call_packed(
             "my_flatten", (x,), sinfo_args=(R.Tensor(ndim=1, dtype="float32"))
         )
-        sh: R.Shape = (n + m, n // m)
+        sh: R.Shape = R.shape([n + m, n // m])
         return z
 
     x = f.params[0]
@@ -870,8 +870,8 @@ def test_class_normalize():
 def test_memory_op():
     @R.function
     def memory(x: R.Tensor) -> R.Tensor:
-        storage = R.memory.alloc_storage((1024,), -1, "global", "float32")
-        alloca = R.memory.alloc_tensor(storage, 0, (1, 256), "float32")
+        storage = R.memory.alloc_storage(R.shape([1024]), -1, "global", "float32")
+        alloca = R.memory.alloc_tensor(storage, 0, R.shape([1, 256]), "float32")
         _ = R.memory.kill_tensor(alloca)
         _ = R.memory.kill_storage(storage)
         return alloca

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -292,7 +292,7 @@ def test_vm_memory_lower():
         @R.function
         def foo(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor:
             m, n = T.var("int64"), T.var("int64")
-            alloc = R.builtin.alloc_tensor((m, n), runtime_device_index=0, dtype="float32")
+            alloc = R.builtin.alloc_tensor(R.shape([m, n]), runtime_device_index=0, dtype="float32")
             _ = R.call_packed(
                 "test.op.identity", x, alloc, sinfo_args=(R.Tensor(ndim=2, dtype="float32"))
             )
@@ -325,7 +325,7 @@ def test_vm_builtin_lower_reshape():
     class TestVMReshape:
         @R.function
         def main(x: R.Tensor((3, 4), "float32")):
-            y = R.reshape(x, (6, 2))
+            y = R.reshape(x, R.shape([6, 2]))
             return y
 
     @tvm.script.ir_module
@@ -333,7 +333,7 @@ def test_vm_builtin_lower_reshape():
         @R.function
         def main(x: R.Tensor((3, 4), "float32")):
             y: R.Tensor((6, 2), "float32") = R.call_packed(
-                "vm.builtin.reshape", x, (6, 2), sinfo_args=R.Tensor((6, 2), "float32")
+                "vm.builtin.reshape", x, R.shape([6, 2]), sinfo_args=R.Tensor((6, 2), "float32")
             )
             return y
 

--- a/tests/python/relax/test_transform_static_plan_block_memory.py
+++ b/tests/python/relax/test_transform_static_plan_block_memory.py
@@ -51,20 +51,20 @@ def test_basic():
 
         @R.function
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
-            alloc: R.Tensor((2, 4), dtype="float32") = R.builtin.alloc_tensor((2, 4), dtype="float32", runtime_device_index=0)
+            alloc: R.Tensor((2, 4), dtype="float32") = R.builtin.alloc_tensor(R.shape([2, 4]), dtype="float32", runtime_device_index=0)
             _: R.Tuple() = exp(x, alloc)
             lv: R.Tensor((2, 4), dtype="float32") = alloc
             lv1: R.Tensor((8,), dtype="float32") = R.reshape(lv, (8,))
-            alloc1: R.Tensor((8,), dtype="float32") = R.builtin.alloc_tensor((8,), dtype="float32", runtime_device_index=0)
+            alloc1: R.Tensor((8,), dtype="float32") = R.builtin.alloc_tensor(R.shape([8]), dtype="float32", runtime_device_index=0)
             _1: R.Tuple() = relu(lv1, alloc1)
             lv2: R.Tensor((8,), dtype="float32") = alloc1
-            alloc2: R.Tensor((8,), dtype="float32") = R.builtin.alloc_tensor((8,), dtype="float32", runtime_device_index=0)
+            alloc2: R.Tensor((8,), dtype="float32") = R.builtin.alloc_tensor(R.shape([8]), dtype="float32", runtime_device_index=0)
             _2: R.Tuple() = add(lv2, R.const(1, "float32"), alloc2)
             lv3: R.Tensor((8,), dtype="float32") = alloc2
-            alloc3: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor((10,), dtype="float32", runtime_device_index=0)
+            alloc3: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor(R.shape([10]), dtype="float32", runtime_device_index=0)
             _3: R.Tuple() = pad(lv3, alloc3)
             lv4: R.Tensor((10,), dtype="float32") = alloc3
-            alloc4: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor((10,), dtype="float32", runtime_device_index=0)
+            alloc4: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor(R.shape([10]), dtype="float32", runtime_device_index=0)
             _4: R.Tuple() = log(lv4, alloc4)
             gv: R.Tensor((10,), dtype="float32") = alloc4
             return gv
@@ -97,26 +97,26 @@ def test_basic():
 
         @R.function
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
-            storage: R.Object = R.memory.alloc_storage((32,), virtual_device_index=0, storage_scope="global", dtype="float32")
-            alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, 0, (2, 4), dtype="float32")
+            storage: R.Object = R.memory.alloc_storage(R.shape([32]), virtual_device_index=0, storage_scope="global", dtype="float32")
+            alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, 0, R.shape([2, 4]), dtype="float32")
             _: R.Tuple() = exp(x, alloc)
             lv: R.Tensor((2, 4), dtype="float32") = alloc
             lv1: R.Tensor((8,), dtype="float32") = R.reshape(lv, (8,))
-            storage1: R.Object = R.memory.alloc_storage((40,), virtual_device_index=0, storage_scope="global", dtype="float32")
-            alloc1: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(storage1, 0, (8,), dtype="float32")
+            storage1: R.Object = R.memory.alloc_storage(R.shape([40]), virtual_device_index=0, storage_scope="global", dtype="float32")
+            alloc1: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(storage1, 0, R.shape([8]), dtype="float32")
             _1: R.Tuple() = relu(lv1, alloc1)
             _2: R.Tuple() = R.memory.kill_tensor(alloc)
             _3: R.Tuple() = R.memory.kill_tensor(lv1)
             lv2: R.Tensor((8,), dtype="float32") = alloc1
-            alloc2: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(storage, 0, (8,), dtype="float32")
+            alloc2: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(storage, 0, R.shape([8]), dtype="float32")
             _4: R.Tuple() = add(lv2, R.const(1, "float32"), alloc2)
             _5: R.Tuple() = R.memory.kill_tensor(alloc1)
             lv3: R.Tensor((8,), dtype="float32") = alloc2
-            alloc3: R.Tensor((10,), dtype="float32") = R.memory.alloc_tensor(storage1, 0, (10,), dtype="float32")
+            alloc3: R.Tensor((10,), dtype="float32") = R.memory.alloc_tensor(storage1, 0, R.shape([10]), dtype="float32")
             _6: R.Tuple() = pad(lv3, alloc3)
             _7: R.Tuple() = R.memory.kill_tensor(alloc2)
             lv4: R.Tensor((10,), dtype="float32") = alloc3
-            alloc4: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor((10,), dtype="float32", runtime_device_index=0)
+            alloc4: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor(R.shape([10]), dtype="float32", runtime_device_index=0)
             _8: R.Tuple() = log(lv4, alloc4)
             _9: R.Tuple() = R.memory.kill_tensor(alloc3)
             gv5: R.Tensor((10,), dtype="float32") = alloc4
@@ -153,12 +153,12 @@ def test_different_dtype():
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="int32")
         ) -> R.Tensor((2, 3), dtype="float32"):
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _: R.Tuple() = add(x, x, alloc)
             gv: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="int32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="int32", runtime_device_index=0
+                R.shape([2, 3]), dtype="int32", runtime_device_index=0
             )
             _1: R.Tuple() = add1(y, y, alloc1)
             gv1: R.Tensor((2, 3), dtype="int32") = alloc1
@@ -187,19 +187,19 @@ def test_different_dtype():
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="int32")
         ) -> R.Tensor((2, 3), dtype="float32"):
             storage: R.Object = R.memory.alloc_storage(
-                (24,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage, 0, (2, 3), dtype="float32"
+                storage, 0, R.shape([2, 3]), dtype="float32"
             )
             _: R.Tuple() = add(x, x, alloc)
             _1: R.Tuple() = R.memory.kill_tensor(alloc)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc
             storage1: R.Object = R.memory.alloc_storage(
-                (24,), virtual_device_index=0, storage_scope="global", dtype="int32"
+                R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="int32"
             )
             alloc1: R.Tensor((2, 3), dtype="int32") = R.memory.alloc_tensor(
-                storage1, 0, (2, 3), dtype="int32"
+                storage1, 0, R.shape([2, 3]), dtype="int32"
             )
             _2: R.Tuple() = add1(y, y, alloc1)
             _3: R.Tuple() = R.memory.kill_tensor(alloc1)
@@ -228,12 +228,12 @@ def test_same_dtype():
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _: R.Tuple() = add(x, x, alloc)
             gv: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _1: R.Tuple() = add(y, y, alloc1)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc1
@@ -254,16 +254,16 @@ def test_same_dtype():
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
             storage: R.Object = R.memory.alloc_storage(
-                (24,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage, 0, (2, 3), dtype="float32"
+                storage, 0, R.shape([2, 3]), dtype="float32"
             )
             _: R.Tuple() = add(x, x, alloc)
             _1: R.Tuple() = R.memory.kill_tensor(alloc)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage, 0, (2, 3), dtype="float32"
+                storage, 0, R.shape([2, 3]), dtype="float32"
             )
             _2: R.Tuple() = add(y, y, alloc1)
             _3: R.Tuple() = R.memory.kill_tensor(alloc1)
@@ -289,7 +289,7 @@ def test_if_cond():
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
             alloc: R.Tensor((), dtype="bool") = R.builtin.alloc_tensor(
-                (), dtype="bool", runtime_device_index=0
+                R.shape([]), dtype="bool", runtime_device_index=0
             )
             _: R.Tuple() = all_less_than_zero(x, alloc)
             x1: R.Tensor((), dtype="bool") = alloc
@@ -297,7 +297,7 @@ def test_if_cond():
                 y: R.Tensor((2, 3), dtype="float32") = x
             else:
                 alloc1: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                    (2, 3), dtype="float32", runtime_device_index=0
+                    R.shape([2, 3]), dtype="float32", runtime_device_index=0
                 )
                 _1: R.Tuple() = exp(x, alloc1)
                 gv3: R.Tensor((2, 3), dtype="float32") = alloc1
@@ -321,7 +321,7 @@ def test_if_then_else():
             cond: R.Tensor((), dtype="bool"), x: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _: R.Tuple() = exp(x, alloc)
             y: R.Tensor((2, 3), dtype="float32") = alloc
@@ -348,20 +348,20 @@ def test_cross_block_use():
             cond: R.Tensor((), dtype="bool"), x: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _: R.Tuple() = exp(x, alloc)
             y: R.Tensor((2, 3), dtype="float32") = alloc
             if cond:
                 alloc1: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                    (2, 3), dtype="float32", runtime_device_index=0
+                    R.shape([2, 3]), dtype="float32", runtime_device_index=0
                 )
                 _1: R.Tuple() = exp(y, alloc1)
                 y2: R.Tensor((2, 3), dtype="float32") = alloc1
                 z: R.Tensor((2, 3), dtype="float32") = y2
             else:
                 alloc2: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                    (2, 3), dtype="float32", runtime_device_index=0
+                    R.shape([2, 3]), dtype="float32", runtime_device_index=0
                 )
                 _2: R.Tuple() = exp(y, alloc2)
                 y2: R.Tensor((2, 3), dtype="float32") = alloc2
@@ -383,17 +383,17 @@ def test_nested_tuple():
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _: R.Tuple() = exp(x, alloc)
             y1: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _1: R.Tuple() = exp(x, alloc1)
             y2: R.Tensor((2, 3), dtype="float32") = alloc1
             alloc2: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _2: R.Tuple() = exp(x, alloc2)
             y3: R.Tensor((2, 3), dtype="float32") = alloc2
@@ -412,17 +412,17 @@ def test_nested_tuple():
             y2_: R.Tensor((2, 3), dtype="float32") = nt0[1]
             y3_: R.Tensor((2, 3), dtype="float32") = nt[1]
             alloc3: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _3: R.Tuple() = exp(y1_, alloc3)
             z1: R.Tensor((2, 3), dtype="float32") = alloc3
             alloc4: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _4: R.Tuple() = exp(y2_, alloc4)
             z2: R.Tensor((2, 3), dtype="float32") = alloc4
             alloc5: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _5: R.Tuple() = exp(y3_, alloc5)
             z3: R.Tensor((2, 3), dtype="float32") = alloc5
@@ -437,26 +437,26 @@ def test_nested_tuple():
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
             storage: R.Object = R.memory.alloc_storage(
-                (24,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage, 0, (2, 3), dtype="float32"
+                storage, 0, R.shape([2, 3]), dtype="float32"
             )
             _: R.Tuple() = exp(x, alloc)
             y1: R.Tensor((2, 3), dtype="float32") = alloc
             storage1: R.Object = R.memory.alloc_storage(
-                (24,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc1: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage1, 0, (2, 3), dtype="float32"
+                storage1, 0, R.shape([2, 3]), dtype="float32"
             )
             _1: R.Tuple() = exp(x, alloc1)
             y2: R.Tensor((2, 3), dtype="float32") = alloc1
             storage2: R.Object = R.memory.alloc_storage(
-                (24,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc2: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage2, 0, (2, 3), dtype="float32"
+                storage2, 0, R.shape([2, 3]), dtype="float32"
             )
             _2: R.Tuple() = exp(x, alloc2)
             y3: R.Tensor((2, 3), dtype="float32") = alloc2
@@ -475,24 +475,24 @@ def test_nested_tuple():
             y2_: R.Tensor((2, 3), dtype="float32") = nt0[1]
             y3_: R.Tensor((2, 3), dtype="float32") = nt[1]
             storage3: R.Object = R.memory.alloc_storage(
-                (24,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc3: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage3, 0, (2, 3), dtype="float32"
+                storage3, 0, R.shape([2, 3]), dtype="float32"
             )
             _3: R.Tuple() = exp(y1_, alloc3)
             _4: R.Tuple() = R.memory.kill_tensor(alloc)
             _11: R.Tuple() = R.memory.kill_tensor(alloc3)
             z1: R.Tensor((2, 3), dtype="float32") = alloc3
             alloc4: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage, 0, (2, 3), dtype="float32"
+                storage, 0, R.shape([2, 3]), dtype="float32"
             )
             _41: R.Tuple() = exp(y2_, alloc4)
             _21: R.Tuple() = R.memory.kill_tensor(alloc1)
             _31: R.Tuple() = R.memory.kill_tensor(alloc4)
             z2: R.Tensor((2, 3), dtype="float32") = alloc4
             alloc5: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage3, 0, (2, 3), dtype="float32"
+                storage3, 0, R.shape([2, 3]), dtype="float32"
             )
             _5: R.Tuple() = exp(y3_, alloc5)
             _42: R.Tuple() = R.memory.kill_tensor(alloc2)
@@ -514,7 +514,7 @@ def test_call_func_other_than_primfunc():
         @R.function
         def main(x: R.Tensor((2, 3), "float32")):
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             _ = R.add(x, alloc)
             y: R.Tensor((2, 3), dtype="float32") = alloc
@@ -541,7 +541,7 @@ def test_symbolic_shape():
             m = T.var("int64")
             n = T.var("int64")
             alloc: R.Tensor((m, n), dtype="float32") = R.builtin.alloc_tensor(
-                (m, n), dtype="float32", runtime_device_index=0
+                R.shape([m, n]), dtype="float32", runtime_device_index=0
             )
             _ = exp(x, alloc)
             y: R.Tensor((m, n), dtype="float32") = alloc
@@ -558,7 +558,7 @@ def test_zero_reference():
         @R.function
         def main(x: R.Tensor((2, 3), "float32")):
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 3), dtype="float32", runtime_device_index=0
+                R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
             return x
 
@@ -567,10 +567,10 @@ def test_zero_reference():
         @R.function
         def main(x: R.Tensor((2, 3), "float32")):
             storage: R.Object = R.memory.alloc_storage(
-                (24,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
-                storage, 0, (2, 3), dtype="float32"
+                storage, 0, R.shape([2, 3]), dtype="float32"
             )
             _: R.Tuple() = R.memory.kill_storage(storage)
             return x
@@ -597,7 +597,7 @@ def test_reshape_param():
             lv: R.Tensor((2, 25, 2), dtype="float32") = R.reshape(x, (2, 25, 2))
             lv1: R.Tensor((2, 25, 2), dtype="float32") = R.reshape(y, (2, 25, 2))
             alloc: R.Tensor((2, 25, 2), dtype="float32") = R.builtin.alloc_tensor(
-                (2, 25, 2), dtype="float32", runtime_device_index=0
+                R.shape([2, 25, 2]), dtype="float32", runtime_device_index=0
             )
             _: R.Tuple() = add(lv, lv1, alloc)
             gv: R.Tensor((2, 25, 2), dtype="float32") = alloc

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1090,5 +1090,4 @@ def test_meta():
 
 
 if __name__ == "__main__":
-    test_simple_func()
     tvm.testing.main()

--- a/tests/python/relax/test_tvmscript_printer_relax.py
+++ b/tests/python/relax/test_tvmscript_printer_relax.py
@@ -291,7 +291,7 @@ c: R.Tensor((1, z, 3), dtype="float32")
 
 def test_shape_expr():
     obj = relax.ShapeExpr([1, 2, 3])
-    _assert_print(obj, "(1, 2, 3)")
+    _assert_print(obj, "R.shape([1, 2, 3])")
 
 
 def test_call():
@@ -303,7 +303,7 @@ def test_call():
         """
 x = T.Var("x", "int64")
 a: R.Tensor((1, x, 3), dtype="float32")
-R.call_tir("my_func", (a,), out_sinfo=R.Tensor((1, x, 3), dtype="float32"), tir_vars=(x,))
+R.call_tir("my_func", (a,), out_sinfo=R.Tensor((1, x, 3), dtype="float32"), tir_vars=R.shape([x]))
 """,
     )
 

--- a/tests/python/relax/test_vm_build.py
+++ b/tests/python/relax/test_vm_build.py
@@ -86,7 +86,7 @@ def test_vm_compile_stage2(exec_mode):
         def foo(x: R.Tensor(dtype="float32")) -> R.Shape:
             n, m = T.var("int64"), T.var("int64")
             _ = R.match_cast(x, R.Tensor((n, m), "float32"))
-            return (n * 2, m * 3)
+            return R.shape([n * 2, m * 3])
 
     mod = TestVMCompileStage2
     target = tvm.target.Target("llvm", host="llvm")
@@ -509,9 +509,9 @@ def test_lower_memory_alloc_storage_tensor(exec_mode):
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")):
             storage = R.memory.alloc_storage(
-                (24,), virtual_device_index=0, storage_scope="global", dtype="float32"
+                R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
-            y = R.memory.alloc_tensor(storage, 0, (2, 3), dtype="float32")
+            y = R.memory.alloc_tensor(storage, 0, R.shape([2, 3]), dtype="float32")
             _ = copy(x, y)
             return y
 

--- a/tests/python/relax/test_vm_codegen_only.py
+++ b/tests/python/relax/test_vm_codegen_only.py
@@ -18,13 +18,15 @@
 
 Restrictions: all shape lowered, explicit allocation.
 """
-import tvm
-import pytest
 import numpy as np
-from tvm import relax, TVMError
-from tvm.script import relax as R, tir as T
+import pytest
+import tvm
+import tvm.testing
+from tvm import relax
+from tvm.relax.testing.runtime_builtin import MakeShapeCode, MatchShapeCode
 from tvm.relax.testing.vm import check_saved_func
-from tvm.relax.testing.runtime_builtin import MatchShapeCode, MakeShapeCode
+from tvm.script import relax as R
+from tvm.script import tir as T
 
 
 def codegen(mod, target, exec_mode="bytecode"):
@@ -310,7 +312,7 @@ def test_vm_builtin_reshape(exec_mode):
         def main(x: R.Tensor((3, 4), "float32")):
             R.func_attr({"global_symbol": "main"})
             y = R.call_packed(
-                "vm.builtin.reshape", x, (6, 2), sinfo_args=R.Tensor((6, 2), "float32")
+                "vm.builtin.reshape", x, R.shape([6, 2]), sinfo_args=R.Tensor((6, 2), "float32")
             )
             return y
 
@@ -325,3 +327,7 @@ def test_vm_builtin_reshape(exec_mode):
     res = vm["main"](input)
     expected = input_np.reshape(6, 2)
     tvm.testing.assert_allclose(res.numpy(), expected, rtol=1e-7, atol=1e-7)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
As we've introduced `arg_sinfo` in CallNode, implicit shape constructor is not widely used in TVMScript. This PR removes the implicit shape since it may cause confusion between shape and tuple.

cc @tqchen @YuchenJin 