### PR TITLE
[CUTLASS] Update cutlass generator to add fp32 SIMT kernels

### DIFF
--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -78,6 +78,8 @@ def generate_sm50_simt(
     profile_all_alignments=False,
     accumulator_dtype="float32",
 ):
+    """Gemerate GEMM or Conv2D SIMT kernels"""
+    # pylint: disable=unused-argument
     min_cc = 50
     max_cc = 1024
     if arg0_dtype == "float32" and arg1_dtype == "float32":
@@ -113,6 +115,8 @@ def generate_sm50_simt(
         return generate_tensor_op_common(
             math_instructions, alignment_constraints, get_tile_descriptions, op_creator
         )
+    else:
+        raise NotImplementedError()
 
 
 def generate_sm75_tensor_op_1688(

--- a/python/tvm/contrib/cutlass/library.py
+++ b/python/tvm/contrib/cutlass/library.py
@@ -302,58 +302,6 @@ class TileDescription:
         )
 
 
-class Direct2dConvFixedStrideDilationTileDescription:
-    def __init__(
-        self,
-        threadblock_output_shape,
-        filter_shape,
-        stages,
-        stride,
-        dilation,
-        warp_count,
-        math_instruction,
-        min_compute,
-        max_compute,
-    ):
-        self.threadblock_shape = [
-            threadblock_output_shape[0] * threadblock_output_shape[1] * threadblock_output_shape[2],
-            threadblock_output_shape[3],
-            filter_shape[0] * filter_shape[1],
-        ]
-        self.threadblock_output_shape = threadblock_output_shape
-        self.filter_shape = filter_shape
-        self.stages = stages
-        self.warp_count = warp_count
-        self.stride = stride
-        self.dilation = dilation
-        self.math_instruction = math_instruction
-        self.minimum_compute_capability = min_compute
-        self.maximum_compute_capability = max_compute
-
-    def procedural_name(self):
-        str_name = "%dx%dx%d_%dx%dx%dx%d_%d_filter%dx%d" % (
-            self.threadblock_shape[0],
-            self.threadblock_shape[1],
-            self.threadblock_shape[2],
-            self.threadblock_output_shape[0],
-            self.threadblock_output_shape[1],
-            self.threadblock_output_shape[2],
-            self.threadblock_output_shape[3],
-            self.stages,
-            self.filter_shape[0],
-            self.filter_shape[1],
-        )
-        # Fixed Strided and dilation
-        if self.stride != [-1, -1] and self.dilation != [-1, -1]:
-            str_name += "_stride%dx%d_dilation%dx%d" % (
-                self.stride[0],
-                self.stride[1],
-                self.dilation[0],
-                self.dilation[1],
-            )
-        return str_name
-
-
 class TensorDescription:
     def __init__(self, element, layout, alignment=1):
         self.element = element

--- a/python/tvm/contrib/cutlass/library.py
+++ b/python/tvm/contrib/cutlass/library.py
@@ -302,6 +302,58 @@ class TileDescription:
         )
 
 
+class Direct2dConvFixedStrideDilationTileDescription:
+    def __init__(
+        self,
+        threadblock_output_shape,
+        filter_shape,
+        stages,
+        stride,
+        dilation,
+        warp_count,
+        math_instruction,
+        min_compute,
+        max_compute,
+    ):
+        self.threadblock_shape = [
+            threadblock_output_shape[0] * threadblock_output_shape[1] * threadblock_output_shape[2],
+            threadblock_output_shape[3],
+            filter_shape[0] * filter_shape[1],
+        ]
+        self.threadblock_output_shape = threadblock_output_shape
+        self.filter_shape = filter_shape
+        self.stages = stages
+        self.warp_count = warp_count
+        self.stride = stride
+        self.dilation = dilation
+        self.math_instruction = math_instruction
+        self.minimum_compute_capability = min_compute
+        self.maximum_compute_capability = max_compute
+
+    def procedural_name(self):
+        str_name = "%dx%dx%d_%dx%dx%dx%d_%d_filter%dx%d" % (
+            self.threadblock_shape[0],
+            self.threadblock_shape[1],
+            self.threadblock_shape[2],
+            self.threadblock_output_shape[0],
+            self.threadblock_output_shape[1],
+            self.threadblock_output_shape[2],
+            self.threadblock_output_shape[3],
+            self.stages,
+            self.filter_shape[0],
+            self.filter_shape[1],
+        )
+        # Fixed Strided and dilation
+        if self.stride != [-1, -1] and self.dilation != [-1, -1]:
+            str_name += "_stride%dx%d_dilation%dx%d" % (
+                self.stride[0],
+                self.stride[1],
+                self.dilation[0],
+                self.dilation[1],
+            )
+        return str_name
+
+
 class TensorDescription:
     def __init__(self, element, layout, alignment=1):
         self.element = element

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -511,6 +511,17 @@ def test_dense():
     )
 
     dense_fp32 = get_dense(M, N, K, "float32", "float32", "float32")
+    # fp32
+    verify_dense(
+        dense_fp32,
+        M,
+        N,
+        K,
+        data_dtype="float32",
+        weight_dtype="float32",
+        use_3xtf32=False,
+        sm=75,
+    )
     # tf32
     verify_dense(
         dense_fp32,


### PR DESCRIPTION
This PR syncs cutlass generator with upstream and enable fp32 SIMT kernels for SM75 (SM80 by default uses TF32 for FP32)

cc @masahi @yelite 