### PR TITLE
[CUTLASS] Move matmul host codegen to python

### DIFF
--- a/python/tvm/contrib/cutlass/gemm_operation.py
+++ b/python/tvm/contrib/cutlass/gemm_operation.py
@@ -257,3 +257,79 @@ class EmitGemmInstance:
             },
         )
         return substitute_template(gemm_template, values)
+
+
+def instantiate_gemm_template(attrs, func_args):
+    template = """
+  using ElementInputA = ${ElementInputA};
+  using ElementInputB = ${ElementInputB};
+  using ElementOutput = ${ElementOutput};
+  using ElementComputeEpilogue = ${ElementOutput};
+
+  ${cutlass_op_def}
+
+  using ${kernel} = Operation_${cutlass_op_name};
+  int M = ${M};
+  int N = ${N};
+  int K = ${K};
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+  ElementComputeEpilogue alpha = ElementComputeEpilogue(1);
+  ElementComputeEpilogue beta = ElementComputeEpilogue(${beta});
+  void* ptr_a = (void*)(${arg0}->data);
+  void* ptr_b = (void*)(${arg1}->data);
+  ${bias_decl}
+  void* ptr_out = (void*)(out0->data);
+
+  typename Gemm::Arguments arguments{
+   problem_size,
+   {static_cast<ElementInputA*>(ptr_a), ${lda}},
+   {static_cast<ElementInputB*>(ptr_b), ${ldb}},
+   {static_cast<ElementOutput*>(${ptr_c}), ${c_stride}},
+   {static_cast<ElementOutput*>(ptr_out), ${ldc}},
+   {${alpha_beta}},
+   1};
+  size_t workspace_size = ${kernel}::get_workspace_size(arguments);
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+  Gemm gemm_op;
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  CHECK(status == cutlass::Status::kSuccess);
+  status = gemm_op.initialize(arguments, workspace.get());
+  CHECK(status == cutlass::Status::kSuccess);
+  status = gemm_op();
+  CHECK(status == cutlass::Status::kSuccess);
+"""
+    has_bias = "bias" in attrs["op_type"]
+    is_gelu = "gelu" in attrs["op_type"]
+
+    aux_map = {"kernel": "Gemm"}
+
+    if has_bias:
+        aux_map.update(
+            {
+                "bias_decl": "void* ptr_c_bias = (void*)(${arg2}->data);\n",
+                "ptr_c": "ptr_c_bias",
+                "c_stride": "0",
+            }
+        )
+    else:
+        aux_map.update({"bias_decl": "", "ptr_c": "ptr_out", "c_stride": attrs["ldc"]})
+
+    if is_gelu:
+        # GeLU epilogue does not compile with NoBetaScaling, so we explicitly specify the scale.
+        aux_map["beta"] = "1"
+    else:
+        aux_map["beta"] = "0"
+
+    if has_bias and not is_gelu:
+        aux_map["alpha_beta"] = "alpha"
+    else:
+        aux_map["alpha_beta"] = "alpha, beta"
+
+    template = substitute_template(template, aux_map)
+
+    attrs = dict(attrs)
+
+    for i, arg in enumerate(func_args):
+        attrs["arg{}".format(i)] = arg
+
+    return substitute_template(template, attrs)

--- a/python/tvm/contrib/cutlass/gemm_operation.py
+++ b/python/tvm/contrib/cutlass/gemm_operation.py
@@ -260,6 +260,8 @@ class EmitGemmInstance:
 
 
 def instantiate_gemm_template(attrs, func_args):
