### PR TITLE
[Tweak] Use StructInfo instead of a type for `assert_op`'s StructInfo-checking rule

### DIFF
--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -109,9 +109,10 @@ class NameTable {
 TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
 
 /*!
- * \brief Check if the given type is a boolean scalar type (tensor of rank 0 with a boolean dtype).
+ * \brief Check if the given StructInfo is for a boolean scalar (tensor of rank 0 with a boolean
+ * dtype).
  *
- * \param ty The input type.
+ * \param sinfo The input StructInfo.
  * \param permit_unknown_rank If true, it will permit the input type to have unknown rank
  *   (ndim of -1), which will require a dynamic check.
  * \param permit_unknown_dtype If true, it will permit the input type to have an unknown dtype
@@ -120,7 +121,7 @@ TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
  * \return True iff the input type is a boolean scalar type (or, depending on options, has unknown
  *   rank or dtype)
  */
-TVM_DLL bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank = true,
+TVM_DLL bool IsBoolStructInfo(const StructInfo& sinfo, bool permit_unknown_rank = true,
                               bool permit_unknown_dtype = true);
 
 /*!

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -175,11 +175,11 @@ StructInfo InferAssertStructInfo(const Call& call, const BlockBuilder& ctx) {
     ctx->ReportFatal(Diagnostic::Error(call)
                      << "Assert must have at least one argument (the condition).");
   }
-  Type arg_type = call->args[0]->checked_type();
-  if (!IsBoolScalarType(arg_type)) {
+  StructInfo arg_struct_info = GetStructInfo(call->args[0]);
+  if (!IsBoolStructInfo(arg_struct_info)) {
     ctx->ReportFatal(Diagnostic::Error(call)
-                     << "The argument to assert must be a boolean scalar type, but received "
-                     << arg_type);
+                     << "The argument to assert must be a boolean scalar, but received "
+                     << arg_struct_info);
   }
   return ReturnVoidStructInfo(call, ctx);
 }

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -67,8 +67,8 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
   }
 }
 
-bool IsBoolScalarType(const Type& ty, bool permit_unknown_rank, bool permit_unknown_dtype) {
-  const DynTensorTypeNode* tt = ty.as<DynTensorTypeNode>();
+bool IsBoolStructInfo(const StructInfo& sinfo, bool permit_unknown_rank, bool permit_unknown_dtype) {
+  const TensorStructInfoNode* tt = sinfo.as<TensorStructInfoNode>();
   if (!tt) {
     return false;
   }

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -67,7 +67,8 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
   }
 }
 
-bool IsBoolStructInfo(const StructInfo& sinfo, bool permit_unknown_rank, bool permit_unknown_dtype) {
+bool IsBoolStructInfo(const StructInfo& sinfo, bool permit_unknown_rank,
+                      bool permit_unknown_dtype) {
   const TensorStructInfoNode* tt = sinfo.as<TensorStructInfoNode>();
   if (!tt) {
     return false;


### PR DESCRIPTION
This PR is a small change to the `FInferStructInfo` for `assert_op`. The previous macro was still using `checked_type`, but it would be preferable to use `StructInfo` instead, to avoid any lingering dependency on types.