### PR TITLE
[VM] Add additional linking step in vm.build if necessary

### DIFF
--- a/include/tvm/runtime/relax_vm/executable.h
+++ b/include/tvm/runtime/relax_vm/executable.h
@@ -141,6 +141,9 @@ class Executable : public runtime::ModuleNode {
    */
   static Module LoadFromFile(const std::string& file_name);
 
+  /*! \brief Check if all imported modules have been fully linked. */
+  bool CheckLinked();
+
   /*! \brief The virtual machine's function table. */
   std::vector<VMFuncInfo> func_table;
   /*! \brief A map from globals (as strings) to their index in the function map. */

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -851,29 +851,3 @@ def finalize_modules_vm(vm_exec, lib_path="compile.so", vmcode_path="vmcode.ro",
         fo.write(code)
     lib = tvm.runtime.load_module(lib_path)
     return tvm.runtime.vm.Executable.load_exec(code, lib)
-
-
-def finalize_modules_relax(vm_exec, lib_path="compile.so", tmp_dir="./tmp"):
-    """finalize_modules_vm equivalent for Relax VM.
-
-    Parameters
-    ----------
-    vm_exec : vm.Executable
-        The output from relax.vm.build containing compiled host code and kernels.
-
-    lib_path : string
-        The path to a shared library which will be generated as the result of the build process.
-
-    tmp_dir : string
-        A temporary directory where intermediate compiled artifacts will be stored.
-
-    Returns
-    -------
-    updated_vm_exec : relax.vm.Executable
-        The updated VM executable with all compilation and linking completed.
-    """
-    lib_path = os.path.join(tmp_dir, lib_path)
-    vm_exec.mod.export_library(lib_path, workspace_dir=tmp_dir, cc="nvcc")
-    lib = tvm.runtime.load_module(lib_path)
-
-    return relax.vm.Executable(lib)

--- a/src/runtime/hexagon/hexagon_module.cc
+++ b/src/runtime/hexagon/hexagon_module.cc
@@ -44,7 +44,7 @@ HexagonModuleNode::HexagonModuleNode(std::string data, std::string fmt,
 
 PackedFunc HexagonModuleNode::GetFunction(const std::string& name,
                                           const ObjectPtr<Object>& sptr_to_self) {
-  LOG(FATAL) << "HexagonModuleNode::GetFunction is not implemented.";
+  return PackedFunc{nullptr};
 }
 
 std::string HexagonModuleNode::GetSource(const std::string& format) {

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -75,7 +75,7 @@ PackedFunc Executable::GetFunction(const std::string& name, const ObjectPtr<Obje
       *rv = Module(vm);
     });
   } else if (name == "check_linked") {
-    return PackedFunc([this](TVMArgs, TVMRetValue*) { return CheckLinked(); });
+    return PackedFunc([sptr_to_self, this](TVMArgs, TVMRetValue* rv) { *rv = CheckLinked(); });
   }
 
   return nullptr;

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -590,7 +590,7 @@ bool Executable::CheckLinked() {
   for (size_t func_index = 0; func_index < func_table.size(); ++func_index) {
     const VMFuncInfo& info = func_table[func_index];
     if (info.kind == VMFuncInfo::FuncKind::kPackedFunc) {
-      if (!exists_in_imports(info.name) && Registry::Get(info.name) == nullptr) {
+      if (Registry::Get(info.name) == nullptr && !exists_in_imports(info.name)) {
         return false;
       }
     }

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -590,7 +590,7 @@ bool Executable::CheckLinked() {
   for (size_t func_index = 0; func_index < func_table.size(); ++func_index) {
     const VMFuncInfo& info = func_table[func_index];
     if (info.kind == VMFuncInfo::FuncKind::kPackedFunc) {
-      if (Registry::Get(info.name) == nullptr && !exists_in_imports(info.name)) {
+      if (!exists_in_imports(info.name) && Registry::Get(info.name) == nullptr) {
         return false;
       }
     }

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -22,8 +22,9 @@ import pytest
 
 import tvm
 import tvm.testing
+import tvm.contrib.cutlass.build
+
 from tvm import relax, relay
-from tvm.contrib.cutlass.build import finalize_modules_relax
 from tvm.relax.dpl import make_fused_bias_activation_pattern, make_matmul_pattern
 from tvm.script import relax as R
 
@@ -232,7 +233,6 @@ def get_result_with_relax_cutlass_offload(mod, patterns: List[Tuple], *args):
 
     target = tvm.target.Target("cuda")
     ex = relax.vm.build(mod, target)
-    ex = finalize_modules_relax(ex)
 
     dev = tvm.gpu(0)
     vm = relax.VirtualMachine(ex, dev)


### PR DESCRIPTION
In CUTLASS BYOC, `vm.build(...)` returns an executable that needs an additional linking step. We have been using `finalize_modules_relax` function for that purpose, but this is not good in terms of UX and I believe `vm.build(...)` should never return such half-baked exe anyway.

This PR adds an additional step in `vm_link`, where we (1) check if all imported modules have been fully linked and (2) do additional export / load back to do the final linking if needed.

@tqchen @vinx13 @YuchenJin @yelite  