+    """Return CUTLASS host code for GEMM based on a template and the provided attribute map."""
+
     template = """
   using ElementInputA = ${ElementInputA};
   using ElementInputB = ${ElementInputB};

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -383,6 +383,24 @@ class ProfilerEngine:
 
 @register_func("contrib.cutlass.instantiate_template")
 def instantiate_template(func_name, annotations, func_args):
+    """Return CUTLASS host code based on a template and the provided annotations.
+
+    Parameters
+    ----------
+    func_name: str
+        A string to identify the type of the kernel (dense/matmul, batched_matmul, or conv2d).
+
+    annotations: container.Map
+        Key and value pairs annotated during kernel selection.
+
+    func_args: list
+        Names of the function arguments.
+
+    Returns
+    -------
+    code : str
+        Generated CUTLASS host code.
+    """
     dtype_map = {
         "float16": "cutlass::half_t",
         "float32": "float",

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -417,13 +417,13 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["ElementInputA"] = dtype_map[annotations["arg0_dtype"]]
         attrs["ElementInputB"] = dtype_map[annotations["arg1_dtype"]]
         attrs["ElementOutput"] = dtype_map[annotations["ret_dtype"]]
-        attrs["M"] = str(arg0_shape[0])
-        attrs["K"] = str(arg0_shape[1])
+        attrs["M"] = str(int(arg0_shape[0]))
+        attrs["K"] = str(int(arg0_shape[1]))
 
         if annotations["ldb"] == "N":
-            attrs["N"] = str(arg1_shape[1])
+            attrs["N"] = str(int(arg1_shape[1]))
         else:
-            attrs["N"] = str(arg1_shape[0])
+            attrs["N"] = str(int(arg1_shape[0]))
 
         for k in ["lda", "ldb", "ldc", "cutlass_op_def", "cutlass_op_name", "op_type"]:
             attrs[k] = annotations[k]

--- a/src/relax/backend/contrib/cutlass/codegen.cc
+++ b/src/relax/backend/contrib/cutlass/codegen.cc
@@ -181,7 +181,7 @@ class CodegenCutlass : public relax::MemoizedExprTranslator<OutputType>,
   }
 
   GenerateBodyOutput GenerateBody(const CallNode* call, const std::string& func_name,
-				  const Map<String, ObjectRef>& attrs) {
+                                  const Map<String, ObjectRef>& attrs) {
     auto func_args = GetArgumentNames(call);
     auto struct_info = GetStructInfo(GetRef<Call>(call));
 

--- a/src/relax/backend/contrib/cutlass/codegen.cc
+++ b/src/relax/backend/contrib/cutlass/codegen.cc
@@ -169,8 +169,8 @@ class CodegenCutlass : public relax::MemoizedExprTranslator<OutputType>,
   }
 
  private:
-  std::vector<std::string> GetArgumentNames(const CallNode* call) {
-    std::vector<std::string> arg_names;
+  Array<String> GetArgumentNames(const CallNode* call) {
+    Array<String> arg_names;
     for (size_t i = 0; i < call->args.size(); ++i) {
       auto res = VisitExpr(call->args[i]);
       for (const auto& out : res) {
@@ -192,7 +192,7 @@ class CodegenCutlass : public relax::MemoizedExprTranslator<OutputType>,
       LOG(FATAL) << "Unimplemented sinfo type: " << struct_info;
     }
 
-    return contrib::GenerateBody(func_name, ext_func_id_, func_args, out_types, attrs, &buf_idx_);
+    return contrib::GenerateBody(func_name, ext_func_id_, out_types, func_args, attrs, &buf_idx_);
   }
 
   /*! \brief The id of the external cutlass ext_func. */

--- a/src/relay/backend/contrib/cutlass/codegen.h
+++ b/src/relay/backend/contrib/cutlass/codegen.h
@@ -61,9 +61,9 @@ std::string EmitSignature(const std::vector<relay::contrib::Output>& out,
 
 /*! \brief Generate the body of the kernel */
 GenerateBodyOutput GenerateBody(const std::string& func_name, const std::string& ext_func_id,
-                                const std::vector<std::string>& func_args,
                                 const std::vector<std::string>& output_types,
-                                const Map<String, ObjectRef>& attrs, int* buf_idx);
+                                const Array<String>& func_args, const Map<String, ObjectRef>& attrs,
+                                int* buf_idx);
 
 /*! \brief Create a C-source module from the given kernel string */
 runtime::Module Finalize(const std::string& code, const Array<String>& func_names);

--- a/src/relay/backend/contrib/cutlass/codegen.h
+++ b/src/relay/backend/contrib/cutlass/codegen.h
@@ -44,7 +44,6 @@ transform::Pass CompileForCutlass();
 
 // The rest is sparsely documented since they are exposed only for code sharing between Relay
 // and Relax backend implementations.
-using Str2StrMap = std::unordered_map<std::string, std::string>;
 
 inline void CutlassPrint(std::ostringstream& os, const std::string& stmt, int indent = 2) {
   for (int i = 0; i < indent; ++i) {
@@ -52,37 +51,6 @@ inline void CutlassPrint(std::ostringstream& os, const std::string& stmt, int in
   }
   os << stmt;
 }
-
-/*! \brief Convert a dimension attribute to a string */
-std::string GetDimAsStr(ObjectRef dim);
-
-/*! \brief Utilities for converting a attribute map for an op to a mapping between strings */
-Str2StrMap ArgsCommon(const Map<String, ObjectRef>& attrs);
-
-Str2StrMap GemmArgsCommon(const Map<String, ObjectRef>& attrs);
-
-Str2StrMap MatmulArgs(const Map<String, ObjectRef>& attrs);
-
-Str2StrMap BatchMatmulArgs(const Map<String, ObjectRef>& attrs);
-
-Str2StrMap Conv2dArgs(const Map<String, ObjectRef>& attrs, bool is_dgrad = false,
-                      bool is_wgrad = false);
-
-/*! \brief Utilities for emitting the body of GEMM or Conv2D kernels */
-void AppendPrologue(std::ostringstream& gemm_decl, const Str2StrMap& attrs,
-                    const std::vector<std::string>& func_args, const std::string& kernel,
-                    bool has_bias, bool is_gelu, int m_axis_idx, int n_axis_idx, int k_axis_idx);
-
-void AppendGemmExecute(std::ostringstream& gemm_decl, const std::string& kernel);
-
-std::string MatmulOp(std::string id, const Str2StrMap& attrs,
-                     const std::vector<std::string>& func_args);
-
-std::string BatchMatmulOp(std::string id, const Str2StrMap& attrs,
-                          const std::vector<std::string>& func_args);
-
-std::string Conv2dOp(std::string id, const Str2StrMap& attrs,
-                     const std::vector<std::string>& func_args, bool has_residual_block = false);
 
 /*! \brief Get CUTLASS headers to be included by all generated source code */
 std::string EmitHeaders();
@@ -95,7 +63,7 @@ std::string EmitSignature(const std::vector<relay::contrib::Output>& out,
 GenerateBodyOutput GenerateBody(const std::string& func_name, const std::string& ext_func_id,
                                 const std::vector<std::string>& func_args,
                                 const std::vector<std::string>& output_types,
-                                const Str2StrMap& attribute_args, int* buf_idx);
+                                const Map<String, ObjectRef>& attrs, int* buf_idx);
 
 /*! \brief Create a C-source module from the given kernel string */
 runtime::Module Finalize(const std::string& code, const Array<String>& func_names);

--- a/src/relay/backend/contrib/cutlass/codegen.h
+++ b/src/relay/backend/contrib/cutlass/codegen.h
@@ -45,13 +45,6 @@ transform::Pass CompileForCutlass();
 // The rest is sparsely documented since they are exposed only for code sharing between Relay
 // and Relax backend implementations.
 
-inline void CutlassPrint(std::ostringstream& os, const std::string& stmt, int indent = 2) {
-  for (int i = 0; i < indent; ++i) {
-    os << " ";
-  }
-  os << stmt;
-}
-
 /*! \brief Get CUTLASS headers to be included by all generated source code */
 std::string EmitHeaders();
 


### PR DESCRIPTION
To make extending CUTLASS BYOC easier, I'm moving C++-side codegen that's responsible for cutlass host code generation to python. This is the first step, only modifying matmul codegen.

I've add a packed func `contrib.cutlass.instantiate_template`, that gets an attribute map from C++, instantiates a host code template, and return the instantiated code back to C++. Op-specific attribute parsing and template instantiation are both done in python, so adding a new op no longer needs modification to the C++ code.

cc @vinx13 @yelite @mbaret 